### PR TITLE
Refactor tests to separate concurrency from parallelism

### DIFF
--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -1,0 +1,277 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+import operator
+
+from traits.api import HasStrictTraits, Instance, List, on_trait_change
+
+from traits_futures.api import (
+    CallFuture,
+    FutureState,
+    CANCELLED,
+    CANCELLING,
+    COMPLETED,
+    EXECUTING,
+    FAILED,
+    WAITING,
+)
+
+
+#: Timeout for blocking operations, in seconds.
+TIMEOUT = 10.0
+
+
+def ping_pong(ping_event, pong_event):
+    """
+    Send a ping, then wait for an answering pong.
+    """
+    ping_event.set()
+    pong_event.wait(timeout=TIMEOUT)
+
+
+def ping_pong_fail(ping_event, pong_event):
+    """
+    Send a ping, wait for an answering pong, then fail.
+    """
+    ping_event.set()
+    pong_event.wait(timeout=TIMEOUT)
+    1 / 0
+
+
+class CallFutureListener(HasStrictTraits):
+    #: Future that we're listening to.
+    future = Instance(CallFuture)
+
+    #: List of states of that future.
+    states = List(FutureState)
+
+    @on_trait_change("future:state")
+    def record_state_change(self, obj, name, old_state, new_state):
+        if not self.states:
+            # On the first state change, record the initial state as well as
+            # the new one.
+            self.states.append(old_state)
+        self.states.append(new_state)
+
+
+class BackgroundCallTests:
+    """ Mixin class containing tests for the background call. """
+
+    def test_successful_call(self):
+        future = self.executor.submit_call(pow, 2, 3)
+        listener = CallFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertResult(future, 8)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, COMPLETED],
+        )
+
+    def test_failed_call(self):
+        future = self.executor.submit_call(operator.floordiv, 1, 0)
+        listener = CallFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertException(future, ZeroDivisionError)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, FAILED],
+        )
+
+    def test_cancellation_vs_started_race_condition(self):
+        # Simulate situation where a STARTED message arrives post-cancellation.
+        event = self.Event()
+
+        future = self.executor.submit_call(event.set)
+        listener = CallFutureListener(future=future)
+
+        # Ensure the background task is past the cancel_event.is_set() check.
+        self.assertTrue(event.wait(timeout=TIMEOUT))
+
+        # And _now_ cancel before we process any messages.
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancellation_before_execution(self):
+        # Case where cancellation occurs before the future even starts
+        # executing.
+        with self.block_worker_pool():
+            future = self.executor.submit_call(pow, 2, 3)
+            listener = CallFutureListener(future=future)
+            self.assertTrue(future.cancellable)
+            future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancellation_before_success(self):
+        signal = self.Event()
+        test_ready = self.Event()
+
+        future = self.executor.submit_call(ping_pong, signal, test_ready)
+        listener = CallFutureListener(future=future)
+
+        # Wait for executing state; the test_ready event ensures we
+        # get no further.
+        self.assertTrue(signal.wait(timeout=TIMEOUT))
+        self.wait_for_state(future, EXECUTING)
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        test_ready.set()
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancellation_before_failure(self):
+        signal = self.Event()
+        test_ready = self.Event()
+
+        future = self.executor.submit_call(ping_pong_fail, signal, test_ready)
+        listener = CallFutureListener(future=future)
+
+        # Wait for executing state; the test_ready event ensures we
+        # get no further.
+        self.assertTrue(signal.wait(timeout=TIMEOUT))
+        self.wait_for_state(future, EXECUTING)
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        test_ready.set()
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    def test_cannot_cancel_after_success(self):
+        future = self.executor.submit_call(pow, 2, 3)
+        listener = CallFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertFalse(future.cancellable)
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+        self.assertResult(future, 8)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, COMPLETED],
+        )
+
+    def test_cannot_cancel_after_failure(self):
+        future = self.executor.submit_call(operator.floordiv, 1, 0)
+        listener = CallFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertFalse(future.cancellable)
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+        self.assertNoResult(future)
+        self.assertException(future, ZeroDivisionError)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, FAILED],
+        )
+
+    def test_cannot_cancel_after_cancel(self):
+        future = self.executor.submit_call(pow, 2, 3)
+        listener = CallFutureListener(future=future)
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        self.assertFalse(future.cancellable)
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, CANCELLING, CANCELLED],
+        )
+
+    def test_double_cancel_variant(self):
+        signal = self.Event()
+        test_ready = self.Event()
+
+        future = self.executor.submit_call(ping_pong, signal, test_ready)
+        listener = CallFutureListener(future=future)
+
+        # Wait for executing state; the test_ready event ensures we
+        # get no further.
+        self.assertTrue(signal.wait(timeout=TIMEOUT))
+        self.wait_for_state(future, EXECUTING)
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        test_ready.set()
+
+        self.assertFalse(future.cancellable)
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    # Helper functions
+
+    def halt_executor(self):
+        """
+        Wait for the executor to stop.
+        """
+        executor = self.executor
+        executor.stop()
+        self.run_until(executor, "stopped", lambda executor: executor.stopped)
+        del self.executor
+
+    def wait_until_done(self, future):
+        self.run_until(future, "done", lambda future: future.done)
+
+    def wait_for_state(self, future, state):
+        self.run_until(future, "state", lambda future: future.state == state)
+
+    # Assertions
+
+    def assertResult(self, future, expected_result):
+        self.assertEqual(future.result, expected_result)
+
+    def assertNoResult(self, future):
+        with self.assertRaises(AttributeError):
+            future.result
+
+    def assertException(self, future, exc_type):
+        self.assertEqual(future.exception[0], str(exc_type))
+
+    def assertNoException(self, future):
+        with self.assertRaises(AttributeError):
+            future.exception

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -1,0 +1,412 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+"""
+Tests for the background iteration functionality.
+"""
+import weakref
+
+from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
+
+from traits_futures.api import (
+    IterationFuture,
+    FutureState,
+    CANCELLED,
+    CANCELLING,
+    EXECUTING,
+    FAILED,
+    COMPLETED,
+    WAITING,
+)
+
+#: Timeout for blocking operations, in seconds.
+TIMEOUT = 10.0
+
+
+def reciprocals(start, stop):
+    """
+    Generate reciprocals of integers in a range.
+
+    Possibly failing iterable used in testing.
+    """
+    for i in range(start, stop):
+        yield 1 / i
+
+
+def squares(start, stop):
+    """
+    Generate squares of integers in a range.
+
+    Simple iterable used in testing.
+    """
+    for i in range(start, stop):
+        yield i * i
+
+
+def yield_then_wait(barrier):
+    """
+    Yield a result, then wait for an external event.
+    """
+    yield 1
+    barrier.wait(timeout=TIMEOUT)
+
+
+def set_then_yield(event):
+    """
+    Set an event before generating the first result.
+    """
+    event.set()
+    yield 1
+
+
+def wait_midway(barrier):
+    """
+    Wait for an external event in the middle of an iteration.
+    """
+    yield 1729
+    barrier.wait(timeout=TIMEOUT)
+    yield 2718
+
+
+def wait_then_fail(barrier):
+    """
+    Wait for an external event, then fail.
+    """
+    barrier.wait(timeout=TIMEOUT)
+    yield 1 / 0
+
+
+def ping_pong(test_ready, midpoint):
+    """
+    Send ping and wait for answering pong mid-iteration.
+    """
+    # Using sets because we need something weakref'able.
+    yield {1, 2, 3}
+    midpoint.set()
+    test_ready.wait(timeout=TIMEOUT)
+    yield {4, 5, 6}
+
+
+def resource_acquiring_iteration(acquired, released, barrier):
+    """
+    Iteration that simulates acquiring a resource.
+    """
+    acquired.set()
+    try:
+        yield 1
+        barrier.wait(timeout=TIMEOUT)
+        yield 2
+    finally:
+        released.set()
+
+
+class IterationFutureListener(HasStrictTraits):
+    #: The object we're listening to.
+    future = Instance(IterationFuture)
+
+    #: List of states of that future.
+    states = List(FutureState)
+
+    #: List of results from the future.
+    results = List(Any())
+
+    @on_trait_change("future:state")
+    def record_state_change(self, obj, name, old_state, new_state):
+        if not self.states:
+            # On the first state change, record the initial state as well as
+            # the new one.
+            self.states.append(old_state)
+        self.states.append(new_state)
+
+    @on_trait_change("future:result_event")
+    def record_iteration_result(self, result):
+        self.results.append(result)
+
+
+class BackgroundIterationTests:
+    def test_successful_iteration(self):
+        # A simple case.
+        future = self.executor.submit_iteration(reciprocals, start=1, stop=4)
+        listener = IterationFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [1.0, 0.5, 1 / 3.0])
+        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
+
+    def test_general_iterable(self):
+        # Any call that returns an iterable should be accepted
+        future = self.executor.submit_iteration(range, 0, 10, 2)
+        listener = IterationFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [0, 2, 4, 6, 8])
+        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
+
+    def test_bad_iteration_setup(self):
+        # Deliberately passing a callable that returns
+        # something non-iterable.
+        future = self.executor.submit_iteration(pow, 2, 5)
+        listener = IterationFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertException(future, TypeError)
+        self.assertEqual(listener.results, [])
+        self.assertEqual(listener.states, [WAITING, EXECUTING, FAILED])
+
+    def test_failing_iteration(self):
+        # Iteration that eventually fails.
+        future = self.executor.submit_iteration(reciprocals, start=-2, stop=2)
+        listener = IterationFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertException(future, ZeroDivisionError)
+        self.assertEqual(listener.results, [-0.5, -1.0])
+        self.assertEqual(listener.states, [WAITING, EXECUTING, FAILED])
+
+    def test_cancel_before_execution(self):
+        # Simulate race condition where we cancel after the background
+        # iteration has checked the cancel event, but before we process
+        # the STARTED message.
+        event = self.Event()
+
+        future = self.executor.submit_iteration(set_then_yield, event)
+        listener = IterationFutureListener(future=future)
+
+        self.assertTrue(event.wait(timeout=TIMEOUT))
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [])
+        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
+
+    def test_cancel_during_iteration(self):
+        # Exercise code path where the cancel event is set during the
+        # iteration.
+
+        blocker = self.Event()
+
+        future = self.executor.submit_iteration(wait_midway, blocker)
+        listener = IterationFutureListener(future=future)
+
+        self.run_until(
+            listener,
+            "results_items",
+            lambda listener: len(listener.results) > 0,
+        )
+
+        # task is prevented from completing until we set the blocker event,
+        # so we can cancel before that happens.
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        blocker.set()
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [1729])
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancel_before_exhausted(self):
+        blocker = self.Event()
+        future = self.executor.submit_iteration(yield_then_wait, blocker)
+        listener = IterationFutureListener(future=future)
+
+        # Make sure we've got the single result.
+        self.run_until(
+            listener,
+            "results_items",
+            lambda listener: len(listener.results) > 0,
+        )
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        blocker.set()
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [1])
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancel_before_start(self):
+        with self.block_worker_pool():
+            future = self.executor.submit_iteration(squares, 0, 10)
+            listener = IterationFutureListener(future=future)
+            self.assertTrue(future.cancellable)
+            future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [])
+        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
+
+    def test_cancel_after_start(self):
+        blocker = self.Event()
+
+        future = self.executor.submit_iteration(wait_midway, blocker)
+        listener = IterationFutureListener(future=future)
+
+        self.run_until(
+            listener,
+            "results_items",
+            lambda listener: len(listener.results) > 0,
+        )
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        blocker.set()
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [1729])
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancel_before_failure(self):
+        blocker = self.Event()
+
+        future = self.executor.submit_iteration(wait_then_fail, blocker)
+        listener = IterationFutureListener(future=future)
+
+        self.wait_for_state(future, EXECUTING)
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        blocker.set()
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [])
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancel_bad_job(self):
+        future = self.executor.submit_iteration(pow, 10, 3)
+        listener = IterationFutureListener(future=future)
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertNoException(future)
+        self.assertEqual(listener.results, [])
+        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
+
+    def test_double_cancel(self):
+        future = self.executor.submit_iteration(squares, 0, 10)
+
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        self.assertFalse(future.cancellable)
+
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+    def test_completed_cancel(self):
+        future = self.executor.submit_iteration(squares, 0, 10)
+
+        self.wait_until_done(future)
+
+        self.assertFalse(future.cancellable)
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+    def test_generator_closed_on_cancellation(self):
+        resource_acquired = self.Event()
+        blocker = self.Event()
+        resource_released = self.Event()
+
+        future = self.executor.submit_iteration(
+            resource_acquiring_iteration,
+            resource_acquired,
+            resource_released,
+            blocker,
+        )
+        listener = IterationFutureListener(future=future)
+
+        self.run_until(
+            listener,
+            "results_items",
+            lambda listener: len(listener.results) > 0,
+        )
+
+        self.assertTrue(resource_acquired.is_set())
+        self.assertFalse(resource_released.is_set())
+
+        future.cancel()
+        blocker.set()
+
+        self.wait_until_done(future)
+        self.assertTrue(resource_released.is_set())
+
+    def test_prompt_result_deletion(self):
+        # Check that we're not hanging onto result references needlessly in the
+        # background task.
+        test_ready = self.Event()
+        midpoint = self.Event()
+
+        future = self.executor.submit_iteration(
+            ping_pong, test_ready, midpoint
+        )
+        listener = IterationFutureListener(future=future)
+
+        self.run_until(
+            listener,
+            "results_items",
+            lambda listener: len(listener.results) > 0,
+        )
+
+        # Check that there are no other references to this result besides
+        # the one in this test.
+        result = listener.results.pop()
+        ref = weakref.ref(result)
+        del result
+
+        try:
+            # midpoint won't be set until we next invoke "next(iterable)",
+            # by which time the IterationBackgroundTask's reference should
+            # have been deleted.
+            self.assertTrue(midpoint.wait(timeout=TIMEOUT))
+            self.assertIsNone(ref())
+        finally:
+            # Let the background task complete, even if the test fails.
+            test_ready.set()
+
+    # Helper functions
+
+    def halt_executor(self):
+        """
+        Wait for the executor to stop.
+        """
+        executor = self.executor
+        executor.stop()
+        self.run_until(executor, "stopped", lambda executor: executor.stopped)
+        del self.executor
+
+    def wait_until_done(self, future):
+        self.run_until(future, "done", lambda future: future.done)
+
+    def wait_for_state(self, future, state):
+        self.run_until(future, "state", lambda future: future.state == state)
+
+    # Assertions
+
+    def assertException(self, future, exc_type):
+        self.assertEqual(future.exception[0], str(exc_type))
+
+    def assertNoException(self, future):
+        with self.assertRaises(AttributeError):
+            future.exception

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -1,0 +1,322 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
+
+from traits_futures.api import (
+    FutureState,
+    ProgressFuture,
+    CANCELLED,
+    CANCELLING,
+    COMPLETED,
+    EXECUTING,
+    FAILED,
+    WAITING,
+)
+
+#: Timeout for blocking operations, in seconds.
+TIMEOUT = 10.0
+
+
+# Target functions used for testing ###########################################
+
+
+def progress_reporting_sum(numbers, progress):
+    """
+    Sum a list of numbers, reporting progress at each step.
+    """
+    count = len(numbers)
+
+    total = 0
+    for i, number in enumerate(numbers):
+        progress((i, count))
+        total += number
+    progress((count, count))
+    return total
+
+
+def bad_progress_reporting_function(progress):
+    """
+    Target function that raises an exception.
+    """
+    progress((5, 10))
+    1 / 0
+
+
+def wait_then_fail(signal, progress):
+    """
+    Target function that waits until given permission to proceed, then fails.
+    """
+    signal.wait(timeout=TIMEOUT)
+    1 / 0
+
+
+def progress_then_signal(signal, progress):
+    """
+    Target function that emits progress, then signals.
+    """
+    progress(1)
+    progress(2)
+    signal.set()
+
+
+def syncing_progress(test_ready, raised, progress):
+    """
+    Target function that allows synchronization with the main thread between
+    the first and second progress notifications.
+    """
+    progress("first")
+    # Synchronise with the test.
+    test_ready.wait(timeout=TIMEOUT)
+    # After the test cancels, the second progress send operation should raise,
+    # so that we never get to the following code.
+    try:
+        progress("second")
+    except BaseException:
+        raised.set()
+        raise
+
+
+def event_set_with_progress(event, progress):
+    """
+    Target function that simply sets an event.
+    """
+    event.set()
+
+
+def resource_acquirer(acquired, ready, checkpoint, progress):
+    """
+    Target function that acquires a resource.
+    """
+    acquired.set()
+    try:
+        checkpoint.set()
+        ready.wait(timeout=TIMEOUT)
+    finally:
+        acquired.clear()
+
+
+class ProgressFutureListener(HasStrictTraits):
+    """
+    Listener for a ProgressFuture. Records state changes and progress messages.
+    """
+
+    #: Future that we're listening to.
+    future = Instance(ProgressFuture)
+
+    #: List of states of that future.
+    states = List(FutureState)
+
+    #: List of progress messages received.
+    progress = List(Any())
+
+    @on_trait_change("future:state")
+    def record_state_change(self, obj, name, old_state, new_state):
+        if not self.states:
+            # On the first state change, record the initial state as well as
+            # the new one.
+            self.states.append(old_state)
+        self.states.append(new_state)
+
+    @on_trait_change("future:progress")
+    def record_progress(self, progress_info):
+        self.progress.append(progress_info)
+
+
+class BackgroundProgressTests:
+    def test_progress(self):
+        # Straightforward case.
+        future = self.executor.submit_progress(
+            progress_reporting_sum, [1, 2, 3]
+        )
+        listener = ProgressFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertResult(future, 6)
+        self.assertNoException(future)
+        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
+
+        expected_progress = [(0, 3), (1, 3), (2, 3), (3, 3)]
+        self.assertEqual(listener.progress, expected_progress)
+
+    def test_progress_with_progress_keyword_argument(self):
+        with self.assertRaises(TypeError):
+            self.executor.submit_progress(
+                progress_reporting_sum, [1, 2, 3], progress=None
+            )
+
+    def test_failed_progress(self):
+        # Callable that raises.
+        future = self.executor.submit_progress(bad_progress_reporting_function)
+        listener = ProgressFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertException(future, ZeroDivisionError)
+        self.assertEqual(listener.states, [WAITING, EXECUTING, FAILED])
+
+        expected_progress = [(5, 10)]
+        self.assertEqual(listener.progress, expected_progress)
+
+    def test_cancellation_before_execution(self):
+        event = self.Event()
+
+        future = self.executor.submit_progress(event_set_with_progress, event)
+        listener = ProgressFutureListener(future=future)
+
+        self.assertTrue(event.wait(timeout=TIMEOUT))
+        self.assertTrue(future.cancellable)
+        future.cancel()
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, CANCELLING, CANCELLED],
+        )
+
+    def test_cancellation_before_background_task_starts(self):
+        # Test case where the background job is cancelled before
+        # it even starts executing.
+        event = self.Event()
+
+        with self.block_worker_pool():
+            future = self.executor.submit_progress(
+                event_set_with_progress, event
+            )
+            listener = ProgressFutureListener(future=future)
+            future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertFalse(event.is_set())
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
+
+    def test_progress_allows_cancellation(self):
+        test_ready = self.Event()
+        raised = self.Event()
+
+        future = self.executor.submit_progress(
+            syncing_progress, test_ready, raised
+        )
+        listener = ProgressFutureListener(future=future)
+
+        # Wait until we get the first progress message.
+        self.run_until(
+            listener,
+            "progress_items",
+            lambda listener: len(listener.progress) > 0,
+        )
+
+        # Cancel, then allow the background task to continue.
+        future.cancel()
+        test_ready.set()
+
+        self.wait_until_done(future)
+
+        self.assertTrue(raised.is_set())
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(
+            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED]
+        )
+        self.assertEqual(listener.progress, ["first"])
+
+    def test_double_cancellation(self):
+        future = self.executor.submit_progress(progress_reporting_sum, [1, 2])
+        self.assertTrue(future.cancellable)
+        future.cancel()
+
+        self.assertFalse(future.cancellable)
+        with self.assertRaises(RuntimeError):
+            future.cancel()
+
+    def test_cancel_raising_task(self):
+        signal = self.Event()
+        future = self.executor.submit_progress(wait_then_fail, signal)
+
+        self.wait_for_state(future, EXECUTING)
+
+        future.cancel()
+        signal.set()
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+
+    def test_progress_messages_after_cancellation(self):
+        signal = self.Event()
+        future = self.executor.submit_progress(progress_then_signal, signal)
+        listener = ProgressFutureListener(future=future)
+
+        # Let the background task run to completion; it will have already sent
+        # progress messages.
+        self.assertTrue(signal.wait(timeout=TIMEOUT))
+
+        future.cancel()
+
+        self.wait_until_done(future)
+
+        self.assertNoResult(future)
+        self.assertNoException(future)
+        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
+        self.assertEqual(listener.progress, [])
+
+    def test_progress_cleanup_on_cancellation(self):
+        acquired = self.Event()
+        ready = self.Event()
+        checkpoint = self.Event()
+
+        try:
+            future = self.executor.submit_progress(
+                resource_acquirer, acquired, ready, checkpoint
+            )
+
+            self.wait_for_state(future, EXECUTING)
+            self.assertTrue(checkpoint.wait(timeout=TIMEOUT))
+            self.assertTrue(acquired.is_set())
+            future.cancel()
+        finally:
+            ready.set()
+
+        self.wait_until_done(future)
+        self.assertFalse(acquired.is_set())
+
+    # Helper functions
+
+    def halt_executor(self):
+        """
+        Wait for the executor to stop.
+        """
+        executor = self.executor
+        executor.stop()
+        self.run_until(executor, "stopped", lambda executor: executor.stopped)
+        del self.executor
+
+    def wait_until_done(self, future):
+        self.run_until(future, "done", lambda future: future.done)
+
+    def wait_for_state(self, future, state):
+        self.run_until(future, "state", lambda future: future.state == state)
+
+    # Assertions
+
+    def assertResult(self, future, expected_result):
+        self.assertEqual(future.result, expected_result)
+
+    def assertNoResult(self, future):
+        with self.assertRaises(AttributeError):
+            future.result
+
+    def assertNoException(self, future):
+        with self.assertRaises(AttributeError):
+            future.exception
+
+    def assertException(self, future, exc_type):
+        self.assertEqual(future.exception[0], str(exc_type))

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -3,24 +3,11 @@
 
 import concurrent.futures
 import contextlib
