### PR TITLE
Minor consistency fix: LazyMessageRouter.__enter__ should return self

### DIFF
--- a/traits_futures/tests/lazy_message_router.py
+++ b/traits_futures/tests/lazy_message_router.py
@@ -14,7 +14,7 @@ class LazyMessageSender(object):
         self.message_queue = message_queue
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, *exc_info):
         self.message_queue.put(("done", self.connection_id))


### PR DESCRIPTION
For consistency, the `LazyMessageRouter` should return itself when used as a context manager.