### PR TITLE
Force an ImportError from the Qt toolkit if Qt is not installed.

### DIFF
--- a/traits_futures/qt/init.py
+++ b/traits_futures/qt/init.py
@@ -4,6 +4,8 @@ Entry point for finding toolkit-specific classes.
 from __future__ import absolute_import, print_function, unicode_literals
 
 from pyface.base_toolkit import Toolkit
+# Force an ImportError if Qt is not installed.
+from pyface.qt import QtCore  # noqa: F401
 
 #: The toolkit object used to find toolkit-specific reources.
 toolkit_object = Toolkit("traits_futures", "qt", "traits_futures.qt")


### PR DESCRIPTION
Currently, the Qt toolkit will be selected even if Qt is not installed. This PR fixes that.