### PR TITLE
Fix Travis CI configuration for Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
 sudo: false
+dist: xenial
+services:
+  - xvfb
 
 env:
   global:
@@ -43,8 +46,6 @@ matrix:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
-  - export DISPLAY=:99.0
-  - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
   - if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then sh -e install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then sh -e install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y -e bootstrap click setuptools
@@ -53,6 +54,3 @@ install:
 script:
   - edm run -e bootstrap -- python -m ci flake8
   - edm run -e bootstrap -- python -m ci test
-notifications:
-  email:
-    - travis-ci@enthought.com


### PR DESCRIPTION
Travis CI is rolling out Xenial everywhere, but our current method of starting the framebuffer doesn't work on Xenial. This PR fixes this to force use of Xenial and use the approved method for starting the framebuffer.

cf: enthought/envisage#159, enthought/traits#485