### PR TITLE
Python 3 compatibility fix: use six.moves for the Queue/queue module.

### DIFF
--- a/traits_futures/job_controller.py
+++ b/traits_futures/job_controller.py
@@ -2,10 +2,10 @@
 
 import collections
 import itertools
-import Queue as queue
 import threading
 
 import concurrent.futures
+from six.moves import queue
 
 from traits.api import Any, Dict, HasStrictTraits, Instance, Int
 from traits.trait_notifiers import ui_dispatch

--- a/traits_futures/tests/test_job_controller.py
+++ b/traits_futures/tests/test_job_controller.py
@@ -1,7 +1,7 @@
-import Queue as queue
 import unittest
 
 import concurrent.futures
+from six.moves import queue
 
 from traits.api import HasStrictTraits, Instance, List, on_trait_change
 

--- a/traits_futures/tests/test_job_runner.py
+++ b/traits_futures/tests/test_job_runner.py
@@ -1,6 +1,7 @@
-import Queue as queue
 import threading
 import unittest
+
+from six.moves import queue
 
 from traits_futures.job import Job
 from traits_futures.job_runner import (


### PR DESCRIPTION
Partial fix for #1.