-import operator
 import threading
 import unittest
 
-from traits.api import HasStrictTraits, Instance, List, on_trait_change
-
-from traits_futures.api import (
-    CallFuture,
-    FutureState,
-    TraitsExecutor,
-    CANCELLED,
-    CANCELLING,
-    EXECUTING,
-    FAILED,
-    COMPLETED,
-    WAITING,
-)
-from traits_futures.tests.common_future_tests import CommonFutureTests
+from traits_futures.api import TraitsExecutor
+from traits_futures.tests.background_call_tests import BackgroundCallTests
 from traits_futures.toolkit_support import toolkit
 
 GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
@@ -30,45 +17,9 @@ GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 TIMEOUT = 10.0
 
 
-def ping_pong(ping_event, pong_event):
-    """
-    Send a ping, then wait for an answering pong.
-    """
-    ping_event.set()
-    pong_event.wait(timeout=TIMEOUT)
-
-
-def ping_pong_fail(ping_event, pong_event):
-    """
-    Send a ping, wait for an answering pong, then fail.
-    """
-    ping_event.set()
-    pong_event.wait(timeout=TIMEOUT)
-    1 / 0
-
-
-class CallFutureListener(HasStrictTraits):
-    #: Future that we're listening to.
-    future = Instance(CallFuture)
-
-    #: List of states of that future.
-    states = List(FutureState)
-
-    @on_trait_change("future:state")
-    def record_state_change(self, obj, name, old_state, new_state):
-        if not self.states:
-            # On the first state change, record the initial state as well as
-            # the new one.
-            self.states.append(old_state)
-        self.states.append(new_state)
-
-
-class TestCallFuture(CommonFutureTests, unittest.TestCase):
-    def setUp(self):
-        self.future_class = CallFuture
-
-
-class TestBackgroundCall(GuiTestAssistant, unittest.TestCase):
+class TestBackgroundCall(
+    GuiTestAssistant, BackgroundCallTests, unittest.TestCase
+):
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.executor = TraitsExecutor()
@@ -77,240 +28,24 @@ class TestBackgroundCall(GuiTestAssistant, unittest.TestCase):
         self.halt_executor()
         GuiTestAssistant.tearDown(self)
 
