### PR TITLE
Add ability to set up and tear down the message router.

### DIFF
--- a/traits_futures/qt/message_router.py
+++ b/traits_futures/qt/message_router.py
@@ -111,6 +111,18 @@ class MessageRouter(HasStrictTraits):
         self._receivers[connection_id] = receiver
         return sender, receiver
 
+    def connect(self):
+        """
+        Prepare router for routing.
+        """
+        pass
+
+    def disconnect(self):
+        """
+        Undo any connections made by the ``connect`` call.
+        """
+        pass
+
     # Private traits ##########################################################
 
     #: Internal queue for messages from all senders.

--- a/traits_futures/tests/test_message_router.py
+++ b/traits_futures/tests/test_message_router.py
@@ -63,14 +63,16 @@ class MultiListener(HasStrictTraits):
 class TestMessageRouter(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
+        self.router = toolkit("message_router:MessageRouter")()
+        self.router.connect()
 
     def tearDown(self):
+        self.router.disconnect()
+        del self.router
         GuiTestAssistant.tearDown(self)
 
     def test_message_sending_from_background_thread(self):
-        MessageRouter = toolkit("message_router:MessageRouter")
-        router = MessageRouter()
-        sender, receiver = router.pipe()
+        sender, receiver = self.router.pipe()
         listener = ReceiverListener(receiver=receiver)
 
         messages = ["inconceivable", 15206, (23, 5.6)]
@@ -96,8 +98,6 @@ class TestMessageRouter(GuiTestAssistant, unittest.TestCase):
             self.assertEqual(thread, main_thread)
 
     def test_multiple_senders(self):
-        MessageRouter = toolkit('message_router:MessageRouter')
-        router = MessageRouter()
         worker_count = 64
         message_count = 64
 
@@ -110,7 +110,7 @@ class TestMessageRouter(GuiTestAssistant, unittest.TestCase):
         workers = []
         listeners = []
         for messages in worker_messages:
-            sender, receiver = router.pipe()
+            sender, receiver = self.router.pipe()
             listeners.append(ReceiverListener(receiver=receiver))
             workers.append(
                 threading.Thread(

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -221,7 +221,9 @@ class TraitsExecutor(HasStrictTraits):
     def __message_router_default(self):
         # Toolkit-specific message router.
         MessageRouter = toolkit('message_router:MessageRouter')
-        return MessageRouter()
+        router = MessageRouter()
+        router.connect()
+        return router
 
     @on_trait_change('_futures:_exiting')
     def _remove_future(self, future, name, new):
@@ -236,6 +238,9 @@ class TraitsExecutor(HasStrictTraits):
         Go to STOPPED state, and shut down the thread pool if we own it.
         """
         assert self.state == STOPPING
+        self._message_router.disconnect()
+        self._message_router = None
+
         if self._own_thread_pool:
             self._thread_pool.shutdown()
         self._thread_pool = None


### PR DESCRIPTION
More preparation for alternative backends: add `connect` and `disconnect` methods for the message router.