### PR TITLE
Update traits-futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,15 @@ matrix:
   - os: linux
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="null"
   - os: linux
-    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT=pyqt
+    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt"
+  - os: linux
+    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt5"
   - os: osx
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="null"
   - os: osx
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt"
+  - os: osx
+    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt5"
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,18 @@ dist: xenial
 services:
   - xvfb
 
+addons:
+  apt:
+    packages:
+    - qt5-default
+    - libxkbcommon-x11-0
+    - libxcb-icccm4
+    - libxcb-image0
+    - libxcb-keysyms1
+    - libxcb-randr0
+    - libxcb-render-util0
+    - libxcb-xinerama0
+
 env:
   global:
     - INSTALL_EDM_VERSION=2.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=1.9.2
+    - INSTALL_EDM_VERSION=2.5.0
       PYTHONUNBUFFERED="1"
 
 cache:
@@ -16,29 +16,9 @@ cache:
 matrix:
   include:
   - os: linux
-    env: CI_PYTHON_VERSION="py27" CI_TOOLKIT="null"
-  - os: linux
-    env: CI_PYTHON_VERSION="py27" CI_TOOLKIT="pyside"
-  - os: linux
-    env: CI_PYTHON_VERSION="py27" CI_TOOLKIT="pyqt"
-  - os: linux
-    env: CI_PYTHON_VERSION="py35" CI_TOOLKIT="null"
-  - os: linux
-    env: CI_PYTHON_VERSION="py35" CI_TOOLKIT="pyqt"
-  - os: linux
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="null"
   - os: linux
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT=pyqt
-  - os: osx
-    env: CI_PYTHON_VERSION="py27" CI_TOOLKIT="null"
-  - os: osx
-    env: CI_PYTHON_VERSION="py27" CI_TOOLKIT="pyside"
-  - os: osx
-    env: CI_PYTHON_VERSION="py27" CI_TOOLKIT="pyqt"
-  - os: osx
-    env: CI_PYTHON_VERSION="py35" CI_TOOLKIT="null"
-  - os: osx
-    env: CI_PYTHON_VERSION="py35" CI_TOOLKIT="pyqt"
   - os: osx
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="null"
   - os: osx

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,5 @@ Run ``python -m ci example`` to see the list of available examples.
 
 All of the above commands take two options. The ``--python-version`` option
 lets you specify the Python version to use for the development environment. The
-``--toolkit`` option allows you to choose between using PyQt and PySide on
-Python 2. Run ``python -m ci <command> --help`` for more information on any
-of these commands.
+``--toolkit`` option allows you to specify a GUI backend. Run ``python -m ci
+<command> --help`` for more information on any of these commands.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,9 @@ platform: x64
 environment:
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "1.9.2"
+    INSTALL_EDM_VERSION: "2.5.0"
 
   matrix:
-    - CI_PYTHON_VERSION: "py27"
-      CI_TOOLKIT: "null"
-    - CI_PYTHON_VERSION: "py27"
-      CI_TOOLKIT: "pyside"
-    - CI_PYTHON_VERSION: "py27"
-      CI_TOOLKIT: "pyqt"
-    - CI_PYTHON_VERSION: "py35"
-      CI_TOOLKIT: "null"
-    - CI_PYTHON_VERSION: "py35"
-      CI_TOOLKIT: "pyqt"
     - CI_PYTHON_VERSION: "py36"
       CI_TOOLKIT: "null"
     - CI_PYTHON_VERSION: "py36"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
       CI_TOOLKIT: "null"
     - CI_PYTHON_VERSION: "py36"
       CI_TOOLKIT: "pyqt"
+    - CI_PYTHON_VERSION: "py36"
+      CI_TOOLKIT: "pyqt5"
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -6,8 +6,6 @@ Utilities for setting up a development environment and running tests.  See
 the top-level repository README for more detailed instructions on how to use
 these.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import contextlib
 import os
 import shutil

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -20,10 +20,6 @@ from ci.python_environment import (
     PythonEnvironment,
 )
 