-    def test_successful_call(self):
-        future = self.executor.submit_call(pow, 2, 3)
-        listener = CallFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertResult(future, 8)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, COMPLETED],
-        )
-
-    def test_failed_call(self):
-        future = self.executor.submit_call(operator.floordiv, 1, 0)
-        listener = CallFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertException(future, ZeroDivisionError)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, FAILED],
-        )
-
-    def test_cancellation_vs_started_race_condition(self):
-        # Simulate situation where a STARTED message arrives post-cancellation.
-        event = threading.Event()
-
-        future = self.executor.submit_call(event.set)
-        listener = CallFutureListener(future=future)
-
-        # Ensure the background task is past the cancel_event.is_set() check.
-        self.assertTrue(event.wait(timeout=TIMEOUT))
-
-        # And _now_ cancel before we process any messages.
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancellation_before_execution(self):
-        # Case where cancellation occurs before the future even starts
-        # executing.
-        with self.blocked_thread_pool():
-            future = self.executor.submit_call(pow, 2, 3)
-            listener = CallFutureListener(future=future)
-            self.assertTrue(future.cancellable)
-            future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancellation_before_success(self):
-        signal = threading.Event()
-        test_ready = threading.Event()
-
-        future = self.executor.submit_call(ping_pong, signal, test_ready)
-        listener = CallFutureListener(future=future)
-
-        # Wait for executing state; the test_ready event ensures we
-        # get no further.
-        self.assertTrue(signal.wait(timeout=TIMEOUT))
-        self.wait_for_state(future, EXECUTING)
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        test_ready.set()
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancellation_before_failure(self):
-        signal = threading.Event()
-        test_ready = threading.Event()
-
-        future = self.executor.submit_call(ping_pong_fail, signal, test_ready)
-        listener = CallFutureListener(future=future)
-
-        # Wait for executing state; the test_ready event ensures we
-        # get no further.
-        self.assertTrue(signal.wait(timeout=TIMEOUT))
-        self.wait_for_state(future, EXECUTING)
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        test_ready.set()
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    def test_cannot_cancel_after_success(self):
-        future = self.executor.submit_call(pow, 2, 3)
-        listener = CallFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-        self.assertResult(future, 8)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, COMPLETED],
-        )
-
-    def test_cannot_cancel_after_failure(self):
-        future = self.executor.submit_call(operator.floordiv, 1, 0)
-        listener = CallFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-        self.assertNoResult(future)
-        self.assertException(future, ZeroDivisionError)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, FAILED],
-        )
-
-    def test_cannot_cancel_after_cancel(self):
-        future = self.executor.submit_call(pow, 2, 3)
-        listener = CallFutureListener(future=future)
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
-        )
-
-    def test_double_cancel_variant(self):
-        signal = threading.Event()
-        test_ready = threading.Event()
-
-        future = self.executor.submit_call(ping_pong, signal, test_ready)
-        listener = CallFutureListener(future=future)
-
-        # Wait for executing state; the test_ready event ensures we
-        # get no further.
-        self.assertTrue(signal.wait(timeout=TIMEOUT))
-        self.wait_for_state(future, EXECUTING)
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        test_ready.set()
-
-        self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    # Helpers
+    #: Factory for a shared event that can be passed to a worker.
+    Event = threading.Event
 
     @contextlib.contextmanager
