### PR TITLE
Small API cleanups

### DIFF
--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -86,7 +86,19 @@ class IterationBackgroundTask(object):
 
     def send(self, message_type, message_args=None):
         """
-        Send a message to the foreground controller.
+        Send a message to the linked IterationFuture.
+
+        Sends a pair consisting of a string giving the message type
+        along with an object providing any relevant arguments. The
+        interpretation of the arguments depends on the message type.
+
+        Parameters
+        ----------
+        message_type : string
+            Type of the message to be sent.
+        message_args : object, optional
+            Any arguments relevant to the message.  Ideally, should be
+            pickleable and immutable. If not provided, ``None`` is sent.
         """
         self.message_sender.send((message_type, message_args))
 
@@ -230,14 +242,32 @@ class BackgroundIteration(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str, Any)
 
-    def prepare(self, cancel_event, message_sender, message_receiver):
+    def future_and_callable(
+            self, cancel_event, message_sender, message_receiver):
         """
-        Prepare the background iteration for running.
+        Return a future and a linked background callable.
 
-        Returns a pair (future, background_iteration), where
-        the future acts as a handle for task cancellation, etc.,
-        and the background_iteration is a callable to be executed
-        in the background.
+        Parameters
+        ----------
+        cancel_event : threading.Event
+            Event used to request cancellation of the background job.
+        message_sender : QtMessageSender (for example)
+            Object used by the background job to send messages to the
+            UI. Supports the context manager protocol, and provides a
+            'send' method.
+        message_receiver : QtMessageReceiver (for example)
+            Object that remains in the main thread and receives messages sent
+            by the message sender. This is a HasTraits subclass with
+            a 'message' Event trait that can be listened to for arriving
+            messages.
+
+        Returns
+        -------
+        future : IterationFuture
+            Foreground object representing the state of the running
+            calculation.
+        runner : IterationBackgroundTask
+            Callable to be executed in the background.
         """
         future = IterationFuture(
             _cancel_event=cancel_event,

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -87,7 +87,7 @@ class TraitsExecutor(HasStrictTraits):
             Future for this task.
         """
         sender, receiver = self._message_router.pipe()
-        future, runner = task.prepare(
+        future, runner = task.future_and_callable(
             cancel_event=threading.Event(),
             message_sender=sender,
             message_receiver=receiver,


### PR DESCRIPTION
- Rename the inaccurately named `prepare` method (which isn't commonly used by users anyway)
- Expand some docstrings to properly follow NumPy docstring format.