### PR TITLE
No need for MessageRouter to be a HasTraits instance.

### DIFF
--- a/traits_futures/tests/test_toolkit_support.py
+++ b/traits_futures/tests/test_toolkit_support.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import unittest
 
-from traits.api import HasTraits
-
 from traits_futures.toolkit_support import toolkit
 
 
@@ -16,4 +14,4 @@ class TestToolkitSupport(unittest.TestCase):
     def test_message_router_class(self):
         MessageRouter = toolkit("message_router:MessageRouter")
         router = MessageRouter()
-        self.assertIsInstance(router, HasTraits)
+        self.assertTrue(hasattr(router, "pipe"))

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -8,8 +8,7 @@ import concurrent.futures
 import threading
 
 from traits.api import (
-    Bool, Enum, HasStrictTraits, HasTraits, Instance, on_trait_change,
-    Property, Set)
+    Any, Bool, Enum, HasStrictTraits, Instance, on_trait_change, Property, Set)
 
 from traits_futures.background_call import BackgroundCall
 from traits_futures.background_iteration import BackgroundIteration
@@ -194,7 +193,7 @@ class TraitsExecutor(HasStrictTraits):
 
     #: Router providing message connections between background tasks
     #: and foreground futures.
-    _message_router = Instance(HasTraits)
+    _message_router = Any()
 
     #: Currently executing futures.
     _futures = Set()


### PR DESCRIPTION
A minor change in support of the null toolkit PR #107: there's no need to require the `MessageRouter` to be a `HasTraits` subclass, and no obvious advantage to that subclassing.