-    def blocked_thread_pool(self):
+    def block_worker_pool(self):
         """
-        Context manager to temporarily block the threads in the thread pool.
+        Context manager to temporarily block the workers in the worker pool.
         """
-        thread_pool = self.executor._thread_pool
-        max_workers = thread_pool._max_workers
+        worker_pool = self.executor._thread_pool
+        max_workers = worker_pool._max_workers
 
-        event = threading.Event()
+        event = self.Event()
 
         futures = []
         for _ in range(max_workers):
-            futures.append(thread_pool.submit(event.wait))
+            futures.append(worker_pool.submit(event.wait))
         try:
             yield
         finally:
             event.set()
-            concurrent.futures.wait(futures)
-
-    def halt_executor(self):
-        """
-        Wait for the executor to stop.
-        """
-        executor = self.executor
-        executor.stop()
-        self.run_until(executor, "stopped", lambda executor: executor.stopped)
-        del self.executor
-
-    def wait_until_done(self, future):
-        self.run_until(future, "done", lambda future: future.done)
-
-    def wait_for_state(self, future, state):
-        self.run_until(future, "state", lambda future: future.state == state)
-
-    # Assertions
-
-    def assertResult(self, future, expected_result):
-        self.assertEqual(future.result, expected_result)
-
-    def assertNoResult(self, future):
-        with self.assertRaises(AttributeError):
-            future.result
-
-    def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], str(exc_type))
-
-    def assertNoException(self, future):
-        with self.assertRaises(AttributeError):
-            future.exception
+            concurrent.futures.wait(futures, timeout=TIMEOUT)

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -8,22 +8,11 @@ import concurrent.futures
 import contextlib
 import threading
 import unittest
