### PR TITLE
Fix: clean up futures in test decorator

### DIFF
--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -1,6 +1,7 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
+import concurrent.futures
 import contextlib
 import operator
 import threading
@@ -273,12 +274,14 @@ class TestBackgroundCall(GuiTestAssistant, unittest.TestCase):
 
         event = threading.Event()
 
+        futures = []
         for _ in range(max_workers):
-            thread_pool.submit(event.wait)
+            futures.append(thread_pool.submit(event.wait))
         try:
             yield
         finally:
             event.set()
+            concurrent.futures.wait(futures)
 
     def halt_executor(self):
         """

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -4,6 +4,7 @@
 """
 Tests for the background iteration functionality.
 """
+import concurrent.futures
 import contextlib
 import threading
 import unittest
@@ -390,12 +391,14 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
 
         event = threading.Event()
 
+        futures = []
         for _ in range(max_workers):
-            thread_pool.submit(event.wait)
+            futures.append(thread_pool.submit(event.wait))
         try:
             yield
         finally:
             event.set()
+            concurrent.futures.wait(futures)
 
     def halt_executor(self):
         """

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -1,6 +1,7 @@
 # (C) Copyright 2018-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
 
+import concurrent.futures
 import contextlib
 import threading
 import unittest
@@ -315,12 +316,14 @@ class TestBackgroundProgress(GuiTestAssistant, unittest.TestCase):
 
         event = threading.Event()
 
+        futures = []
         for _ in range(max_workers):
-            thread_pool.submit(event.wait)
+            futures.append(thread_pool.submit(event.wait))
         try:
             yield
         finally:
             event.set()
+            concurrent.futures.wait(futures)
 
     def halt_executor(self):
         """


### PR DESCRIPTION
Minor fix to a test helper function: make sure that we wait for all futures to complete before exiting the with block.