-# Click will complain about unicode_literals unless we disable the warning.
-# Ref: http://click.pocoo.org/5/python3/#unicode-literals
-click.disable_unicode_literals_warning = True
-
 
 # Common options for the commands.
 python_version_option = click.option(

--- a/ci/config.py
+++ b/ci/config.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 
 import pkg_resources

--- a/ci/config.py
+++ b/ci/config.py
@@ -24,7 +24,8 @@ PYTHON_VERSIONS = [PYTHON36]
 # Toolkits
 NULL = "null"  # no GUI toolkit; a simulated event loop is used for tests
 PYQT = "pyqt"  # Qt 4, PyQt
-TOOLKITS = [NULL, PYQT]
+PYQT5 = "pyqt5"  # Qt 5, PyQt
+TOOLKITS = [NULL, PYQT, PYQT5]
 
 # Default Python version and toolkit.
 DEFAULT_PYTHON = PYTHON36
@@ -81,6 +82,9 @@ PLATFORMS = [
     (MACOS, PYTHON36, PYQT),
     (LINUX, PYTHON36, PYQT),
     (WINDOWS, PYTHON36, PYQT),
+    (MACOS, PYTHON36, PYQT5),
+    (LINUX, PYTHON36, PYQT5),
+    (WINDOWS, PYTHON36, PYQT5),
 ]
 
 # Dependencies needed for all platforms, toolkits and Python versions.
@@ -104,6 +108,7 @@ ADDITIONAL_CI_DEPS = [
 # list of requirements.
 TOOLKIT_CI_DEPS = {
     PYQT: ["mock", "pyqt", "traitsui"],
+    PYQT5: ["mock", "pyqt5", "traitsui"],
 }
 
 # Additional packages needed for local development, examples.

--- a/ci/config.py
+++ b/ci/config.py
@@ -14,7 +14,7 @@ PREFIX = PACKAGE_NAME.lower().replace("_", "-")
 
 # Platforms
 MACOS = "osx-x86_64"
-LINUX = "rh6-x86_64"
+LINUX = "rh7-x86_64"
 WINDOWS = "win-x86_64"
 
 # Python versions

--- a/ci/config.py
+++ b/ci/config.py
@@ -61,7 +61,7 @@ EXAMPLES = {
 
 # Python runtime versions.
 RUNTIME_VERSION = {
-    PYTHON36: "3.6.0",
+    PYTHON36: "3.6",
 }
 
 # Directories and files that should be checked for flake8-cleanness.

--- a/ci/config.py
+++ b/ci/config.py
@@ -23,10 +23,8 @@ PYTHON_VERSIONS = [PYTHON36]
 
 # Toolkits
 NULL = "null"  # no GUI toolkit; a simulated event loop is used for tests
-PYSIDE = "pyside"  # Qt 4, PySide 1; only available for Python 2.x.
-PYQT = "pyqt"  # Qt 4, PyQt, available for Python 2 and Python 3.
-WXPYTHON = "wxpython"  # available for Python 2 only.
-TOOLKITS = [NULL, PYSIDE, PYQT, WXPYTHON]
+PYQT = "pyqt"  # Qt 4, PyQt
+TOOLKITS = [NULL, PYQT]
 
 # Default Python version and toolkit.
 DEFAULT_PYTHON = PYTHON36
@@ -106,8 +104,6 @@ ADDITIONAL_CI_DEPS = [
 # list of requirements.
 TOOLKIT_CI_DEPS = {
     PYQT: ["mock", "pyqt", "traitsui"],
-    PYSIDE: ["mock", "pyside", "traitsui"],
-    WXPYTHON: ["wxpython"],
 }
 
 # Additional packages needed for local development, examples.

--- a/ci/config.py
+++ b/ci/config.py
@@ -114,7 +114,6 @@ CORE_DEPS = [
     # Actual library runtime dependencies. Also need "futures" on Python 2.7.
     "pyface",
     "setuptools",
-    "six",
     "traits",
 ]
 

--- a/ci/config.py
+++ b/ci/config.py
@@ -18,10 +18,8 @@ LINUX = "rh6-x86_64"
 WINDOWS = "win-x86_64"
 
 # Python versions
-PYTHON27 = "py27"
-PYTHON35 = "py35"
 PYTHON36 = "py36"
-PYTHON_VERSIONS = [PYTHON27, PYTHON35, PYTHON36]
+PYTHON_VERSIONS = [PYTHON36]
 
 # Toolkits
 NULL = "null"  # no GUI toolkit; a simulated event loop is used for tests
@@ -64,8 +62,6 @@ EXAMPLES = {
 
 # Python runtime versions.
 RUNTIME_VERSION = {
-    PYTHON27: "2.7.13",
-    PYTHON35: "3.5.2",
     PYTHON36: "3.6.0",
 }
 
@@ -81,24 +77,6 @@ FLAKE8_TARGETS = [
 # Platforms and Python versions that we support.
 # Triples (edm-platform-string, Python major.minor version, GUI toolkit)
 PLATFORMS = [
-    (MACOS, PYTHON27, NULL),
-    (LINUX, PYTHON27, NULL),
-    (WINDOWS, PYTHON27, NULL),
-    (MACOS, PYTHON27, WXPYTHON),
-    (LINUX, PYTHON27, WXPYTHON),
-    (WINDOWS, PYTHON27, WXPYTHON),
-    (MACOS, PYTHON27, PYSIDE),
-    (LINUX, PYTHON27, PYSIDE),
-    (WINDOWS, PYTHON27, PYSIDE),
-    (MACOS, PYTHON27, PYQT),
-    (LINUX, PYTHON27, PYQT),
-    (WINDOWS, PYTHON27, PYQT),
-    (MACOS, PYTHON35, NULL),
-    (LINUX, PYTHON35, NULL),
-    (WINDOWS, PYTHON35, NULL),
-    (MACOS, PYTHON35, PYQT),
-    (LINUX, PYTHON35, PYQT),
-    (WINDOWS, PYTHON35, PYQT),
     (MACOS, PYTHON36, NULL),
     (LINUX, PYTHON36, NULL),
     (WINDOWS, PYTHON36, NULL),
@@ -109,7 +87,6 @@ PLATFORMS = [
 
 # Dependencies needed for all platforms, toolkits and Python versions.
 CORE_DEPS = [
-    # Actual library runtime dependencies. Also need "futures" on Python 2.7.
     "pyface",
     "setuptools",
     "traits",
@@ -117,9 +94,7 @@ CORE_DEPS = [
 
 # Python-version-specific core dependencies. Dictionary mapping Python version
 # to list of requirements.
-VERSION_CORE_DEPS = {
-    PYTHON27: ["futures"],
-}
+VERSION_CORE_DEPS = {}
 
 # Additional packages needed for running tests under CI.
 ADDITIONAL_CI_DEPS = [

--- a/ci/config.py
+++ b/ci/config.py
@@ -29,7 +29,7 @@ TOOLKITS = [NULL, PYQT, PYQT5]
 
 # Default Python version and toolkit.
 DEFAULT_PYTHON = PYTHON36
-DEFAULT_TOOLKIT = PYQT
+DEFAULT_TOOLKIT = PYQT5
 
 # Location of repository root. Assumes that the ci script is being
 # run from the root of the repository.

--- a/ci/config.py
+++ b/ci/config.py
@@ -107,8 +107,8 @@ ADDITIONAL_CI_DEPS = [
 # Toolkit-specific ci dependencies. Dictionary mapping toolkit to
 # list of requirements.
 TOOLKIT_CI_DEPS = {
-    PYQT: ["mock", "pyqt", "traitsui"],
-    PYQT5: ["mock", "pyqt5", "traitsui"],
+    PYQT: ["pyqt", "traitsui"],
+    PYQT5: ["pyqt5", "traitsui"],
 }
 
 # Additional packages needed for local development, examples.

--- a/ci/python_environment.py
+++ b/ci/python_environment.py
@@ -257,7 +257,7 @@ def current_platform():
     if platform.startswith("win32"):
         return "win-x86_64" if is_64bits else "win-x86"
     elif platform.startswith("linux"):
-        return "rh6-x86_64"
+        return "rh7-x86_64"
     elif platform == "darwin":
         return "osx-x86_64"
     else:

--- a/ci/python_environment.py
+++ b/ci/python_environment.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import re
 import subprocess

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ Features
   the main thread. This eliminates a large class of potential issues with
   traditional thread-based solutions (race conditions, deadlocks, and UI
   updates off the main thread).
-- Cross-platform, and compatible with both Python 2 and Python 3.
+- Cross-platform.
 
 
 Limitations
@@ -41,6 +41,7 @@ Limitations
 - For the moment, |traits_futures| requires Qt. Support for wxPython
   may arrive in a future release.
 - No multiprocessing support yet. Maybe one day.
+- Requires Python 3.5 or later.
 
 
 Quick start

--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -8,9 +8,6 @@ a Chaco plot.
 
 Note: this example requires NumPy and Chaco.
 """
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
-
 import numpy as np
 
 from chaco.api import ArrayPlotData, Plot

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -8,8 +8,6 @@ modal progress dialog.
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
-from six.moves import range
-
 from pyface.qt import QtCore, QtGui
 from pyface.ui.qt4.dialog import Dialog
 from traits.api import (

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -5,9 +5,6 @@
 Example showing progress reporting from a background computation, with a
 modal progress dialog.
 """
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
-
 from pyface.qt import QtCore, QtGui
 from pyface.ui.qt4.dialog import Dialog
 from traits.api import (

--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import random
 import time
 

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -4,11 +4,11 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh5_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -8,7 +8,7 @@ install_edm() {
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh7_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -8,7 +8,7 @@ install_edm() {
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh7_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -4,7 +4,7 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -9,12 +9,12 @@ FOR /F "tokens=1,2,3 delims=." %%a in ("%INSTALL_EDM_VERSION%") do (
 )
 
 SET EDM_MAJOR_MINOR=%MAJOR%.%MINOR%
-SET EDM_PACKAGE=edm_%INSTALL_EDM_VERSION%_x86_64.msi
+SET EDM_PACKAGE=edm_cli_%INSTALL_EDM_VERSION%_x86_64.msi
 SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
 SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
 
 IF NOT EXIST %EDM_INSTALLER_PATH% CALL powershell.exe -Command %COMMAND% || GOTO error
-CALL msiexec /qn /a %EDM_INSTALLER_PATH% TARGETDIR=c:\ || GOTO error
+CALL msiexec /qn /i %EDM_INSTALLER_PATH% EDMAPPDIR=C:\Enthought\edm || GOTO error
 
 ENDLOCAL
 @ECHO.DONE

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-import io
 import os
 
 from setuptools import find_packages, setup
@@ -11,7 +10,7 @@ def get_version_info():
     """ Extract version information as a dictionary from version.py. """
     version_info = {}
     version_filename = os.path.join("traits_futures", "version.py")
-    with io.open(version_filename, "r", encoding="utf-8") as version_module:
+    with open(version_filename, "r", encoding="utf-8") as version_module:
         version_code = compile(version_module.read(), "version.py", "exec")
         exec(version_code, version_info)
     return version_info
@@ -19,7 +18,7 @@ def get_version_info():
 
 def get_long_description():
     """ Read long description from README.rst. """
-    with io.open("README.rst", "r", encoding="utf-8") as readme:
+    with open("README.rst", "r", encoding="utf-8") as readme:
         return readme.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,6 @@ setup(
             "qt = traits_futures.qt.init:toolkit_object",
         ],
     },
+    python_requires=">=3.5",
+    license="BSD",
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ def get_long_description():
 install_requires = [
     "pyface",
     "setuptools",
-    "six",
     "traits",
 ]
 if sys.version_info < (3,):

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,12 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
         "traits_futures.toolkits": [

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ install_requires = [
     "setuptools",
     "traits",
 ]
-if sys.version_info < (3,):
-    install_requires.append("futures")
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import io
 import os
-import sys
 
 from setuptools import find_packages, setup
 

--- a/traits_futures/__init__.py
+++ b/traits_futures/__init__.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits_futures.version import version as __version__
 
 __all__ = ["__version__"]

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -4,8 +4,6 @@
 """
 Core API for the traits_futures package.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits_futures.background_call import CallFuture
 from traits_futures.background_iteration import IterationFuture
 from traits_futures.background_progress import ProgressFuture

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -4,8 +4,6 @@
 """
 Background task consisting of a simple callable.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits.api import (
     Any, Bool, Callable, Dict, Event, HasStrictTraits, HasTraits, Instance,
     on_trait_change, Property, Str, Tuple, Unicode)

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -83,9 +83,6 @@ class IterationBackgroundTask(object):
                     break
                 except BaseException as e:
                     message, message_args = RAISED, marshal_exception(e)
-                    # Make sure we're not keeping references to anything
-                    # in the exception details. Not needed on Python 3.
-                    del e
                     break
                 else:
                     self.send(GENERATED, result)

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -4,8 +4,6 @@
 """
 Background task that sends results from an iteration.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import types
 
 from traits.api import (

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -12,8 +12,6 @@ Every progress submission also marks a point where the callable can
 be cancelled.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits.api import (
     Any, Bool, Callable, Dict, Event, HasStrictTraits, HasTraits, Instance,
     on_trait_change, Property, Str, Tuple, Unicode)

--- a/traits_futures/exception_handling.py
+++ b/traits_futures/exception_handling.py
@@ -8,15 +8,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import traceback
 
-import six
-
 
 def marshal_exception(e):
     """
     Turn exception details into something that can be safely
     transmitted across thread / process boundaries.
     """
-    exc_type = six.text_type(type(e))
-    exc_value = six.text_type(e)
-    formatted_traceback = six.text_type(traceback.format_exc())
+    exc_type = str(type(e))
+    exc_value = str(e)
+    formatted_traceback = str(traceback.format_exc())
     return exc_type, exc_value, formatted_traceback

--- a/traits_futures/exception_handling.py
+++ b/traits_futures/exception_handling.py
@@ -4,8 +4,6 @@
 """
 Support for transferring exception information from a background task.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import traceback
 
 

--- a/traits_futures/future_states.py
+++ b/traits_futures/future_states.py
@@ -4,8 +4,6 @@
 """
 Future states, used by the various future classes.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits.api import Enum
 
 #: Task queued, waiting to be executed.

--- a/traits_futures/null/event_loop.py
+++ b/traits_futures/null/event_loop.py
@@ -7,9 +7,8 @@ A bare-bones event loop that doesn't need any UI framework.
 from __future__ import absolute_import, print_function, unicode_literals
 
 import itertools
+import queue
 import time
-
-from six.moves import queue
 
 #: Event loop action: call with given arguments.
 _CALL_ACTION = "call"

--- a/traits_futures/null/event_loop.py
+++ b/traits_futures/null/event_loop.py
@@ -4,8 +4,6 @@
 """
 A bare-bones event loop that doesn't need any UI framework.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import itertools
 import queue
 import time

--- a/traits_futures/null/event_loop.py
+++ b/traits_futures/null/event_loop.py
@@ -198,9 +198,7 @@ class EventLoop(object):
                 # Timed out before the condition became true.
                 return False
 
-            # Python 2-compatible version of "action, *action_args = event".
-            action_type, action_args = event[0], event[1:]
-
+            action_type, *action_args = event
             if action_type == _CALL_ACTION:
                 handler_id, args, kwargs = action_args
                 event_handler = self._event_handlers[handler_id]

--- a/traits_futures/null/gui_test_assistant.py
+++ b/traits_futures/null/gui_test_assistant.py
@@ -4,8 +4,6 @@
 """
 Support for emulating an event loop for testing purposes.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits_futures.null.event_loop import EventLoop
 from traits_futures.null.package_globals import get_event_loop, set_event_loop
 

--- a/traits_futures/null/init.py
+++ b/traits_futures/null/init.py
@@ -4,8 +4,6 @@
 """
 Entry point for finding toolkit specific classes.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from pyface.base_toolkit import Toolkit
 
 #: The toolkit object used to find toolkit-specific reources.

--- a/traits_futures/null/message_router.py
+++ b/traits_futures/null/message_router.py
@@ -5,8 +5,6 @@
 Support for routing message streams from background processes to their
 corresponding foreground receivers.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits.api import Any, Event, HasStrictTraits
 
 from traits_futures.null.package_globals import get_event_loop

--- a/traits_futures/null/package_globals.py
+++ b/traits_futures/null/package_globals.py
@@ -4,8 +4,6 @@
 """
 Global shared state for this package.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 #: Global event loop.
 _event_loop = None
 

--- a/traits_futures/null/tests/test_event_loop.py
+++ b/traits_futures/null/tests/test_event_loop.py
@@ -4,8 +4,6 @@
 """
 Tests for the null toolkit EventLoop
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import unittest
 
 from traits_futures.null.event_loop import AsyncCaller, EventLoop

--- a/traits_futures/null/tests/test_package_globals.py
+++ b/traits_futures/null/tests/test_package_globals.py
@@ -4,8 +4,6 @@
 """
 Tests for the null toolkit EventLoop
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import unittest
 
 from traits_futures.null.event_loop import EventLoop

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -5,8 +5,6 @@
 Test support, providing the ability to run the event loop from tests.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 from pyface.ui.qt4.util.gui_test_assistant import (
     GuiTestAssistant as PyFaceGuiTestAssistant)
 

--- a/traits_futures/qt/init.py
+++ b/traits_futures/qt/init.py
@@ -4,8 +4,6 @@
 """
 Entry point for finding toolkit-specific classes.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from pyface.base_toolkit import Toolkit
 # Force an ImportError if Qt is not installed.
 from pyface.qt import QtCore  # noqa: F401

--- a/traits_futures/qt/message_router.py
+++ b/traits_futures/qt/message_router.py
@@ -4,8 +4,6 @@
 """
 Message routing for the Qt toolkit.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import collections
 import itertools
 import queue

--- a/traits_futures/qt/message_router.py
+++ b/traits_futures/qt/message_router.py
@@ -8,8 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import collections
 import itertools
-
-from six.moves import queue
+import queue
 
 from pyface.qt.QtCore import QObject, Signal, Slot
 from traits.api import Any, Dict, Event, HasStrictTraits, Instance, Int

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -4,8 +4,6 @@
 """
 Test methods run for all future types.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from traits.api import Any, Bool, HasStrictTraits, List, on_trait_change, Tuple
 
 from traits_futures.api import (

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import unittest
 
 

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import contextlib
 import operator
 import threading

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -8,8 +8,6 @@ import operator
 import threading
 import unittest
 
-import six
-
 from traits.api import HasStrictTraits, Instance, List, on_trait_change
 
 from traits_futures.api import (
@@ -309,7 +307,7 @@ class TestBackgroundCall(GuiTestAssistant, unittest.TestCase):
             future.result
 
     def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], six.text_type(exc_type))
+        self.assertEqual(future.exception[0], str(exc_type))
 
     def assertNoException(self, future):
         with self.assertRaises(AttributeError):

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -4,9 +4,6 @@
 """
 Tests for the background iteration functionality.
 """
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
-
 import contextlib
 import threading
 import unittest

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -12,8 +12,6 @@ import threading
 import unittest
 import weakref
 
-import six
-
 from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
 
 from traits_futures.api import (
@@ -420,7 +418,7 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
     # Assertions
 
     def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], six.text_type(exc_type))
+        self.assertEqual(future.exception[0], str(exc_type))
 
     def assertNoException(self, future):
         with self.assertRaises(AttributeError):

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import contextlib
 import threading
 import unittest

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -7,8 +7,6 @@ import contextlib
 import threading
 import unittest
 
-import six
-
 from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
 
 from traits_futures.api import (
@@ -355,4 +353,4 @@ class TestBackgroundProgress(GuiTestAssistant, unittest.TestCase):
             future.exception
 
     def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], six.text_type(exc_type))
+        self.assertEqual(future.exception[0], str(exc_type))

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import unittest
 
-import six
-
 from traits_futures.exception_handling import marshal_exception
 
 
@@ -18,11 +16,11 @@ class TestExceptionHandling(unittest.TestCase):
             marshalled = marshal_exception(exception)
 
         exc_type, exc_value, exc_traceback = marshalled
-        self.assertIsInstance(exc_type, six.text_type)
-        self.assertIsInstance(exc_value, six.text_type)
-        self.assertIsInstance(exc_traceback, six.text_type)
+        self.assertIsInstance(exc_type, str)
+        self.assertIsInstance(exc_value, str)
+        self.assertIsInstance(exc_traceback, str)
 
-        self.assertEqual(exc_type, six.text_type(RuntimeError))
+        self.assertEqual(exc_type, str(RuntimeError))
         self.assertIn("something went wrong", exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)
 
@@ -34,10 +32,10 @@ class TestExceptionHandling(unittest.TestCase):
             marshalled = marshal_exception(exception)
 
         exc_type, exc_value, exc_traceback = marshalled
-        self.assertIsInstance(exc_type, six.text_type)
-        self.assertIsInstance(exc_value, six.text_type)
-        self.assertIsInstance(exc_traceback, six.text_type)
+        self.assertIsInstance(exc_type, str)
+        self.assertIsInstance(exc_value, str)
+        self.assertIsInstance(exc_traceback, str)
 
-        self.assertEqual(exc_type, six.text_type(ValueError))
+        self.assertEqual(exc_type, str(ValueError))
         self.assertIn(message, exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import unittest
 
 from traits_futures.exception_handling import marshal_exception

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -4,8 +4,6 @@
 """
 Tests for the GuiTestAssistant.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import time
 import unittest
 

--- a/traits_futures/tests/test_message_router.py
+++ b/traits_futures/tests/test_message_router.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import threading
 import unittest
 

--- a/traits_futures/tests/test_toolkit_support.py
+++ b/traits_futures/tests/test_toolkit_support.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import unittest
 
 from traits_futures.toolkit_support import toolkit

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -4,8 +4,6 @@
 """
 Tests for the TraitsExecutor class.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 import concurrent.futures
 import contextlib
 import threading

--- a/traits_futures/tests/test_version.py
+++ b/traits_futures/tests/test_version.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import re
 import unittest
 
-import six
-
 import traits_futures.version
 
 # Regex matching a version number of one of the two forms
@@ -26,7 +24,7 @@ VERSION_MATCHER = re.compile(r"\A\d+\.\d+.\d+(?:\.dev\d+)?\Z")
 class TestVersion(unittest.TestCase):
     def test_version_string(self):
         version = traits_futures.version.version
-        self.assertIsInstance(version, six.text_type)
+        self.assertIsInstance(version, str)
         match = VERSION_MATCHER.match(version)
         self.assertIsNotNone(
             match, msg="{!r} appears to be an invalid version".format(version))

--- a/traits_futures/tests/test_version.py
+++ b/traits_futures/tests/test_version.py
@@ -1,8 +1,6 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import re
 import unittest
 

--- a/traits_futures/toolkit_support.py
+++ b/traits_futures/toolkit_support.py
@@ -4,8 +4,6 @@
 """
 Support for toolkit-specific classes.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 from pyface.base_toolkit import find_toolkit
 
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -5,8 +5,6 @@
 Main-thread executor for submission of background tasks.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import concurrent.futures
 import threading
 

--- a/traits_futures/version.py
+++ b/traits_futures/version.py
@@ -4,7 +4,5 @@
 """
 Version information for the traits_futures package.
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 #: Version of the traits_futures package, as a string.
 version = '0.2.0.dev0'


### PR DESCRIPTION
Various updates to the Traits futures infrastructure, with no functional changes to the core code.

- Remove Python 2 support
- Explicitly support Python 3.8 and Python 3.9
- Update CI to use most recent EDM; drop support for CI on 2.7 and 3.5.

This is a messy PR that may take several iterations to get right. Once it's passing CI, I may close this and recreate it in separate well-defined PRs.