-import weakref
 
-from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
-
-from traits_futures.api import (
-    IterationFuture,
-    FutureState,
-    TraitsExecutor,
-    CANCELLED,
-    CANCELLING,
-    EXECUTING,
-    FAILED,
-    COMPLETED,
-    WAITING,
+from traits_futures.api import TraitsExecutor
+from traits_futures.tests.background_iteration_tests import (
+    BackgroundIterationTests,
 )
-from traits_futures.tests.common_future_tests import CommonFutureTests
 from traits_futures.toolkit_support import toolkit
 
 GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
@@ -33,112 +22,9 @@ GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 TIMEOUT = 10.0
 
 
-def reciprocals(start, stop):
-    """
-    Generate reciprocals of integers in a range.
-
-    Possibly failing iterable used in testing.
-    """
-    for i in range(start, stop):
-        yield 1 / i
-
-
-def squares(start, stop):
-    """
-    Generate squares of integers in a range.
-
-    Simple iterable used in testing.
-    """
-    for i in range(start, stop):
-        yield i * i
-
-
-def yield_then_wait(barrier):
-    """
-    Yield a result, then wait for an external event.
-    """
-    yield 1
-    barrier.wait(timeout=TIMEOUT)
-
-
-def set_then_yield(event):
-    """
-    Set an event before generating the first result.
-    """
-    event.set()
-    yield 1
-
-
-def wait_midway(barrier):
-    """
-    Wait for an external event in the middle of an iteration.
-    """
-    yield 1729
-    barrier.wait(timeout=TIMEOUT)
-    yield 2718
-
-
-def wait_then_fail(barrier):
-    """
-    Wait for an external event, then fail.
-    """
-    barrier.wait(timeout=TIMEOUT)
-    yield 1 / 0
-
-
-def ping_pong(test_ready, midpoint):
-    """
-    Send ping and wait for answering pong mid-iteration.
-    """
-    # Using sets because we need something weakref'able.
-    yield {1, 2, 3}
-    midpoint.set()
-    test_ready.wait(timeout=TIMEOUT)
-    yield {4, 5, 6}
-
-
-def resource_acquiring_iteration(acquired, released, barrier):
-    """
-    Iteration that simulates acquiring a resource.
-    """
-    acquired.set()
-    try:
-        yield 1
-        barrier.wait(timeout=TIMEOUT)
-        yield 2
-    finally:
-        released.set()
-
-
-class IterationFutureListener(HasStrictTraits):
-    #: The object we're listening to.
-    future = Instance(IterationFuture)
-
-    #: List of states of that future.
-    states = List(FutureState)
-
-    #: List of results from the future.
-    results = List(Any())
-
-    @on_trait_change("future:state")
-    def record_state_change(self, obj, name, old_state, new_state):
-        if not self.states:
-            # On the first state change, record the initial state as well as
-            # the new one.
-            self.states.append(old_state)
-        self.states.append(new_state)
-
-    @on_trait_change("future:result_event")
-    def record_iteration_result(self, result):
-        self.results.append(result)
-
-
-class TestIterationFuture(CommonFutureTests, unittest.TestCase):
-    def setUp(self):
-        self.future_class = IterationFuture
-
-
-class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
+class TestBackgroundIteration(
+    GuiTestAssistant, BackgroundIterationTests, unittest.TestCase
+):
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.executor = TraitsExecutor()
@@ -147,308 +33,24 @@ class TestBackgroundIteration(GuiTestAssistant, unittest.TestCase):
         self.halt_executor()
         GuiTestAssistant.tearDown(self)
 
-    def test_successful_iteration(self):
-        # A simple case.
-        future = self.executor.submit_iteration(reciprocals, start=1, stop=4)
-        listener = IterationFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [1.0, 0.5, 1 / 3.0])
-        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
-
-    def test_general_iterable(self):
-        # Any call that returns an iterable should be accepted
-        future = self.executor.submit_iteration(range, 0, 10, 2)
-        listener = IterationFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [0, 2, 4, 6, 8])
-        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
-
-    def test_bad_iteration_setup(self):
-        # Deliberately passing a callable that returns
-        # something non-iterable.
-        future = self.executor.submit_iteration(pow, 2, 5)
-        listener = IterationFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertException(future, TypeError)
-        self.assertEqual(listener.results, [])
-        self.assertEqual(listener.states, [WAITING, EXECUTING, FAILED])
-
-    def test_failing_iteration(self):
-        # Iteration that eventually fails.
-        future = self.executor.submit_iteration(reciprocals, start=-2, stop=2)
-        listener = IterationFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertException(future, ZeroDivisionError)
-        self.assertEqual(listener.results, [-0.5, -1.0])
-        self.assertEqual(listener.states, [WAITING, EXECUTING, FAILED])
-
-    def test_cancel_before_execution(self):
-        # Simulate race condition where we cancel after the background
-        # iteration has checked the cancel event, but before we process
-        # the STARTED message.
-        event = threading.Event()
-
-        future = self.executor.submit_iteration(set_then_yield, event)
-        listener = IterationFutureListener(future=future)
-
-        self.assertTrue(event.wait(timeout=TIMEOUT))
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [])
-        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
-
-    def test_cancel_during_iteration(self):
-        # Exercise code path where the cancel event is set during the
-        # iteration.
-
-        blocker = threading.Event()
-
-        future = self.executor.submit_iteration(wait_midway, blocker)
-        listener = IterationFutureListener(future=future)
-
-        self.run_until(
-            listener,
-            "results_items",
-            lambda listener: len(listener.results) > 0,
-        )
-
-        # task is prevented from completing until we set the blocker event,
-        # so we can cancel before that happens.
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        blocker.set()
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [1729])
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancel_before_exhausted(self):
-        blocker = threading.Event()
-        future = self.executor.submit_iteration(yield_then_wait, blocker)
-        listener = IterationFutureListener(future=future)
-
-        # Make sure we've got the single result.
-        self.run_until(
-            listener,
-            "results_items",
-            lambda listener: len(listener.results) > 0,
-        )
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        blocker.set()
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [1])
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancel_before_start(self):
-        with self.blocked_thread_pool():
-            future = self.executor.submit_iteration(squares, 0, 10)
-            listener = IterationFutureListener(future=future)
-            self.assertTrue(future.cancellable)
-            future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [])
-        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
-
-    def test_cancel_after_start(self):
-        blocker = threading.Event()
-
-        future = self.executor.submit_iteration(wait_midway, blocker)
-        listener = IterationFutureListener(future=future)
-
-        self.run_until(
-            listener,
-            "results_items",
-            lambda listener: len(listener.results) > 0,
-        )
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        blocker.set()
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [1729])
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancel_before_failure(self):
-        blocker = threading.Event()
-
-        future = self.executor.submit_iteration(wait_then_fail, blocker)
-        listener = IterationFutureListener(future=future)
-
-        self.wait_for_state(future, EXECUTING)
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        blocker.set()
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [])
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancel_bad_job(self):
-        future = self.executor.submit_iteration(pow, 10, 3)
-        listener = IterationFutureListener(future=future)
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertNoException(future)
-        self.assertEqual(listener.results, [])
-        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
-
-    def test_double_cancel(self):
-        future = self.executor.submit_iteration(squares, 0, 10)
-
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        self.assertFalse(future.cancellable)
-
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-    def test_completed_cancel(self):
-        future = self.executor.submit_iteration(squares, 0, 10)
-
-        self.wait_until_done(future)
-
-        self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-    def test_generator_closed_on_cancellation(self):
-        resource_acquired = threading.Event()
-        blocker = threading.Event()
-        resource_released = threading.Event()
-
-        future = self.executor.submit_iteration(
-            resource_acquiring_iteration,
-            resource_acquired,
-            resource_released,
-            blocker,
-        )
-        listener = IterationFutureListener(future=future)
-
-        self.run_until(
-            listener,
-            "results_items",
-            lambda listener: len(listener.results) > 0,
-        )
-
-        self.assertTrue(resource_acquired.is_set())
-        self.assertFalse(resource_released.is_set())
-
-        future.cancel()
-        blocker.set()
-
-        self.wait_until_done(future)
-        self.assertTrue(resource_released.is_set())
-
-    def test_prompt_result_deletion(self):
-        # Check that we're not hanging onto result references needlessly in the
-        # background task.
-        test_ready = threading.Event()
-        midpoint = threading.Event()
-
-        future = self.executor.submit_iteration(
-            ping_pong, test_ready, midpoint
-        )
-        listener = IterationFutureListener(future=future)
-
-        self.run_until(
-            listener,
-            "results_items",
-            lambda listener: len(listener.results) > 0,
-        )
-
-        # Check that there are no other references to this result besides
-        # the one in this test.
-        result = listener.results.pop()
-        ref = weakref.ref(result)
-        del result
-
-        try:
-            # midpoint won't be set until we next invoke "next(iterable)",
-            # by which time the IterationBackgroundTask's reference should
-            # have been deleted.
-            self.assertTrue(midpoint.wait(timeout=TIMEOUT))
-            self.assertIsNone(ref())
-        finally:
-            # Let the background task complete, even if the test fails.
-            test_ready.set()
-
-    # Helpers
+    #: Factory for a shared event that can be passed to a worker.
+    Event = threading.Event
 
     @contextlib.contextmanager
