### PR TITLE
Separate parallelization from concurrency in TraitsExecutor

### DIFF
--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -16,6 +16,8 @@ from traits_futures.future_states import (
     COMPLETED,
     WAITING,
 )
+from traits_futures.i_parallel_context import IParallelContext
+from traits_futures.multithreading_context import MultithreadingContext
 from traits_futures.traits_executor import (
     TraitsExecutor,
     ExecutorState,
@@ -44,4 +46,7 @@ __all__ = [
     "RUNNING",
     "STOPPING",
     "STOPPED",
+    # Contexts
+    "IParallelContext",
+    "MultithreadingContext",
 ]

--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -5,10 +5,10 @@
 Interface for the parallelism context needed by the TraitsExecutor
 """
 
-from abc import ABC, abstractmethod
+import abc
 
 
-class IParallelContext(ABC):
+class IParallelContext(abc.ABC):
     """
     Interface for the parallelism context needed by the TraitsExecutor.
 
@@ -18,7 +18,7 @@ class IParallelContext(ABC):
     multiprocessing.
     """
 
-    @abstractmethod
+    @abc.abstractmethod
     def worker_pool(self, *, max_workers=None):
         """
         Provide a worker pool suitable for this context.
@@ -36,7 +36,7 @@ class IParallelContext(ABC):
         executor : concurrent.futures.Executor
         """
 
-    @abstractmethod
+    @abc.abstractmethod
     def event(self):
         """
         Return a shareable event suitable for this context.
@@ -47,7 +47,7 @@ class IParallelContext(ABC):
             An event that can be shared safely with workers.
         """
 
-    @abstractmethod
+    @abc.abstractmethod
     def queue(self):
         """
         Return a shareable queue suitable for this context.
@@ -58,7 +58,7 @@ class IParallelContext(ABC):
             A queue that can be shared safely with workers.
         """
 
-    @abstractmethod
+    @abc.abstractmethod
     def message_router(self):
         """
         Return a message router suitable for use in this context.
@@ -68,14 +68,14 @@ class IParallelContext(ABC):
         message_router : MessageRouter
         """
 
-    @abstractmethod
+    @abc.abstractmethod
     def close(self):
         """
         Do any cleanup necessary before disposal of the context.
         """
 
     @property
-    @abstractmethod
+    @abc.abstractmethod
     def closed(self):
         """
         True if this context is closed, else False.

--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -45,6 +45,9 @@ class IParallelContext(abc.ABC):
         -------
         event : event-like
             An event that can be shared safely with workers.
+            The event should have the same API as ``threading.Event``
+            and ``multiprocessing.Event``, providing at a minimum
+            the ``set`` and ``is_set`` methods from that API.
         """
 
     @abc.abstractmethod
@@ -55,7 +58,8 @@ class IParallelContext(abc.ABC):
         Returns
         -------
         queue : queue-like
-            A queue that can be shared safely with workers.
+            A queue that can be shared safely with workers. This package
+            relies only on the ``put`` and ``get`` methods of the queue.
         """
 
     @abc.abstractmethod

--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -1,0 +1,82 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+"""
+Interface for the parallelism context needed by the TraitsExecutor
+"""
+
+from abc import ABC, abstractmethod
+
+
+class IParallelContext(ABC):
+    """
+    Interface for the parallelism context needed by the TraitsExecutor.
+
+    A class implementing this interface provides a worker pool,
+    message router and other concurrency primitives suitable for a
+    particular form of parallelism, for example multithreading or
+    multiprocessing.
+    """
+
+    @abstractmethod
+    def worker_pool(self, *, max_workers=None):
+        """
+        Provide a worker pool suitable for this context.
+
+        Parameters
+        ----------
+        max_workers : int, optional
+            Maximum number of workers in the worker pool. If not given, it's
+            up to the worker pool to choose a suitable number of workers,
+            perhaps dependent on the number of logical cores present on
+            the target machine.
+
+        Returns
+        -------
+        executor : concurrent.futures.Executor
+        """
+
+    @abstractmethod
+    def event(self):
+        """
+        Return a shareable event suitable for this context.
+
+        Returns
+        -------
+        event : event-like
+            An event that can be shared safely with workers.
+        """
+
+    @abstractmethod
+    def queue(self):
+        """
+        Return a shareable queue suitable for this context.
+
+        Returns
+        -------
+        queue : queue-like
+            A queue that can be shared safely with workers.
+        """
+
+    @abstractmethod
+    def message_router(self):
+        """
+        Return a message router suitable for use in this context.
+
+        Returns
+        -------
+        message_router : MessageRouter
+        """
+
+    @abstractmethod
+    def close(self):
+        """
+        Do any cleanup necessary before disposal of the context.
+        """
+
+    @property
+    @abstractmethod
+    def closed(self):
+        """
+        True if this context is closed, else False.
+        """

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -1,0 +1,84 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+"""
+Context providing multithreading-friendly worker pools, events, and routers.
+"""
+
+import concurrent.futures
+import queue
+import threading
+
+from traits_futures.i_parallel_context import IParallelContext
+from traits_futures.toolkit_support import toolkit
+
+
+class MultithreadingContext(IParallelContext):
+    """
+    Context for multithreading, suitable for use with the TraitsExecutor.
+    """
+
+    def __init__(self):
+        self._closed = False
+
+    def worker_pool(self, *, max_workers=None):
+        """
+        Provide a new worker pool suitable for this context.
+
+        Parameters
+        ----------
+        max_workers : int, optional
+            Maximum number of workers to use. If not given, the choice is
+            delegated to the ThreadPoolExecutor.
+
+        Returns
+        -------
+        executor : concurrent.futures.Executor
+        """
+        return concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+    def event(self):
+        """
+        Return a shareable event suitable for this context.
+
+        Returns
+        -------
+        event : event-like
+            An event that can be shared safely with workers.
+        """
+        return threading.Event()
+
+    def queue(self):
+        """
+        Return a shareable queue suitable for this context.
+
+        Returns
+        -------
+        queue : queue-like
+            A queue that can be shared safely with workers.
+        """
+        return queue.Queue()
+
+    def message_router(self):
+        """
+        Return a message router suitable for use in this context.
+
+        Returns
+        -------
+        message_router : MessageRouter
+        """
+        router_class = toolkit("message_router:MessageRouter")
+        return router_class()
+
+    def close(self):
+        """
+        Do any cleanup necessary before disposal of the context.
+        """
+        self._closed = True
+
+    @property
+    def closed(self):
+        """
+        True if this context is closed, else False.
+        """
+        return self._closed

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -22,6 +22,8 @@ class TestApi(unittest.TestCase):
             RUNNING,
             STOPPING,
             STOPPED,
+            IParallelContext,
+            MultithreadingContext,
         )
 
     def test___all__(self):

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -330,4 +330,5 @@ class TraitsExecutor(HasStrictTraits):
 
         if self._own_context:
             self._context.close()
