### PR TITLE
Bring in changelog from release branch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,35 @@
 Changelog for Traits Futures
 ============================
 
+
+Release 0.1.1
+-------------
+
+Release date: 2019-02-05
+
+This is a bugfix release, in preparation for the first public release to PyPI. There
+are no functional or API changes to the core library since 0.1.0 in this release.
+
+Fixes
+~~~~~
+
+- Add missing ``long_description`` field in setup script. (#116, backported in #118)
+
+Changes
+~~~~~~~
+
+- Add copyright headers to all Python and reST files. (#114, backported in #118)
+
+Build
+~~~~~
+
+- Remove unnecessary bundle generation machinery. (#99, backported in #118)
+
+
 Release 0.1.0
 -------------
+
+Release date: 2018-08-08
 
 Initial release. Provides support for submitting background calls, iterations,
 and progress-reporting tasks for Traits UI applications based on Qt.


### PR DESCRIPTION
This was a leftover post-release action for the 0.1.1 release.
