### PR TITLE
We need to listen to 'progress_items', not 'progress'.

### DIFF
--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -227,7 +227,9 @@ class TestBackgroundProgress(GuiTestAssistant, unittest.TestCase):
 
         # Wait until we get the first progress message.
         self.run_until(
-            listener, "progress", lambda listener: len(listener.progress) > 0)
+            listener, "progress_items",
+            lambda listener: len(listener.progress) > 0,
+        )
 
         # Cancel, then allow the background task to continue.
         future.cancel()


### PR DESCRIPTION
One of the tests was listening to the wrong trait. This doesn't matter for the Qt backend, since we're polling the condition we're waiting on instead of reacting to trait changes, but it'll matter for the null backend and possibly for the wx backend, too.