### PR TITLE
Include examples directory in flake8 coverage.

### DIFF
--- a/ci/config.py
+++ b/ci/config.py
@@ -65,7 +65,8 @@ RUNTIME_VERSION = {
 FLAKE8_TARGETS = [
     'ci',
     'setup.py',
-    PACKAGE_NAME
+    PACKAGE_NAME,
+    'examples',
 ]
 
 # Platforms and Python versions that we support.


### PR DESCRIPTION
After #27, the example script was no longer subject to flake8 checks. This PR fixes that.