-    def blocked_thread_pool(self):
+    def block_worker_pool(self):
         """
-        Context manager to temporarily block the threads in the thread pool.
+        Context manager to temporarily block the workers in the worker pool.
         """
-        thread_pool = self.executor._thread_pool
-        max_workers = thread_pool._max_workers
+        worker_pool = self.executor._thread_pool
+        max_workers = worker_pool._max_workers
 
-        event = threading.Event()
+        event = self.Event()
 
         futures = []
         for _ in range(max_workers):
-            futures.append(thread_pool.submit(event.wait))
+            futures.append(worker_pool.submit(event.wait))
         try:
             yield
         finally:
             event.set()
-            concurrent.futures.wait(futures)
-
-    def halt_executor(self):
-        """
-        Wait for the executor to stop.
-        """
-        executor = self.executor
-        executor.stop()
-        self.run_until(executor, "stopped", lambda executor: executor.stopped)
-        del self.executor
-
-    def wait_until_done(self, future):
-        self.run_until(future, "done", lambda future: future.done)
-
-    def wait_for_state(self, future, state):
-        self.run_until(future, "state", lambda future: future.state == state)
-
-    # Assertions
-
-    def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], str(exc_type))
-
-    def assertNoException(self, future):
-        with self.assertRaises(AttributeError):
-            future.exception
+            concurrent.futures.wait(futures, timeout=TIMEOUT)

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -1,25 +1,18 @@
 # (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 
