### PR TITLE
Max workers is configurable

### DIFF
--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -86,6 +86,17 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             del self.executor
         GuiTestAssistant.tearDown(self)
 
+    def test_max_workers(self):
+        executor = TraitsExecutor(max_workers=11)
+        self.assertEqual(executor._thread_pool._max_workers, 11)
+        executor.stop()
+        self.wait_until_stopped(executor)
+
+    def test_max_workers_mutually_exclusive_with_thread_pool(self):
+        with self.temporary_thread_pool() as thread_pool:
+            with self.assertRaises(TypeError):
+                TraitsExecutor(thread_pool=thread_pool, max_workers=11)
+
     def test_stop_method(self):
         executor = TraitsExecutor()
         listener = ExecutorListener(executor=executor)

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -38,6 +38,20 @@ ExecutorState = Enum(RUNNING, STOPPING, STOPPED)
 class TraitsExecutor(HasStrictTraits):
     """
     Executor to initiate and manage background tasks.
+
+    Parameters
+    ----------
+    thread_pool : concurrent.futures.ThreadPoolExecutor, optional
+        If supplied, provides the underlying thread pool executor to use. In
+        this case, the creator of the TraitsExecutor is responsible for
+        shutting down the thread pool once it's no longer needed. If not
+        supplied, a new private thread pool will be created, and this object's
+        ``stop`` method will shut down that thread pool.
+    max_workers : int or None, optional
+        Maximum number of workers for the private thread pool. This parameter
+        is mutually exclusive with thread_pool. The default is ``None``, which
+        delegates the choice of number of workers to Python's
+        ``ThreadPoolExecutor``.
     """
     #: Current state of this executor.
     state = ExecutorState
@@ -50,7 +64,7 @@ class TraitsExecutor(HasStrictTraits):
     #: to dispose of related resources (like the thread pool).
     stopped = Property(Bool())
 
-    def __init__(self, thread_pool=None, max_workers=4, **traits):
+    def __init__(self, thread_pool=None, max_workers=None, **traits):
         super(TraitsExecutor, self).__init__(**traits)
 
         if thread_pool is None:
@@ -58,6 +72,10 @@ class TraitsExecutor(HasStrictTraits):
                 max_workers=max_workers)
             self._own_thread_pool = True
         else:
+            if max_workers is not None:
+                raise TypeError(
+                    "at most one of 'thread_pool' and 'max_workers' "
+                    "should be supplied")
             self._thread_pool = thread_pool
             self._own_thread_pool = False
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -50,12 +50,12 @@ class TraitsExecutor(HasStrictTraits):
     #: to dispose of related resources (like the thread pool).
     stopped = Property(Bool())
 
-    def __init__(self, thread_pool=None, **traits):
+    def __init__(self, thread_pool=None, max_workers=4, **traits):
         super(TraitsExecutor, self).__init__(**traits)
 
         if thread_pool is None:
             self._thread_pool = concurrent.futures.ThreadPoolExecutor(
-                max_workers=4)
+                max_workers=max_workers)
             self._own_thread_pool = True
         else:
             self._thread_pool = thread_pool


### PR DESCRIPTION
Closes #124 

This PR contains the minimal amount of changes to make the `max_workers` configurable, when the `TraitsExecutor` owns its own thread pool.

A couple things I'd like feedback on:
- An API problems I see, if `thread_pool` is provided, then `max_workers` does nothing.
- The other option discussed was to make this a trait on the `TraitsExecutor`. If we do this, do we respond to changes to `max_workers`? I could see something like the following work well:
```python
@on_trait_change('max_workers', post_init=True)
def replace_thread_pool(self, new):
    if self._own_thread_pool:
        self._thread_pool.shutdown()  # optionally, wait=False here
        self._thread_pool = ThreadPoolExecutor(max_workers=new)
```