### PR TITLE
Rename TraitsExecutor thread_pool argument to worker_pool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,31 @@ Changelog for Traits Futures
 ============================
 
 
+Release 0.2.0
+-------------
+
+Release date: XXXX-XX-XX
+
+Features
+~~~~~~~~
+
+- ``TraitsExecutor`` now accepts a ``max_workers`` argument, which will
+  be used to specify the number of workers if the executor creates its own
+  worker pool.
+
+Changes
+~~~~~~~
+
+- The ``thread_pool`` argument to ``TraitsExecutor`` has been renamed to
+  ``worker_pool``. The old name ``thread_pool`` continues to work, but its
+  use is deprecated.
+
+- The default number of workers in the worker pool has changed. Previously
+  it was hard-coded as ``4``. Now it defaults to whatever Python's
+  ``concurrent.futures`` executors give (but it can be controlled by
+  passing the ``max_workers`` argument).
+
+
 Release 0.1.1
 -------------
 

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -254,8 +254,8 @@ application components. In that case, you can instantiate the |TraitsExecutor|
 with an existing thread pool, which should be an instance of
 ``concurrent.futures.ThreadPoolExecutor``::
 
-    thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=24)
-    executor = TraitsExecutor(thread_pool=thread_pool)
+    worker_pool = concurrent.futures.ThreadPoolExecutor(max_workers=24)
+    executor = TraitsExecutor(worker_pool=worker_pool)
 
 It's then your responsibility to shut down the thread pool once it's no longer
 needed.

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -118,7 +118,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
     def test_max_workers_mutually_exclusive_with_thread_pool(self):
         with self.temporary_thread_pool() as thread_pool:
             with self.assertRaises(TypeError):
-                TraitsExecutor(thread_pool=thread_pool, max_workers=11)
+                TraitsExecutor(worker_pool=thread_pool, max_workers=11)
 
     def test_stop_method(self):
         executor = TraitsExecutor()
@@ -222,9 +222,20 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         with self.assertRaises(RuntimeError):
             thread_pool.submit(int)
 
+    def test_thread_pool_argument_deprecated(self):
+        with self.temporary_thread_pool() as thread_pool:
+            with self.assertWarns(DeprecationWarning) as warning_info:
+                executor = TraitsExecutor(thread_pool=thread_pool)
+            executor.stop()
+            self.wait_until_stopped(executor)
+
+        # Check we're using the right stack level in the warning.
+        *_, this_module = __name__.rsplit(".")
+        self.assertIn(this_module, warning_info.filename)
+
     def test_shared_thread_pool(self):
         with self.temporary_thread_pool() as thread_pool:
-            executor = TraitsExecutor(thread_pool=thread_pool)
+            executor = TraitsExecutor(worker_pool=thread_pool)
             executor.stop()
             self.wait_until_stopped(executor)
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -64,16 +64,16 @@ class TraitsExecutor(HasStrictTraits):
            Use ``worker_pool`` instead.
 
     worker_pool : concurrent.futures.ThreadPoolExecutor, optional
-        If supplied, provides the underlying thread pool executor to use. In
+        If supplied, provides the underlying worker pool executor to use. In
         this case, the creator of the TraitsExecutor is responsible for
-        shutting down the thread pool once it's no longer needed. If not
-        supplied, a new private thread pool will be created, and this object's
-        ``stop`` method will shut down that thread pool.
+        shutting down the worker pool once it's no longer needed. If not
+        supplied, a new private worker pool will be created, and this object's
+        ``stop`` method will shut down that worker pool.
     max_workers : int or None, optional
-        Maximum number of workers for the private thread pool. This parameter
-        is mutually exclusive with thread_pool. The default is ``None``, which
-        delegates the choice of number of workers to Python's
-        ``ThreadPoolExecutor``.
+        Maximum number of workers for the private worker pool. This parameter
+        is mutually exclusive with ``worker_pool``. The default is ``None``,
+        which delegates the choice of number of workers to Python's
+        ``concurrent.futures`` module.
     """
 
     #: Current state of this executor.


### PR DESCRIPTION
This PR:

- Renames the `thread_pool` argument to `TraitsExecutor` to `worker_pool`, to better fit with the anticipated case of supporting multiprocessing as well as multithreading. (It's also a better match with the `max_workers` name.)
- Makes the new `worker_pool` argument keyword-only.
- Keeps the `thread_pool` argument as as deprecated alias for `worker_pool`
- Makes the existing `max_workers` argument keyword-only. (Note that the `max_workers` feature has not yet been released, so this should not cause backwards compatibility issues.)

@jvkersch Unlike most of the recent PRs, this one actually changes functionality. Would you be willing to do a sanity check review?