+"""
+Tests for the background progress functionality.
+"""
 import concurrent.futures
 import contextlib
 import threading
 import unittest
 
-from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
-
-from traits_futures.api import (
-    FutureState,
-    ProgressFuture,
-    TraitsExecutor,
-    CANCELLED,
-    CANCELLING,
-    COMPLETED,
-    EXECUTING,
-    FAILED,
-    WAITING,
+from traits_futures.api import TraitsExecutor
+from traits_futures.tests.background_progress_tests import (
+    BackgroundProgressTests,
 )
-from traits_futures.tests.common_future_tests import CommonFutureTests
 from traits_futures.toolkit_support import toolkit
 
 GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
@@ -29,117 +22,9 @@ GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 TIMEOUT = 10.0
 
 
-# Target functions used for testing ###########################################
-
-
-def progress_reporting_sum(numbers, progress):
-    """
-    Sum a list of numbers, reporting progress at each step.
-    """
-    count = len(numbers)
-
-    total = 0
-    for i, number in enumerate(numbers):
-        progress((i, count))
-        total += number
-    progress((count, count))
-    return total
-
-
-def bad_progress_reporting_function(progress):
-    """
-    Target function that raises an exception.
-    """
-    progress((5, 10))
-    1 / 0
-
-
-def wait_then_fail(signal, progress):
-    """
-    Target function that waits until given permission to proceed, then fails.
-    """
-    signal.wait(timeout=TIMEOUT)
-    1 / 0
-
-
-def progress_then_signal(signal, progress):
-    """
-    Target function that emits progress, then signals.
-    """
-    progress(1)
-    progress(2)
-    signal.set()
-
-
-def syncing_progress(test_ready, raised, progress):
-    """
-    Target function that allows synchronization with the main thread between
-    the first and second progress notifications.
-    """
-    progress("first")
-    # Synchronise with the test.
-    test_ready.wait(timeout=TIMEOUT)
-    # After the test cancels, the second progress send operation should raise,
-    # so that we never get to the following code.
-    try:
-        progress("second")
-    except BaseException:
-        raised.set()
-        raise
-
-
-def event_set_with_progress(event, progress):
-    """
-    Target function that simply sets an event.
-    """
-    event.set()
-
-
-def resource_acquirer(acquired, ready, checkpoint, progress):
-    """
-    Target function that acquires a resource.
-    """
-    acquired.set()
-    try:
-        checkpoint.set()
-        ready.wait(timeout=TIMEOUT)
-    finally:
-        acquired.clear()
-
-
-class ProgressFutureListener(HasStrictTraits):
-    """
-    Listener for a ProgressFuture. Records state changes and progress messages.
-    """
-
-    #: Future that we're listening to.
-    future = Instance(ProgressFuture)
-
-    #: List of states of that future.
-    states = List(FutureState)
-
-    #: List of progress messages received.
-    progress = List(Any())
-
-    @on_trait_change("future:state")
-    def record_state_change(self, obj, name, old_state, new_state):
-        if not self.states:
-            # On the first state change, record the initial state as well as
-            # the new one.
-            self.states.append(old_state)
-        self.states.append(new_state)
-
-    @on_trait_change("future:progress")
-    def record_progress(self, progress_info):
-        self.progress.append(progress_info)
-
-
-class TestProgressFuture(CommonFutureTests, unittest.TestCase):
-    def setUp(self):
-        self.future_class = ProgressFuture
-
-
-class TestBackgroundProgress(GuiTestAssistant, unittest.TestCase):
+class TestBackgroundProgress(
+    GuiTestAssistant, BackgroundProgressTests, unittest.TestCase
+):
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.executor = TraitsExecutor()
@@ -148,218 +33,24 @@ class TestBackgroundProgress(GuiTestAssistant, unittest.TestCase):
         self.halt_executor()
         GuiTestAssistant.tearDown(self)
 
-    def test_progress(self):
-        # Straightforward case.
-        future = self.executor.submit_progress(
-            progress_reporting_sum, [1, 2, 3]
-        )
-        listener = ProgressFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertResult(future, 6)
-        self.assertNoException(future)
-        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
-
-        expected_progress = [(0, 3), (1, 3), (2, 3), (3, 3)]
-        self.assertEqual(listener.progress, expected_progress)
-
-    def test_progress_with_progress_keyword_argument(self):
-        with self.assertRaises(TypeError):
-            self.executor.submit_progress(
-                progress_reporting_sum, [1, 2, 3], progress=None
-            )
-
-    def test_failed_progress(self):
-        # Callable that raises.
-        future = self.executor.submit_progress(bad_progress_reporting_function)
-        listener = ProgressFutureListener(future=future)
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertException(future, ZeroDivisionError)
-        self.assertEqual(listener.states, [WAITING, EXECUTING, FAILED])
-
-        expected_progress = [(5, 10)]
-        self.assertEqual(listener.progress, expected_progress)
-
-    def test_cancellation_before_execution(self):
-        event = threading.Event()
-
-        future = self.executor.submit_progress(event_set_with_progress, event)
-        listener = ProgressFutureListener(future=future)
-
-        self.assertTrue(event.wait(timeout=TIMEOUT))
-        self.assertTrue(future.cancellable)
-        future.cancel()
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
-        )
-
-    def test_cancellation_before_background_task_starts(self):
-        # Test case where the background job is cancelled before
-        # it even starts executing.
-        event = threading.Event()
-
-        with self.blocked_thread_pool():
-            future = self.executor.submit_progress(
-                event_set_with_progress, event
-            )
-            listener = ProgressFutureListener(future=future)
-            future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertFalse(event.is_set())
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
-
-    def test_progress_allows_cancellation(self):
-        test_ready = threading.Event()
-        raised = threading.Event()
-
-        future = self.executor.submit_progress(
-            syncing_progress, test_ready, raised
-        )
-        listener = ProgressFutureListener(future=future)
-
-        # Wait until we get the first progress message.
-        self.run_until(
-            listener,
-            "progress_items",
-            lambda listener: len(listener.progress) > 0,
-        )
-
-        # Cancel, then allow the background task to continue.
-        future.cancel()
-        test_ready.set()
-
-        self.wait_until_done(future)
-
-        self.assertTrue(raised.is_set())
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED]
-        )
-        self.assertEqual(listener.progress, ["first"])
-
-    def test_double_cancellation(self):
-        future = self.executor.submit_progress(progress_reporting_sum, [1, 2])
-        self.assertTrue(future.cancellable)
-        future.cancel()
-
-        self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
-
-    def test_cancel_raising_task(self):
-        signal = threading.Event()
-        future = self.executor.submit_progress(wait_then_fail, signal)
-
-        self.wait_for_state(future, EXECUTING)
-
-        future.cancel()
-        signal.set()
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-
-    def test_progress_messages_after_cancellation(self):
-        signal = threading.Event()
-        future = self.executor.submit_progress(progress_then_signal, signal)
-        listener = ProgressFutureListener(future=future)
-
-        # Let the background task run to completion; it will have already sent
-        # progress messages.
-        self.assertTrue(signal.wait(timeout=TIMEOUT))
-
-        future.cancel()
-
-        self.wait_until_done(future)
-
-        self.assertNoResult(future)
-        self.assertNoException(future)
-        self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
-        self.assertEqual(listener.progress, [])
-
-    def test_progress_cleanup_on_cancellation(self):
-        acquired = threading.Event()
-        ready = threading.Event()
-        checkpoint = threading.Event()
-
-        try:
-            future = self.executor.submit_progress(
-                resource_acquirer, acquired, ready, checkpoint
-            )
-
-            self.wait_for_state(future, EXECUTING)
-            self.assertTrue(checkpoint.wait(timeout=TIMEOUT))
-            self.assertTrue(acquired.is_set())
-            future.cancel()
-        finally:
-            ready.set()
-
-        self.wait_until_done(future)
-        self.assertFalse(acquired.is_set())
-
-    # Helper functions
+    #: Factory for a shared event that can be passed to a worker.
+    Event = threading.Event
 
     @contextlib.contextmanager
