### PR TITLE
Remove some redundant exception object deletions

### DIFF
--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -57,7 +57,6 @@ class CallBackgroundTask(object):
                 result = self.callable(*self.args, **self.kwargs)
             except BaseException as e:
                 self.send(RAISED, marshal_exception(e))
-                del e
             else:
                 self.send(RETURNED, result)
 

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -68,7 +68,6 @@ class IterationBackgroundTask(object):
                 iterable = iter(self.callable(*self.args, **self.kwargs))
             except BaseException as e:
                 self.send(RAISED, marshal_exception(e))
-                del e
                 return
 
             while True:

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -108,7 +108,6 @@ class ProgressBackgroundTask(object):
                 self.send(INTERRUPTED)
             except BaseException as e:
                 self.send(RAISED, marshal_exception(e))
-                del e
             else:
                 self.send(RETURNED, result)
 


### PR DESCRIPTION
Now that we're no longer supporting Python 3 there's no need to explicitly delete exception objects; Python will do that for us.