### PR TITLE
Rename IterationFuture.result to IterationFuture.result_event.

### DIFF
--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -159,11 +159,11 @@ trait like this::
             current_step, max_steps, matches)
 
 The |submit_iteration| method is a little bit different: it produces a result
-on each iteration, but doesn't give any final result. Its ``result`` trait is
-an ``Event`` that you can hook listeners up to in order to receive the
+on each iteration, but doesn't give any final result. Its ``result_event``
+trait is an ``Event`` that you can hook listeners up to in order to receive the
 results. For example::
 
-    @on_trait_change('future:result')
+    @on_trait_change('future:result_event')
     def _record_result(self, result):
         self.results.append(result)
         self.update_plot_data()

--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -116,7 +116,7 @@ class PiIterator(Handler):
     def _reset_results(self):
         self.results = []
 
-    @on_trait_change('future:result')
+    @on_trait_change('future:result_event')
     def _record_result(self, result):
         self.results.append(result)
         self._update_plot_data()

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -156,7 +156,7 @@ class IterationFuture(HasStrictTraits):
 
     #: Event fired whenever a result arrives from the background
     #: iteration.
-    result = Event(Any())
+    result_event = Event(Any())
 
     @property
     def exception(self):
@@ -244,7 +244,7 @@ class IterationFuture(HasStrictTraits):
         assert self.state in (EXECUTING, CANCELLING)
         # Any results arriving after a cancellation request are ignored.
         if self.state == EXECUTING:
-            self.result = result
+            self.result_event = result
 
     def _get_cancellable(self):
         return self.state in CANCELLABLE_STATES

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -81,7 +81,7 @@ class Listener(HasStrictTraits):
             self.states.append(old_state)
         self.states.append(new_state)
 
-    @on_trait_change('future:result')
+    @on_trait_change('future:result_event')
     def record_iteration_result(self, result):
         self.results.append(result)
 
@@ -363,9 +363,9 @@ class TestIterationNoUI(unittest.TestCase):
             def result_handler(new):
                 results.append(new)
 
-            future.on_trait_change(result_handler, "result")
+            future.on_trait_change(result_handler, "result_event")
             self.router.route_until(lambda: results, timeout=TIMEOUT)
-            future.on_trait_change(result_handler, "result", remove=True)
+            future.on_trait_change(result_handler, "result_event", remove=True)
 
             # Check that there are no other references to this result besides
             # the one in this test.

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -177,8 +177,11 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         self.wait_for_stop(executor)
 
         # Check that the the shared thread pool is still available.
-        future = self.thread_pool.submit(int)
-        self.assertEqual(future.result(), 0)
+
+        # Careful: this is a concurrent.futures Future instance, not
+        # one of our traits_futures Futures.
+        cf_future = self.thread_pool.submit(int)
+        self.assertEqual(cf_future.result(), 0)
 
     def test_submit_call(self):
         def test_call(*args, **kwds):
@@ -208,7 +211,8 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             test_iteration, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2")
 
         results = []
-        future.on_trait_change(lambda result: results.append(result), 'result')
+        future.on_trait_change(
+            lambda result: results.append(result), 'result_event')
 
         self.wait_for_future(future)
         self.assertEqual(


### PR DESCRIPTION
Renaming `IterationFuture.result` to `IterationFuture.result_event`, to avoid confusion with `CallFuture.result` and `ProgressFuture.result`, which are quite different beasts.

Closes #83.