-    def blocked_thread_pool(self):
+    def block_worker_pool(self):
         """
-        Context manager to temporarily block the threads in the thread pool.
+        Context manager to temporarily block the workers in the worker pool.
         """
-        thread_pool = self.executor._thread_pool
-        max_workers = thread_pool._max_workers
+        worker_pool = self.executor._thread_pool
+        max_workers = worker_pool._max_workers
 
-        event = threading.Event()
+        event = self.Event()
 
         futures = []
         for _ in range(max_workers):
-            futures.append(thread_pool.submit(event.wait))
+            futures.append(worker_pool.submit(event.wait))
         try:
             yield
         finally:
             event.set()
-            concurrent.futures.wait(futures)
-
-    def halt_executor(self):
-        """
-        Wait for the executor to stop.
-        """
-        executor = self.executor
-        executor.stop()
-        self.run_until(executor, "stopped", lambda executor: executor.stopped)
-        del self.executor
-
-    def wait_until_done(self, future):
-        self.run_until(future, "done", lambda future: future.done)
-
-    def wait_for_state(self, future, state):
-        self.run_until(future, "state", lambda future: future.state == state)
-
-    # Assertions
-
-    def assertResult(self, future, expected_result):
-        self.assertEqual(future.result, expected_result)
-
-    def assertNoResult(self, future):
-        with self.assertRaises(AttributeError):
-            future.result
-
-    def assertNoException(self, future):
-        with self.assertRaises(AttributeError):
-            future.exception
-
-    def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], str(exc_type))
+            concurrent.futures.wait(futures, timeout=TIMEOUT)

--- a/traits_futures/tests/test_call_future.py
+++ b/traits_futures/tests/test_call_future.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+import unittest
+
+from traits_futures.api import CallFuture
+from traits_futures.tests.common_future_tests import CommonFutureTests
+
+
+class TestCallFuture(CommonFutureTests, unittest.TestCase):
+    def setUp(self):
+        self.future_class = CallFuture

--- a/traits_futures/tests/test_iteration_future.py
+++ b/traits_futures/tests/test_iteration_future.py
@@ -1,0 +1,15 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+"""
+Tests for the IterationFuture class.
+"""
+import unittest
+
+from traits_futures.api import IterationFuture
+from traits_futures.tests.common_future_tests import CommonFutureTests
+
+
+class TestIterationFuture(CommonFutureTests, unittest.TestCase):
+    def setUp(self):
+        self.future_class = IterationFuture

--- a/traits_futures/tests/test_progress_future.py
+++ b/traits_futures/tests/test_progress_future.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+import unittest
+
+from traits_futures.api import ProgressFuture
+from traits_futures.tests.common_future_tests import CommonFutureTests
+
+
+class TestProgressFuture(CommonFutureTests, unittest.TestCase):
+    def setUp(self):
+        self.future_class = ProgressFuture


### PR DESCRIPTION
This PR refactors the test structure for the various background calls to separate the tests themselves (which know nothing about threading or the parallelism mechanism that will be used) from the part that does need to know about the parallelism.

This is in preparation for adding multiprocessing support.

In more detail, `test_background_call.py` has been split into:

- `background_call_tests.py`, which defines a mixin class containing the actual tests, along with some helpers and assertion methods, but has no knowledge of parallelism (threading vs. multiprocessing vs. coroutines vs ...)
- `test_call_future.py`, a short test module containing tests for `CallFuture` (those tests don't depend on any parallelism, so we don't want to repeat them for multiprocessing)
- `test_background_call.py`, which uses the tests from `background_call_tests.py` as a mixin, and provides the parallelism details

Analogous changes were made for `test_background_iteration.py` and `test_background_progress.py`.

A few identifiers have been changed to make them more parallelism-agnostic (e.g., changing "thread pool" to "worker pool").
