### PR TITLE
Rename internal uses of 'thread_pool' to 'worker_pool'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,31 @@ Changelog for Traits Futures
 ============================
 
 
+Release 0.2.0
+-------------
+
+Release date: XXXX-XX-XX
+
+Features
+~~~~~~~~
+
+- ``TraitsExecutor`` now accepts a ``max_workers`` argument, which will
+  be used to specify the number of workers if the executor creates its own
+  worker pool.
+
+Changes
+~~~~~~~
+
+- The ``thread_pool`` argument to ``TraitsExecutor`` has been renamed to
+  ``worker_pool``. The old name ``thread_pool`` continues to work, but its
+  use is deprecated.
+
+- The default number of workers in the worker pool has changed. Previously
+  it was hard-coded as ``4``. Now it defaults to whatever Python's
+  ``concurrent.futures`` executors give (but it can be controlled by
+  passing the ``max_workers`` argument).
+
+
 Release 0.1.1
 -------------
 

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -14,9 +14,9 @@ Submitting background tasks
 
 The |TraitsExecutor| is the main point of entry to |traits_futures|. Its job is
 to accept one or more task submissions. For each task submitted, it sends the
-computation to run in the background on a thread pool worker, and returns a
-corresponding "future" object that allows monitoring of the state of the
-background computation and retrieval of its results.
+computation to run in the background on a worker from a worker pool, and
+returns a corresponding "future" object that allows monitoring of the state of
+the background computation and retrieval of its results.
 
 We'll examine the future objects in the next section. This section deals with
 the executor's main top-level methods.
@@ -92,12 +92,11 @@ underlying computation. That state has one of six possible different values:
 
 |WAITING|
    The background task has been scheduled to run, but has not yet started
