### PR TITLE
Add mock to requirements

### DIFF
--- a/ci/bundle/traits-futures-py27-pyqt-osx-x86_64.json
+++ b/ci/bundle/traits-futures-py27-pyqt-osx-x86_64.json
@@ -25,6 +25,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "futures",
             "state": "manual"
         },
@@ -33,7 +37,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -141,6 +153,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "68214befae442b5353f46eab25a759d3357bb5d8adf4e8a57371c4007112ddb0",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "futures",
             "repository": "enthought/free",
             "sha256": "03acb40e575125f5d2881cd83e1cc76003c87ebf241f8341a66532cf4bef09f8",
@@ -153,10 +171,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "26b0209ccb1c2bb21a40ab336e8207f8982cae0934d67f2111bc4fcc11f4a833",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "5b8e7461a2e899cba9ba9e449c67632d7ea94750635c1294641d0887a041e258",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "096c50df35e6592ca74d2684a8f39a5034d03dfac61690905b680c9725367355",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -203,8 +233,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "38f2e94317a844ef38c3d72950a010d19428bf38711c77108441515cc07c556a",
-            "version": "4.8.7-7"
+            "sha256": "0069145fc80f106615fb7c9ae1f265c135e6cadc2d5181b662ad4844ede29b15",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py27-pyqt-rh6-x86_64.json
+++ b/ci/bundle/traits-futures-py27-pyqt-rh6-x86_64.json
@@ -25,6 +25,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "futures",
             "state": "manual"
         },
@@ -37,7 +41,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -145,6 +157,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "68c34c87f4387b15ff2cbd7e1519894cdc983e5a271d4959ffd0a2435b06f4b9",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "futures",
             "repository": "enthought/free",
             "sha256": "55ea5a0910d36b20770f4cfd628fb8cd2c613d830a710c4926507f00746b857d",
@@ -163,10 +181,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "bb089f045e9e9e1610d3196173c81ca1d251139ef7e271072615dff28171e8a4",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "490c576cd0325b04bff3d13306ac26610b19df7b06dccebfa4ff83c9b56c431b",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "a0d60f8d84f62baf963a20fe9026b6f4b7788c1139d982820e67a84940bf8238",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -213,8 +243,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "a2a953317f1d8e1973f2859b1dc6dda2f9545c82494ab7593ae23fff6212a69d",
-            "version": "4.8.7-8"
+            "sha256": "e84538ec21670273598d4c9d701e67d2e9ee62912450cb650145caf635823a0c",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py27-pyqt-win-x86_64.json
+++ b/ci/bundle/traits-futures-py27-pyqt-win-x86_64.json
@@ -25,6 +25,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "futures",
             "state": "manual"
         },
@@ -33,7 +37,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -137,6 +149,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "6a92149f70f40a7b2ef02f789592b6a34f05b58aa4cfe29ef5aa617f0f107082",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "futures",
             "repository": "enthought/free",
             "sha256": "a64f320ffb56ad7fe690c107fab0e6d6a989a3907ec4f9d9df63d092f518673f",
@@ -149,10 +167,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "945d0ff8120fe5b1f8c160c840e2d201615ac0aa8d371d001fd4fa720cf2def9",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "b8666928bada876c88909ea73795182d769d39074f16159a194b378db6907dcb",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "6c0803402b3cb0c9d300f3a7ed04f952aa6926cb64d0b887276eb5fc9840d909",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",

--- a/ci/bundle/traits-futures-py27-pyside-osx-x86_64.json
+++ b/ci/bundle/traits-futures-py27-pyside-osx-x86_64.json
@@ -25,6 +25,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "futures",
             "state": "manual"
         },
@@ -41,7 +45,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -149,6 +161,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "68214befae442b5353f46eab25a759d3357bb5d8adf4e8a57371c4007112ddb0",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "futures",
             "repository": "enthought/free",
             "sha256": "03acb40e575125f5d2881cd83e1cc76003c87ebf241f8341a66532cf4bef09f8",
@@ -173,10 +191,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "26b0209ccb1c2bb21a40ab336e8207f8982cae0934d67f2111bc4fcc11f4a833",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "5b8e7461a2e899cba9ba9e449c67632d7ea94750635c1294641d0887a041e258",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "096c50df35e6592ca74d2684a8f39a5034d03dfac61690905b680c9725367355",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -223,8 +253,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "38f2e94317a844ef38c3d72950a010d19428bf38711c77108441515cc07c556a",
-            "version": "4.8.7-7"
+            "sha256": "0069145fc80f106615fb7c9ae1f265c135e6cadc2d5181b662ad4844ede29b15",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py27-pyside-rh6-x86_64.json
+++ b/ci/bundle/traits-futures-py27-pyside-rh6-x86_64.json
@@ -25,6 +25,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "futures",
             "state": "manual"
         },
