### PR TITLE
Clean up the api module

### DIFF
--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -1,60 +1,46 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-from traits_futures.background_call import (
-    BackgroundCall,
-    CallFuture,
-)
-from traits_futures.background_iteration import (
-    BackgroundIteration,
-    IterationFuture,
-)
-from traits_futures.background_progress import (
-    BackgroundProgress,
-    ProgressFuture,
-)
+from traits_futures.background_call import CallFuture
+from traits_futures.background_iteration import IterationFuture
+from traits_futures.background_progress import ProgressFuture
 from traits_futures.future_states import (
+    FutureState,
     CANCELLED,
     CANCELLING,
     EXECUTING,
     FAILED,
     COMPLETED,
     WAITING,
-    FutureState,
 )
 from traits_futures.traits_executor import (
     TraitsExecutor,
+    ExecutorState,
     RUNNING,
     STOPPING,
     STOPPED,
-    ExecutorState,
 )
 
 __all__ = [
-    # Executor
-    "TraitsExecutor",
-    "RUNNING",
-    "STOPPING",
-    "STOPPED",
-    "ExecutorState",
-
-    # Background calls
-    "BackgroundCall",
+    # Different types of Future
     "CallFuture",
-
-    # Background iterations
-    "BackgroundIteration",
     "IterationFuture",
-
-    # Background progress
-    "BackgroundProgress",
     "ProgressFuture",
 
-    # Common execution states (shared by background calls and iterations).
+    # Future states
+    "FutureState",
     "CANCELLED",
     "CANCELLING",
     "EXECUTING",
     "FAILED",
     "COMPLETED",
     "WAITING",
-    "FutureState",
+
+    # Executor
+    "TraitsExecutor",
+
+    # Executor states
+    "ExecutorState",
+    "RUNNING",
+    "STOPPING",
+    "STOPPED",
 ]

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -6,28 +6,23 @@ import unittest
 class TestApi(unittest.TestCase):
     def test_imports(self):
         from traits_futures.api import (  # noqa: F401
-            TraitsExecutor,
-            RUNNING,
-            STOPPING,
-            STOPPED,
-            ExecutorState,
-
-            BackgroundCall,
             CallFuture,
-
-            BackgroundIteration,
             IterationFuture,
-
-            BackgroundProgress,
             ProgressFuture,
 
+            FutureState,
             CANCELLED,
             CANCELLING,
             EXECUTING,
             FAILED,
             COMPLETED,
             WAITING,
-            FutureState,
+
+            TraitsExecutor,
+            ExecutorState,
+            RUNNING,
+            STOPPING,
+            STOPPED,
         )
 
     def test___all__(self):


### PR DESCRIPTION
- Remove `BackgroundIteration`, `BackgroundCall` and `BackgroundProgress` from `traits_futures.api`; they're not generally useful.
- Re-order the import lists.