### PR TITLE
Replace uses of the Unicode trait with Str

### DIFF
--- a/docs/source/examples/quick_start.py
+++ b/docs/source/examples/quick_start.py
@@ -5,7 +5,7 @@ import time
 
 from traits.api import (
     Bool, Button, HasStrictTraits, Instance, Int,
-    on_trait_change, Property, Unicode)
+    on_trait_change, Property, Str)
 from traitsui.api import Item, UItem, View
 
 from traits_futures.api import CallFuture, TraitsExecutor
@@ -31,7 +31,7 @@ class QuickStartExample(HasStrictTraits):
     input_for_calculation = Int()
 
     #: Message about state of calculation.
-    message = Unicode("No previous calculation runs")
+    message = Str("No previous calculation runs")
 
     #: Button to start the calculation.
     calculate = Button()

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -9,7 +9,7 @@ from pyface.qt import QtCore, QtGui
 from pyface.ui.qt4.dialog import Dialog
 from traits.api import (
     Any, Bool, Button, HasStrictTraits, Instance, Int, on_trait_change,
-    Property, Unicode)
+    Property, Str)
 from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
 
 from traits_futures.api import (
@@ -24,7 +24,7 @@ class ProgressDialog(Dialog, HasStrictTraits):
     future = Instance(ProgressFuture)
 
     #: The message to display.
-    message = Unicode()
+    message = Str()
 
     #: The maximum number of steps.
     maximum = Int(1)
@@ -172,7 +172,7 @@ class PrimeCounter(Handler):
     count_enabled = Property(Bool, depends_on='future.done')
 
     #: Result from the previous run.
-    result_message = Unicode("No previous result")
+    result_message = Str("No previous result")
 
     #: Limit used for most recent run.
     _last_limit = Int()

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -6,7 +6,7 @@ Background task consisting of a simple callable.
 """
 from traits.api import (
     Any, Bool, Callable, Dict, Event, HasStrictTraits, HasTraits, Instance,
-    on_trait_change, Property, Str, Tuple, Unicode)
+    on_trait_change, Property, Str, Tuple)
 
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
@@ -162,7 +162,7 @@ class CallFuture(HasStrictTraits):
     _result = Any()
 
     #: Exception information from the background task.
-    _exception = Tuple(Unicode(), Unicode(), Unicode())
+    _exception = Tuple(Str(), Str(), Str())
 
     #: Object that receives messages from the background task.
     _message_receiver = Instance(HasTraits)

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -8,7 +8,7 @@ import types
 
 from traits.api import (
     Any, Bool, Callable, Dict, Event, HasStrictTraits, HasTraits, Instance,
-    on_trait_change, Property, Str, Tuple, Unicode)
+    on_trait_change, Property, Str, Tuple)
 
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
@@ -192,7 +192,7 @@ class IterationFuture(HasStrictTraits):
     _cancel_event = Any()
 
     #: Exception information from the background task.
-    _exception = Tuple(Unicode(), Unicode(), Unicode())
+    _exception = Tuple(Str(), Str(), Str())
 
     #: Object that receives messages from the background task.
     _message_receiver = Instance(HasTraits)

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -14,7 +14,7 @@ be cancelled.
 
 from traits.api import (
     Any, Bool, Callable, Dict, Event, HasStrictTraits, HasTraits, Instance,
-    on_trait_change, Property, Str, Tuple, Unicode)
+    on_trait_change, Property, Str, Tuple)
 
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
@@ -207,7 +207,7 @@ class ProgressFuture(HasStrictTraits):
     _result = Any()
 
     #: Exception information from the background task.
-    _exception = Tuple(Unicode(), Unicode(), Unicode())
+    _exception = Tuple(Str(), Str(), Str())
 
     #: Object that receives messages from the background task.
     _message_receiver = Instance(HasTraits)


### PR DESCRIPTION
The `Unicode` trait type is deprecated since Traits 6.0.0, and `Str` is a drop-in replacement on Python 3 (even for Traits versions earlier than 6.0). This PR replaces all uses of the `Unicode` trait type with the `Str` trait type.