### PR TITLE
Fix a misuse of traceback.format_exc that breaks on Python 3.

### DIFF
--- a/traits_futures/job_runner.py
+++ b/traits_futures/job_runner.py
@@ -13,7 +13,7 @@ def _marshal_exception(e):
     """
     exc_type = str(type(e))
     exc_value = str(e)
-    formatted_traceback = traceback.format_exc(e)
+    formatted_traceback = traceback.format_exc()
     return exc_type, exc_value, formatted_traceback
 
 


### PR DESCRIPTION
We were mistakenly passing the exception object to `traceback.format_exc`, and it was being interpreted as a limit. On Python 2, that was benign, but on Python 3, it causes breakage.

With this change and #8, tests pass on Python 3 for me.