-   executing (for example, because the thread pool is still busy dealing
+   executing (for example, because the worker pool is still busy dealing
    with previously-submitted tasks.
 
 |EXECUTING|
-   The background task is currently executing on one of the thread pool
-   workers.
+   The background task is currently executing on one of the workers.
 
 |COMPLETED|
    The background task has completed without error. For a progress task or a
@@ -237,27 +236,27 @@ executing or waiting futures, puts the executor into |STOPPING| state and then
 returns.
 
 Once all futures reach |CANCELLED| state, an executor in |STOPPING| state moves
-into |STOPPED| state. If the executor owns its thread pool, that thread pool is
+into |STOPPED| state. If the executor owns its worker pool, that worker pool is
 shut down immediately before moving into |STOPPED| state.
 
 It's advisable to stop the executor explicitly and wait for it to reach
 |STOPPING| state before exiting an application using it.
 
 
-Using a shared thread pool
+Using a shared worker pool
 --------------------------
 
-By default, the |TraitsExecutor| creates its own thread pool, and shuts that
-thread pool down when its |stop| method is called. In a large multithreaded
-application, you might want to use a shared thread pool for multiple different
+By default, the |TraitsExecutor| creates its own worker pool, and shuts that
+worker pool down when its |stop| method is called. In a large multithreaded
+application, you might want to use a shared worker pool for multiple different
 application components. In that case, you can instantiate the |TraitsExecutor|
-with an existing thread pool, which should be an instance of
+with an existing worker pool, which should be an instance of
 ``concurrent.futures.ThreadPoolExecutor``::
 
     worker_pool = concurrent.futures.ThreadPoolExecutor(max_workers=24)
     executor = TraitsExecutor(worker_pool=worker_pool)
 
-It's then your responsibility to shut down the thread pool once it's no longer
+It's then your responsibility to shut down the worker pool once it's no longer
 needed.
 
 ..

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -254,8 +254,8 @@ application components. In that case, you can instantiate the |TraitsExecutor|
 with an existing thread pool, which should be an instance of
 ``concurrent.futures.ThreadPoolExecutor``::
 
-    thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=24)
-    executor = TraitsExecutor(thread_pool=thread_pool)
+    worker_pool = concurrent.futures.ThreadPoolExecutor(max_workers=24)
+    executor = TraitsExecutor(worker_pool=worker_pool)
 
 It's then your responsibility to shut down the thread pool once it's no longer
 needed.

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -99,7 +99,7 @@ class ProgressBackgroundTask:
     """
     Background portion of a progress background task.
 
-    This provides the callable that will be submitted to the thread pool, and
+    This provides the callable that will be submitted to the worker pool, and
     sends messages to communicate with the ProgressFuture.
     """
 

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -36,7 +36,7 @@ class TestBackgroundCall(
         """
         Context manager to temporarily block the workers in the worker pool.
         """
-        worker_pool = self.executor._thread_pool
+        worker_pool = self.executor._worker_pool
         max_workers = worker_pool._max_workers
 
         event = self.Event()

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -41,7 +41,7 @@ class TestBackgroundIteration(
         """
         Context manager to temporarily block the workers in the worker pool.
         """
-        worker_pool = self.executor._thread_pool
+        worker_pool = self.executor._worker_pool
         max_workers = worker_pool._max_workers
 
         event = self.Event()

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -41,7 +41,7 @@ class TestBackgroundProgress(
         """
         Context manager to temporarily block the workers in the worker pool.
         """
-        worker_pool = self.executor._thread_pool
+        worker_pool = self.executor._worker_pool
         max_workers = worker_pool._max_workers
 
         event = self.Event()

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -118,7 +118,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
     def test_max_workers_mutually_exclusive_with_thread_pool(self):
         with self.temporary_thread_pool() as thread_pool:
             with self.assertRaises(TypeError):
-                TraitsExecutor(thread_pool=thread_pool, max_workers=11)
+                TraitsExecutor(worker_pool=thread_pool, max_workers=11)
 
     def test_stop_method(self):
         executor = TraitsExecutor()
@@ -225,9 +225,20 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         with self.assertRaises(RuntimeError):
             thread_pool.submit(int)
 
+    def test_thread_pool_argument_deprecated(self):
+        with self.temporary_thread_pool() as thread_pool:
+            with self.assertWarns(DeprecationWarning) as warning_info:
+                executor = TraitsExecutor(thread_pool=thread_pool)
+            executor.stop()
+            self.wait_until_stopped(executor)
+
+        # Check we're using the right stack level in the warning.
+        *_, this_module = __name__.rsplit(".")
+        self.assertIn(this_module, warning_info.filename)
+
     def test_shared_thread_pool(self):
         with self.temporary_thread_pool() as thread_pool:
-            executor = TraitsExecutor(thread_pool=thread_pool)
+            executor = TraitsExecutor(worker_pool=thread_pool)
             executor.stop()
             self.wait_until_stopped(executor)
 

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -221,7 +221,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         executor.stop()
         self.wait_until_stopped(executor)
 
-        # Check that the internally-created thread pool has been shut down.
+        # Check that the internally-created worker pool has been shut down.
         with self.assertRaises(RuntimeError):
             worker_pool.submit(int)
 
@@ -242,7 +242,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             executor.stop()
             self.wait_until_stopped(executor)
 
-            # Check that the the shared thread pool is still usable.
+            # Check that the the shared worker pool is still usable.
             cf_future = worker_pool.submit(int)
             self.assertEqual(cf_future.result(), 0)
 
@@ -393,7 +393,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
     @contextlib.contextmanager
     def temporary_worker_pool(self):
         """
-        Create a thread pool that's shut down at the end of the with block.
+        Create a worker pool that's shut down at the end of the with block.
         """
         worker_pool = concurrent.futures.ThreadPoolExecutor(max_workers=4)
         try:

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -7,6 +7,7 @@ Main-thread executor for submission of background tasks.
 
 import concurrent.futures
 import threading
+import warnings
 
 from traits.api import (
     Any,
@@ -57,16 +58,22 @@ class TraitsExecutor(HasStrictTraits):
     Parameters
     ----------
     thread_pool : concurrent.futures.ThreadPoolExecutor, optional
-        If supplied, provides the underlying thread pool executor to use. In
+        Deprecated alias for worker_pool.
+
+        .. deprecated:: 0.2
+           Use ``worker_pool`` instead.
+
+    worker_pool : concurrent.futures.ThreadPoolExecutor, optional
+        If supplied, provides the underlying worker pool executor to use. In
         this case, the creator of the TraitsExecutor is responsible for
-        shutting down the thread pool once it's no longer needed. If not
-        supplied, a new private thread pool will be created, and this object's
-        ``stop`` method will shut down that thread pool.
+        shutting down the worker pool once it's no longer needed. If not
+        supplied, a new private worker pool will be created, and this object's
+        ``stop`` method will shut down that worker pool.
     max_workers : int or None, optional
-        Maximum number of workers for the private thread pool. This parameter
-        is mutually exclusive with thread_pool. The default is ``None``, which
-        delegates the choice of number of workers to Python's
-        ``ThreadPoolExecutor``.
+        Maximum number of workers for the private worker pool. This parameter
+        is mutually exclusive with ``worker_pool``. The default is ``None``,
+        which delegates the choice of number of workers to Python's
+        ``concurrent.futures`` module.
     """
 
     #: Current state of this executor.
@@ -80,10 +87,23 @@ class TraitsExecutor(HasStrictTraits):
     #: to dispose of related resources (like the thread pool).
     stopped = Property(Bool())
 
-    def __init__(self, thread_pool=None, max_workers=None, **traits):
+    def __init__(
+        self, thread_pool=None, *, worker_pool=None, max_workers=None, **traits
+    ):
         super(TraitsExecutor, self).__init__(**traits)
 
-        if thread_pool is None:
+        if thread_pool is not None:
+            warnings.warn(
+                (
+                    "The thread_pool argument to TraitsExecutor is "
+                    "deprecated. Use worker_pool instead."
+                ),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            worker_pool = thread_pool
+
+        if worker_pool is None:
             self._thread_pool = concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers
             )
@@ -91,10 +111,10 @@ class TraitsExecutor(HasStrictTraits):
         else:
             if max_workers is not None:
                 raise TypeError(
-                    "at most one of 'thread_pool' and 'max_workers' "
+                    "at most one of 'worker_pool' and 'max_workers' "
                     "should be supplied"
                 )
-            self._thread_pool = thread_pool
+            self._thread_pool = worker_pool
             self._own_thread_pool = False
 
     def submit_call(self, callable, *args, **kwargs):

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -104,18 +104,18 @@ class TraitsExecutor(HasStrictTraits):
             worker_pool = thread_pool
 
         if worker_pool is None:
-            self._thread_pool = concurrent.futures.ThreadPoolExecutor(
+            self._worker_pool = concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers
             )
-            self._own_thread_pool = True
+            self._own_worker_pool = True
         else:
             if max_workers is not None:
                 raise TypeError(
                     "at most one of 'worker_pool' and 'max_workers' "
                     "should be supplied"
                 )
-            self._thread_pool = worker_pool
-            self._own_thread_pool = False
+            self._worker_pool = worker_pool
+            self._own_worker_pool = False
 
     def submit_call(self, callable, *args, **kwargs):
         """
@@ -211,7 +211,7 @@ class TraitsExecutor(HasStrictTraits):
             self._message_router.close_pipe(sender, receiver)
             raise
 
-        self._thread_pool.submit(_background_job_wrapper, runner, sender)
+        self._worker_pool.submit(_background_job_wrapper, runner, sender)
         self._futures[receiver] = future
         return future
 
@@ -237,11 +237,11 @@ class TraitsExecutor(HasStrictTraits):
     # Private traits ##########################################################
 
     #: concurrent.futures.Executor instance providing the thread pool.
-    _thread_pool = Instance(concurrent.futures.Executor)
+    _worker_pool = Instance(concurrent.futures.Executor)
 
     #: True if we own this thread pool (and are therefore responsible
     #: for shutting it down), else False.
-    _own_thread_pool = Bool()
+    _own_worker_pool = Bool()
 
     #: Router providing message connections between background tasks
     #: and foreground futures.
@@ -293,7 +293,7 @@ class TraitsExecutor(HasStrictTraits):
         self._message_router.disconnect()
         self._message_router = None
 
-        if self._own_thread_pool:
-            self._thread_pool.shutdown()
-        self._thread_pool = None
+        if self._own_worker_pool:
+            self._worker_pool.shutdown()
+        self._worker_pool = None
         self.state = STOPPED

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -84,7 +84,7 @@ class TraitsExecutor(HasStrictTraits):
     running = Property(Bool())
 
     #: Derived state: true if this executor is stopped and it's safe
-    #: to dispose of related resources (like the thread pool).
+    #: to dispose of related resources (like the worker pool).
     stopped = Property(Bool())
 
     def __init__(
@@ -236,10 +236,10 @@ class TraitsExecutor(HasStrictTraits):
 
     # Private traits ##########################################################
 
-    #: concurrent.futures.Executor instance providing the thread pool.
+    #: concurrent.futures.Executor instance providing the worker pool.
     _worker_pool = Instance(concurrent.futures.Executor)
 
-    #: True if we own this thread pool (and are therefore responsible
+    #: True if we own this worker pool (and are therefore responsible
     #: for shutting it down), else False.
     _own_worker_pool = Bool()
 
@@ -287,7 +287,7 @@ class TraitsExecutor(HasStrictTraits):
 
     def _stop(self):
         """
-        Go to STOPPED state, and shut down the thread pool if we own it.
+        Go to STOPPED state, and shut down the worker pool if we own it.
         """
         assert self.state == STOPPING
         self._message_router.disconnect()


### PR DESCRIPTION
Followup to #144: rename internal uses of 'thread_pool' to 'worker_pool'; no user-facing changes.