### PR TITLE
Don't explicitly inherit from object

### DIFF
--- a/ci/python_environment.py
+++ b/ci/python_environment.py
@@ -12,7 +12,7 @@ import sys
 MINIMUM_EDM_VERSION = 1, 6, 0
 
 
-class PythonEnvironment(object):
+class PythonEnvironment:
     """ A Python Environment provisioned by edm. """
 
     def __init__(self, name, runtime_version, edm_platform=None,

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -34,7 +34,7 @@ RAISED = "raised"
 RETURNED = "returned"
 
 
-class CallBackgroundTask(object):
+class CallBackgroundTask:
     """
     Wrapper around the actual callable to be run. This wrapper provides the
     task that will be submitted to the concurrent.futures executor

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -46,7 +46,7 @@ EXHAUSTED = "exhausted"
 GENERATED = "generated"
 
 
-class IterationBackgroundTask(object):
+class IterationBackgroundTask:
     """
     Iteration to be executed in the background.
     """

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -49,7 +49,7 @@ class _ProgressCancelled(Exception):
     """
 
 
-class ProgressReporter(object):
+class ProgressReporter:
     """
     Object used by the target callable to report progress.
     """
@@ -75,7 +75,7 @@ class ProgressReporter(object):
         self.send(PROGRESS, progress_info)
 
 
-class ProgressBackgroundTask(object):
+class ProgressBackgroundTask:
     """
     Background portion of a progress background task.
 

--- a/traits_futures/null/event_loop.py
+++ b/traits_futures/null/event_loop.py
@@ -21,7 +21,7 @@ _IDLE = "idle"
 _RUNNING = "running"
 
 
-class AsyncCaller(object):
+class AsyncCaller:
     """
     Object allowing asynchronous execution of a callable.
 
@@ -64,7 +64,7 @@ class AsyncCaller(object):
         self._closed = True
 
 
-class EventLoop(object):
+class EventLoop:
     """
     A simple event loop that doesn't require any UI framework.
 

--- a/traits_futures/null/gui_test_assistant.py
+++ b/traits_futures/null/gui_test_assistant.py
@@ -11,7 +11,7 @@ from traits_futures.null.package_globals import get_event_loop, set_event_loop
 DEFAULT_TIMEOUT = 10.0
 
 
-class GuiTestAssistant(object):
+class GuiTestAssistant:
     def setUp(self):
         # Save the old event loop and create a fresh one for testing.
         self._old_event_loop = get_event_loop()
@@ -51,13 +51,13 @@ class GuiTestAssistant(object):
         RuntimeError
             If the condition didn't become true before timeout.
         """
-        if condition(object):
+        if condition:
             return
 
         event_loop = get_event_loop()
 
         def stop_on_condition():
-            if condition(object):
+            if condition:
                 event_loop.stop()
 
         object.on_trait_change(stop_on_condition, trait)

--- a/traits_futures/null/gui_test_assistant.py
+++ b/traits_futures/null/gui_test_assistant.py
@@ -51,13 +51,13 @@ class GuiTestAssistant:
         RuntimeError
             If the condition didn't become true before timeout.
         """
-        if condition:
+        if condition(object):
             return
 
         event_loop = get_event_loop()
 
         def stop_on_condition():
-            if condition:
+            if condition(object):
                 event_loop.stop()
 
         object.on_trait_change(stop_on_condition, trait)

--- a/traits_futures/null/message_router.py
+++ b/traits_futures/null/message_router.py
@@ -24,7 +24,7 @@ class MessageReceiver(HasStrictTraits):
         self.message = message
 
 
-class MessageSender(object):
+class MessageSender:
     """
     Object allowing the worker to send messages.
 

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -15,4 +15,4 @@ class GuiTestAssistant(PyFaceGuiTestAssistant):
         Run the event loop until the given condition holds true.
         """
         self.event_loop_helper.event_loop_until_condition(
-            lambda: condition, timeout=timeout)
+            lambda: condition(object), timeout=timeout)

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -15,4 +15,4 @@ class GuiTestAssistant(PyFaceGuiTestAssistant):
         Run the event loop until the given condition holds true.
         """
         self.event_loop_helper.event_loop_until_condition(
-            lambda: condition(object), timeout=timeout)
+            lambda: condition, timeout=timeout)

--- a/traits_futures/qt/message_router.py
+++ b/traits_futures/qt/message_router.py
@@ -36,7 +36,7 @@ class _MessageSignallee(QObject):
         self.on_message_sent()
 
 
-class MessageSender(object):
+class MessageSender:
     """
     Object allowing the worker to send messages.
 

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -32,7 +32,7 @@ class FutureListener(HasStrictTraits):
         self.done_changes.append((old, new))
 
 
-class CommonFutureTests(object):
+class CommonFutureTests:
     """
     Mixin class providing tests that are run for all future types.
     """

--- a/traits_futures/toolkit_support.py
+++ b/traits_futures/toolkit_support.py
@@ -7,7 +7,7 @@ Support for toolkit-specific classes.
 from pyface.base_toolkit import find_toolkit
 
 
-class Toolkit(object):
+class Toolkit:
     """
     Provide access to toolkit-specific classes.
 


### PR DESCRIPTION
Another post-Python2-migration cleanup: there's no longer any need to explicitly inherit from `object`.