@@ -45,7 +49,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -153,6 +165,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "68c34c87f4387b15ff2cbd7e1519894cdc983e5a271d4959ffd0a2435b06f4b9",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "futures",
             "repository": "enthought/free",
             "sha256": "55ea5a0910d36b20770f4cfd628fb8cd2c613d830a710c4926507f00746b857d",
@@ -183,10 +201,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "bb089f045e9e9e1610d3196173c81ca1d251139ef7e271072615dff28171e8a4",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "490c576cd0325b04bff3d13306ac26610b19df7b06dccebfa4ff83c9b56c431b",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "a0d60f8d84f62baf963a20fe9026b6f4b7788c1139d982820e67a84940bf8238",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -233,8 +263,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "a2a953317f1d8e1973f2859b1dc6dda2f9545c82494ab7593ae23fff6212a69d",
-            "version": "4.8.7-8"
+            "sha256": "e84538ec21670273598d4c9d701e67d2e9ee62912450cb650145caf635823a0c",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py27-pyside-win-x86_64.json
+++ b/ci/bundle/traits-futures-py27-pyside-win-x86_64.json
@@ -25,6 +25,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "futures",
             "state": "manual"
         },
@@ -33,7 +37,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -137,6 +149,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "6a92149f70f40a7b2ef02f789592b6a34f05b58aa4cfe29ef5aa617f0f107082",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "futures",
             "repository": "enthought/free",
             "sha256": "a64f320ffb56ad7fe690c107fab0e6d6a989a3907ec4f9d9df63d092f518673f",
@@ -149,10 +167,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "945d0ff8120fe5b1f8c160c840e2d201615ac0aa8d371d001fd4fa720cf2def9",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "b8666928bada876c88909ea73795182d769d39074f16159a194b378db6907dcb",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "6c0803402b3cb0c9d300f3a7ed04f952aa6926cb64d0b887276eb5fc9840d909",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",

--- a/ci/bundle/traits-futures-py35-pyqt-osx-x86_64.json
+++ b/ci/bundle/traits-futures-py35-pyqt-osx-x86_64.json
@@ -17,11 +17,23 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "mccabe",
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -117,16 +129,34 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "5e266cb00734dceeba7c128b371c14efb293813d436bd4afcefe172545567dbb",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "mccabe",
             "repository": "enthought/free",
             "sha256": "66e5797665bd1490c8b58e8a42cd541e3620755e3ba9e4c7a7d16f2404441b0d",
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "72a72939cd999a2c9f7a2cf41587d5cb1991c68903790d97faaa5a92f007daa7",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "1fc4a17221069cf8381ee77d07aaa654015dce509f4be86a1dd313613d9caf90",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "14b705eddcebe283ced07a3a073ed51e4f9cbb81770f97acdae8d2314eb377c5",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -173,8 +203,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "38f2e94317a844ef38c3d72950a010d19428bf38711c77108441515cc07c556a",
-            "version": "4.8.7-7"
+            "sha256": "0069145fc80f106615fb7c9ae1f265c135e6cadc2d5181b662ad4844ede29b15",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py35-pyqt-rh6-x86_64.json
+++ b/ci/bundle/traits-futures-py35-pyqt-rh6-x86_64.json
@@ -17,6 +17,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "libpng",
             "state": "auto"
         },
@@ -25,7 +29,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -121,6 +133,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "58d1e12bfaff8043bcf5f34e8037ed3c23fdd07d1645fe1ec7f0e2590815bfa0",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "libpng",
             "repository": "enthought/free",
             "sha256": "72402221f70eadf881d7d4c6db115720daa277941e32b5d806c32db1072f4f4d",
@@ -133,10 +151,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "4fce1037363c5f4d962802c6925a48f343045faf84f0c5e1babc0f84982f1f4b",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "920db8d9c36b40ad33a91c7a7ef556ebaeaff2eaad00c0a9d02ea1803ac07f79",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "87561323689e23723e78558fe6aaacaf3c31df3f5270c6f491cc9b4037a53bd7",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -183,8 +213,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "a2a953317f1d8e1973f2859b1dc6dda2f9545c82494ab7593ae23fff6212a69d",
-            "version": "4.8.7-8"
+            "sha256": "e84538ec21670273598d4c9d701e67d2e9ee62912450cb650145caf635823a0c",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py35-pyqt-win-x86_64.json
+++ b/ci/bundle/traits-futures-py35-pyqt-win-x86_64.json
@@ -17,11 +17,23 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "mccabe",
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -113,16 +125,34 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "a5b033e2381ea4b9e51e108a99e64bb484313830964b2023facb93f048a62928",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "mccabe",
             "repository": "enthought/free",
             "sha256": "37c42a09f594f8eea319bf13d0b608bd2178b2e1a86f221a82ef99a0f34c67ae",
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "03c728c65da9ffcbf77b973c9e4b970dca2e654cbb08b0680a2684c3f97c639d",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "a39982097e3ca1fcbda6e2ba51b6ca5968fb00f58d646add69052e6613b1bc0d",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "bfd1ec8a0bef0e0b1d75c27246a02eb7be5787a4d5ae9ef34dda72d490a496f7",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",

