### PR TITLE
Fix a test that doesn't property stop the executor it creates

### DIFF
--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -187,6 +187,9 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         self.wait_until_done(future)
         self.assertEqual(future.state, CANCELLED)
 
+        self.wait_until_stopped(executor)
+        self.assertEqual(executor.state, STOPPED)
+
     def test_running(self):
         executor = TraitsExecutor()
         self.assertTrue(executor.running)


### PR DESCRIPTION
One of the unit tests stopped the executor but failed to wait for that stop to complete. This PR fixes that.