+        self._context = None
         self.state = STOPPED

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -2,11 +2,10 @@
 # All rights reserved.
 
 """
-Main-thread executor for submission of background tasks.
+Executor to submit background tasks.
 """
 
 import concurrent.futures
-import threading
 import warnings
 
 from traits.api import (
@@ -23,7 +22,7 @@ from traits.api import (
 from traits_futures.background_call import BackgroundCall
 from traits_futures.background_iteration import BackgroundIteration
 from traits_futures.background_progress import BackgroundProgress
-from traits_futures.toolkit_support import toolkit
+from traits_futures.i_parallel_context import IParallelContext
 
 
 # Executor states.
@@ -74,6 +73,12 @@ class TraitsExecutor(HasStrictTraits):
         is mutually exclusive with ``worker_pool``. The default is ``None``,
         which delegates the choice of number of workers to Python's
         ``concurrent.futures`` module.
+    context : IParallelContext, optional
+        Parallelism context, providing appropriate concurrent primitives
+        and worker pools for a given choice of parallelism (for example
+        multithreading or multiprocessing). If not given, assumes
+        multithreading. Note that if both ``context`` and ``worker_pool``
+        are given, they must be compatible.
     """
 
     #: Current state of this executor.
@@ -88,7 +93,13 @@ class TraitsExecutor(HasStrictTraits):
     stopped = Property(Bool())
 
     def __init__(
-        self, thread_pool=None, *, worker_pool=None, max_workers=None, **traits
+        self,
+        thread_pool=None,
+        *,
+        worker_pool=None,
+        max_workers=None,
+        context=None,
+        **traits,
     ):
         super(TraitsExecutor, self).__init__(**traits)
 
@@ -103,10 +114,17 @@ class TraitsExecutor(HasStrictTraits):
             )
             worker_pool = thread_pool
 
+        if context is not None:
+            self._context = context
+
         own_worker_pool = worker_pool is None
         if own_worker_pool:
-            worker_pool = concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers)
+            if max_workers is None:
+                worker_pool = self._context.worker_pool()
+            else:
+                worker_pool = self._context.worker_pool(
+                    max_workers=max_workers
+                )
         elif max_workers is not None:
             raise TypeError(
                 "at most one of 'worker_pool' and 'max_workers' "
@@ -201,10 +219,11 @@ class TraitsExecutor(HasStrictTraits):
         if not self.running:
             raise RuntimeError("Can't submit task unless executor is running.")
 
+        cancel_event = self._context.event()
         sender, receiver = self._message_router.pipe()
         try:
             future, runner = task.future_and_callable(
-                cancel_event=threading.Event(), message_receiver=receiver,
+                cancel_event=cancel_event, message_receiver=receiver,
             )
         except Exception:
             self._message_router.close_pipe(sender, receiver)
@@ -234,6 +253,12 @@ class TraitsExecutor(HasStrictTraits):
             self._stop()
 
     # Private traits ##########################################################
+
+    #: Parallelization context
+    _context = Instance(IParallelContext)
+
+    #: True if we own this context, else False.
+    _own_context = Bool(False)
 
     #: concurrent.futures.Executor instance providing the worker pool.
     _worker_pool = Instance(concurrent.futures.Executor)
@@ -271,10 +296,17 @@ class TraitsExecutor(HasStrictTraits):
 
     def __message_router_default(self):
         # Toolkit-specific message router.
-        MessageRouter = toolkit("message_router:MessageRouter")
-        router = MessageRouter()
+        router = self._context.message_router()
         router.connect()
         return router
+
+    def __context_default(self):
+        # By default, we use multithreading
+        from traits_futures.multithreading_context import MultithreadingContext
+
+        context = MultithreadingContext()
+        self._own_context = True
+        return context
 
     @on_trait_change("_message_router:receiver_done")
     def _remove_future(self, receiver):
@@ -295,4 +327,7 @@ class TraitsExecutor(HasStrictTraits):
         if self._own_worker_pool:
             self._worker_pool.shutdown()
         self._worker_pool = None
+
+        if self._own_context:
+            self._context.close()
         self.state = STOPPED


### PR DESCRIPTION
This PR is a refactoring to pull out aspects of the TraitsExecutor that depend on the particular form of parallelism (e.g., threading versus multiprocessing) into a new `Context` object.

* Add new `IParallelContext` interface
* Add new `MultithreadingContext` implementing `IParallelContext`
* Add new `context` argument to the `TraitsExecutor`
* Use a `MultithreadingContext` by default if `context` is not provided.

This is part of the work towards supporting multiprocessing: we'll eventually define a `MultiprocessingContext` that can be used in place of `MultithreadingContext`.