### PR TITLE
Shut down a self-created thread pool before stopping.

### DIFF
--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -140,7 +140,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         self.wait_for_stop(executor)
         self.assertTrue(executor.stopped)
 
-    def test_own_thread_pool(self):
+    def test_owned_thread_pool(self):
         executor = TraitsExecutor()
         thread_pool = executor._thread_pool
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -119,7 +119,7 @@ class TraitsExecutor(HasStrictTraits):
         future : CallFuture or IterationFuture
             Future for this task.
         """
-        if self.state != RUNNING:
+        if not self.running:
             raise RuntimeError("Can't submit task unless executor is running.")
 
         sender, receiver = self._message_router.pipe()
@@ -136,7 +136,7 @@ class TraitsExecutor(HasStrictTraits):
         """
         Initiate stop: cancel existing jobs and prevent new ones.
         """
-        if self.state != RUNNING:
+        if not self.running:
             raise RuntimeError("Executor is not currently running.")
 
         # For consistency, we always go through the STOPPING state,


### PR DESCRIPTION
In the case that the `TraitsExecutor` is created without a shared thread pool, it creates its own. In that situation, it should shut down that thread pool before reaching STOPPED state.

This closes #42.