### PR TITLE
Improve error message for unsupported configurations.

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -258,6 +258,17 @@ def _get_devenv(python_version, toolkit):
     Return a PythonEnvironment corresponding to the development environment for
     a given Python version and UI toolkit.
     """
+    platform = current_platform()
+    if (platform, python_version, toolkit) not in cfg.PLATFORMS:
+        raise click.ClickException(
+            "Unsupported configuration: platform={platform}, "
+            "python_version={python_version}, toolkit={toolkit}".format(
+                platform=platform,
+                python_version=python_version,
+                toolkit=toolkit,
+            )
+        )
+
     runtime_version = cfg.RUNTIME_VERSION[python_version]
     environment_name = cfg.ENVIRONMENT_TEMPLATE.format(
         prefix=cfg.PREFIX,


### PR DESCRIPTION
Before:
```
taniyama:traits-futures mdickinson$ ci build --toolkit pyside
Usage: edm environments import [OPTIONS] ENVIRONMENT_NAME

Error: Invalid value for "-f" / "--filename": Path "/Users/mdickinson/Desktop/traits-futures/ci/bundle/traits-futures-py36-pyside-osx-x86_64.json" does not exist.
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/mdickinson/Desktop/traits-futures/ci/__main__.py", line 368, in <module>
    cli()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/mdickinson/Desktop/traits-futures/ci/__main__.py", line 67, in build
    pyenv.create_from_bundle(bundle_file)
  File "/Users/mdickinson/Desktop/traits-futures/ci/python_environment.py", line 141, in create_from_bundle
    self.edm(cmd)
  File "/Users/mdickinson/Desktop/traits-futures/ci/python_environment.py", line 58, in edm
    return subprocess.check_call(self._edm_base_command + command)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 328, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['edm', '--config', '/Users/mdickinson/Desktop/traits-futures/ci/data/edm.yml', 'environments', 'import', 'traits-futures-py36-pyside', '--filename', '/Users/mdickinson/Desktop/traits-futures/ci/bundle/traits-futures-py36-pyside-osx-x86_64.json', '--force']' returned non-zero exit status 2.
```

After:
```
taniyama:traits-futures mdickinson$ ci build --toolkit pyside
Error: Unsupported configuration: platform=osx-x86_64, python_version=py36, toolkit=pyside
```