--- a/ci/bundle/traits-futures-py36-pyqt-osx-x86_64.json
+++ b/ci/bundle/traits-futures-py36-pyqt-osx-x86_64.json
@@ -17,11 +17,23 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "mccabe",
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -117,16 +129,34 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "002872ed650c18dc52e0657c9550daf2e573e4f6205d020275c1f69a531739bf",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "mccabe",
             "repository": "enthought/free",
             "sha256": "93d8c44066f61bc4664695385b1bcc2899cc33b93aac4e30f4e5593ff8738071",
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "9f4d2928435f27eca8b30ae6058f043b1acf83e7aa399bc2cace73c429421f3d",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "da8e4ae4d824f348d8a48dd4f8b93d64615fe4b617896c8c61ceff661561bec9",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "e6a2b54c8b86806e3bbed38a1f76e89fc4eac580912c15f0496c3c89058b8a4f",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -173,8 +203,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "38f2e94317a844ef38c3d72950a010d19428bf38711c77108441515cc07c556a",
-            "version": "4.8.7-7"
+            "sha256": "0069145fc80f106615fb7c9ae1f265c135e6cadc2d5181b662ad4844ede29b15",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py36-pyqt-rh6-x86_64.json
+++ b/ci/bundle/traits-futures-py36-pyqt-rh6-x86_64.json
@@ -17,6 +17,10 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "libpng",
             "state": "auto"
         },
@@ -25,7 +29,15 @@
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -121,6 +133,12 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "2136481e3958e6152736f9f583e4448f387744e21d5efc21175b2352a1e93cc7",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "libpng",
             "repository": "enthought/free",
             "sha256": "72402221f70eadf881d7d4c6db115720daa277941e32b5d806c32db1072f4f4d",
@@ -133,10 +151,22 @@
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "57cb14632a8578ac0a06982fae21729eed429015eb50223229c555ff55abe8cd",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "d95ae75c2ed7e286b3272999cc708fbebee368d220b631074bb75dcf1b7e164e",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "987b1f653f6224f67dce9aa17e6b2bd5c14aacf2b2f49c591ca58a7258f440eb",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",
@@ -183,8 +213,8 @@
         {
             "name": "qt",
             "repository": "enthought/free",
-            "sha256": "a2a953317f1d8e1973f2859b1dc6dda2f9545c82494ab7593ae23fff6212a69d",
-            "version": "4.8.7-8"
+            "sha256": "e84538ec21670273598d4c9d701e67d2e9ee62912450cb650145caf635823a0c",
+            "version": "4.8.7-9"
         },
         {
             "name": "setuptools",

--- a/ci/bundle/traits-futures-py36-pyqt-win-x86_64.json
+++ b/ci/bundle/traits-futures-py36-pyqt-win-x86_64.json
@@ -17,11 +17,23 @@
             "state": "manual"
         },
         {
+            "name": "funcsigs",
+            "state": "auto"
+        },
+        {
             "name": "mccabe",
             "state": "auto"
         },
         {
+            "name": "mock",
+            "state": "manual"
+        },
+        {
             "name": "packaging",
+            "state": "auto"
+        },
+        {
+            "name": "pbr",
             "state": "auto"
         },
         {
@@ -113,16 +125,34 @@
             "version": "3.3.0-2"
         },
         {
+            "name": "funcsigs",
+            "repository": "enthought/free",
+            "sha256": "5a0c8b1bee069f4875ca4265c7dfc6e8f5170879dd24c1dcf94e65b013ebb92f",
+            "version": "1.0.2-1"
+        },
+        {
             "name": "mccabe",
             "repository": "enthought/free",
             "sha256": "5ef2bd3ad55c4da43a2a53550eed3fc64b7c0974c3d783449678346a059f8dab",
             "version": "0.6.1-1"
         },
         {
+            "name": "mock",
+            "repository": "enthought/free",
+            "sha256": "df9cceeddb66883a48527cb60c034605961627cb0fd0d06a88bd4a4fbb7b6ef2",
+            "version": "2.0.0-1"
+        },
+        {
             "name": "packaging",
             "repository": "enthought/free",
             "sha256": "53dc57b6e7d3f586cddd5986ee4cbac780662be9d8f22fac7f0f9df98a7adc7d",
             "version": "16.8-2"
+        },
+        {
+            "name": "pbr",
+            "repository": "enthought/free",
+            "sha256": "aa037012942129d045d7a8690e27ce6b23208e205dc663590a266ce9bd50e0f4",
+            "version": "1.8.1-13"
         },
         {
             "name": "pip",

--- a/ci/config.py
+++ b/ci/config.py
@@ -94,6 +94,7 @@ PLATFORMS = [
 CORE_DEPS = [
     'coverage',
     'flake8',
+    'mock',  # used by the pyface GuiTestAssistant
     'pip',
     'setuptools',
     'six',


### PR DESCRIPTION
The `mock` package is currently needed by the PyFace GuiTestAssistant, which we plan to use for testing.