### PR TITLE
Remove future_imports check

### DIFF
--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -27,16 +27,10 @@ class TestApi(unittest.TestCase):
     def test___all__(self):
         import traits_futures.api
 
-        future_imports = [
-            "absolute_import",
-            "print_function",
-            "unicode_literals",
-        ]
         items_in_all = set(traits_futures.api.__all__)
         items_in_api = {
             name
             for name in dir(traits_futures.api)
             if not name.startswith("_")
-            if name not in future_imports
         }
         self.assertEqual(items_in_all, items_in_api)


### PR DESCRIPTION
Remove a check against names from future imports. This check is unnecessary now that we've removed Python 2 support.