### PR TITLE
Replace nested test functions with module-level functions

### DIFF
--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -45,6 +45,63 @@ def squares(start, stop):
         yield i * i
 
 
+def yield_then_wait(barrier):
+    """
+    Yield a result, then wait for an external event.
+    """
+    yield 1
+    barrier.wait(timeout=TIMEOUT)
+
+
+def set_then_yield(event):
+    """
+    Set an event before generating the first result.
+    """
+    event.set()
+    yield 1
+
+
+def wait_midway(barrier):
+    """
+    Wait for an external event in the middle of an iteration.
+    """
+    yield 1729
+    barrier.wait(timeout=TIMEOUT)
+    yield 2718
+
+
+def wait_then_fail(barrier):
+    """
+    Wait for an external event, then fail.
+    """
+    barrier.wait(timeout=TIMEOUT)
+    yield 1 / 0
+
+
+def ping_pong(test_ready, midpoint):
+    """
+    Send ping and wait for answering pong mid-iteration.
+    """
+    # Using sets because we need something weakref'able.
+    yield {1, 2, 3}
+    midpoint.set()
+    test_ready.wait(timeout=TIMEOUT)
+    yield {4, 5, 6}
+
+
+def resource_acquiring_iteration(acquired, released, barrier):
+    """
+    Iteration that simulates acquiring a resource.
+    """
+    acquired.set()
+    try:
+        yield 1
+        barrier.wait(timeout=TIMEOUT)
+        yield 2
+    finally:
+        released.set()
+
+
 class IterationFutureListener(HasStrictTraits):
     #: The object we're listening to.
     future = Instance(IterationFuture)
@@ -134,11 +191,7 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
         # the STARTED message.
         event = threading.Event()
 
-        def set_then_yield():
-            event.set()
-            yield 1
-
-        future = self.executor.submit_iteration(set_then_yield)
+        future = self.executor.submit_iteration(set_then_yield, event)
         listener = IterationFutureListener(future=future)
 
         self.assertTrue(event.wait(timeout=TIMEOUT))
@@ -156,12 +209,7 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
 
         blocker = threading.Event()
 
-        def wait_midway():
-            yield 1
-            blocker.wait(timeout=TIMEOUT)
-            yield 2
-
-        future = self.executor.submit_iteration(wait_midway)
+        future = self.executor.submit_iteration(wait_midway, blocker)
         listener = IterationFutureListener(future=future)
 
         self.run_until(
@@ -177,17 +225,13 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
         self.wait_until_done(future)
 
         self.assertNoException(future)
-        self.assertEqual(listener.results, [1])
+        self.assertEqual(listener.results, [1729])
         self.assertEqual(
             listener.states,
             [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cancel_before_exhausted(self):
-        def yield_then_wait(blocker):
-            yield 1
-            blocker.wait(timeout=TIMEOUT)
-
         blocker = threading.Event()
         future = self.executor.submit_iteration(yield_then_wait, blocker)
         listener = IterationFutureListener(future=future)
@@ -224,14 +268,9 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
         self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
 
     def test_cancel_after_start(self):
-        def target(blocker):
-            yield 1729
-            blocker.wait(timeout=TIMEOUT)
-            yield 2718
-
         blocker = threading.Event()
 
-        future = self.executor.submit_iteration(target, blocker)
+        future = self.executor.submit_iteration(wait_midway, blocker)
         listener = IterationFutureListener(future=future)
 
         self.run_until(
@@ -252,13 +291,9 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
         )
 
     def test_cancel_before_failure(self):
-        def target(blocker):
-            blocker.wait(timeout=TIMEOUT)
-            yield 1 / 0
-
         blocker = threading.Event()
 
-        future = self.executor.submit_iteration(target, blocker)
+        future = self.executor.submit_iteration(wait_then_fail, blocker)
         listener = IterationFutureListener(future=future)
 
         self.wait_for_state(future, EXECUTING)
@@ -307,22 +342,12 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
             future.cancel()
 
     def test_generator_closed_on_cancellation(self):
-        def target(resource_acquired, resource_released, blocker):
-            # Generator function that requires cleanup on exit.
-            resource_acquired.set()
-            try:
-                yield 1
-                blocker.wait(timeout=TIMEOUT)
-                yield 2
-            finally:
-                resource_released.set()
-
         resource_acquired = threading.Event()
         blocker = threading.Event()
         resource_released = threading.Event()
 
         future = self.executor.submit_iteration(
-            target,
+            resource_acquiring_iteration,
             resource_acquired, resource_released, blocker)
         listener = IterationFutureListener(future=future)
 
@@ -343,18 +368,11 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
     def test_prompt_result_deletion(self):
         # Check that we're not hanging onto result references needlessly in the
         # background task.
-        def waiting_iteration(test_ready, midpoint):
-            # Using sets because we need something weakref'able.
-            yield {1, 2, 3}
-            midpoint.set()
-            test_ready.wait(timeout=TIMEOUT)
-            yield {4, 5, 6}
-
         test_ready = threading.Event()
         midpoint = threading.Event()
 
         future = self.executor.submit_iteration(
-            waiting_iteration, test_ready, midpoint)
+            ping_pong, test_ready, midpoint)
         listener = IterationFutureListener(future=future)
 
         self.run_until(

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -20,6 +20,14 @@ class Dummy(HasStrictTraits):
     never_fired = Event()
 
 
+def slow_return():
+    """
+    Return after a delay.
+    """
+    time.sleep(0.1)
+    return 1729
+
+
 class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
@@ -69,14 +77,10 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
 
     def test_run_until_success(self):
         # Trait fired, condition starts false but becomes true.
-        def target():
-            time.sleep(0.1)
-            return 1729
-
         executor = TraitsExecutor()
 
         # Case 1: condition true on second trait change event.
-        future = executor.submit_call(target)
+        future = executor.submit_call(slow_return)
         self.run_until(
             future,
             "state",

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -73,6 +73,22 @@ class FuturesListener(HasStrictTraits):
         return all(future.done for future in self.futures)
 
 
+def test_call(*args, **kwds):
+    """ Simple test target for submit_call. """
+    return args, kwds
+
+
+def test_iteration(*args, **kwargs):
+    """ Simple test target for submit_iteration. """
+    yield args
+    yield kwargs
+
+
+def test_progress(arg1, arg2, kwd1, kwd2, progress):
+    """ Simple test target for submit_progress. """
+    return arg1, arg2, kwd1, kwd2
+
+
 class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
@@ -197,9 +213,6 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             self.assertEqual(cf_future.result(), 0)
 
     def test_submit_call(self):
-        def test_call(*args, **kwds):
-            return args, kwds
-
         self.executor = TraitsExecutor()
         future = self.executor.submit_call(
             test_call, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2")
@@ -215,10 +228,6 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         )
 
     def test_submit_iteration(self):
-        def test_iteration(*args, **kwargs):
-            yield args
-            yield kwargs
-
         self.executor = TraitsExecutor()
         future = self.executor.submit_iteration(
             test_iteration, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2")
@@ -237,9 +246,6 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         )
 
     def test_submit_progress(self):
-        def test_progress(arg1, arg2, kwd1, kwd2, progress):
-            return arg1, arg2, kwd1, kwd2
-
         self.executor = TraitsExecutor()
         future = self.executor.submit_progress(
             test_progress, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2")


### PR DESCRIPTION
Nested test functions prevent the multiprocessing-equivalent of the thread executor, since they're unpickleable. This PR replaces them all with module-level functions.