### PR TITLE
Add example use of a background iteration.

### DIFF
--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -158,6 +158,9 @@ class PiIterator(HasStrictTraits):
         )
         plot.underlays.append(pi_line)
 
+        # Allow extra room for the y-axis label.
+        plot.padding_left = 100
+
         return plot
 
     def _traits_executor_default(self):


### PR DESCRIPTION
Add an example showing use of the `background_iteration` functionality. Requires Chaco and NumPy to run.

![screen shot 2018-07-27 at 10 23 37](https://user-images.githubusercontent.com/662003/43313234-63c47e7e-9187-11e8-9371-91fdb98c72c6.png)
