### PR TITLE
React rather than polling in the Qt GuiTestAssistant

### DIFF
--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -5,16 +5,66 @@
 Test support, providing the ability to run the event loop from tests.
 """
 
-from pyface.ui.qt4.util.gui_test_assistant import (
-    GuiTestAssistant as PyFaceGuiTestAssistant,
-)
+from pyface.qt.QtGui import QApplication
+from pyface.qt.QtCore import QTimer
 
 
-class GuiTestAssistant(PyFaceGuiTestAssistant):
-    def run_until(self, object, trait, condition, timeout=10.0):
+#: Default timeout, in seconds
+TIMEOUT = 10.0
+
+
+class GuiTestAssistant:
+    def setUp(self):
+        qt_app = QApplication.instance()
+        if qt_app is None:
+            qt_app = QApplication([])
+        self.qt_app = qt_app
+
+    def tearDown(self):
+        del self.qt_app
+
+    def run_until(self, object, trait, condition, timeout=TIMEOUT):
         """
-        Run the event loop until the given condition holds true.
+        Run the event loop until the given condition holds true, or
+        until timeout.
+
+        The condition is re-evaluated, with the object as argument, every time
+        the trait changes.
+
+        Raises if timeout is reached, regardless of whether the condition
+        is true at that point.
         """
-        self.event_loop_helper.event_loop_until_condition(
-            lambda: condition(object), timeout=timeout
-        )
+        qt_app = self.qt_app
+
+        timeout_in_ms = round(1000.0 * timeout)
+        timeout_timer = QTimer()
+        timeout_timer.setSingleShot(True)
+        timeout_timer.setInterval(timeout_in_ms)
+
+        def stop_on_timeout():
+            qt_app.exit(1)
+
+        def stop_if_condition():
+            if condition(object):
+                qt_app.exit(0)
+
+        object.on_trait_change(stop_if_condition, trait)
+        try:
+            # The condition may have become True before we
+            # started listening to changes. So start with a check.
+            QTimer.singleShot(0, stop_if_condition)
+            timeout_timer.timeout.connect(stop_on_timeout)
+            timeout_timer.start()
+            try:
+                timed_out = qt_app.exec_()
+            finally:
+                timeout_timer.stop()
+                timeout_timer.timeout.disconnect(stop_on_timeout)
+        finally:
+            object.on_trait_change(stop_if_condition, trait, remove=True)
+
+        # If we stopped due to timeout, raise.
+        if timed_out:
+            raise RuntimeError(
+                "run_until timed out after {} seconds".format(timeout)
+            )

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -25,15 +25,31 @@ class GuiTestAssistant:
 
     def run_until(self, object, trait, condition, timeout=TIMEOUT):
         """
-        Run the event loop until the given condition holds true, or
-        until timeout.
+        Run event loop until the given condition holds true, or until timeout.
 
         The condition is re-evaluated, with the object as argument, every time
         the trait changes.
 
-        Raises if timeout is reached, regardless of whether the condition
-        is true at that point.
+        Parameters
+        ----------
+        object : HasTraits
+            Object whose trait we monitor.
+        trait : str
+            Name of the trait to monitor for changes.
+        condition : callable
+            Single-argument callable, returning a boolean. This will be
+            called with *object* as the only input.
+        timeout : float, optional
+            Number of seconds to allow before timing out with an exception.
+            The (somewhat arbitrary) default is 10 seconds.
+
+        Raises
+        ------
+        RuntimeError
+            If timeout is reached, regardless of whether the condition is
+            true or not at that point.
         """
+
         qt_app = self.qt_app
 
         timeout_in_ms = round(1000.0 * timeout)

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -64,6 +64,11 @@ class GuiTestAssistant:
             object.on_trait_change(stop_if_condition, trait, remove=True)
 
         if timed_out:
+            condition_at_timeout = condition(object)
+
             raise RuntimeError(
-                "run_until timed out after {} seconds".format(timeout)
+                "run_until timed out after {} seconds. "
+                "At timeout, condition was {}.".format(
+                    timeout, condition_at_timeout
+                )
             )

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -5,8 +5,8 @@
 Test support, providing the ability to run the event loop from tests.
 """
 
-from pyface.qt.QtGui import QApplication
 from pyface.qt.QtCore import QTimer
+from pyface.qt.QtGui import QApplication
 
 
 #: Default timeout, in seconds
@@ -63,7 +63,6 @@ class GuiTestAssistant:
         finally:
             object.on_trait_change(stop_if_condition, trait, remove=True)
 
-        # If we stopped due to timeout, raise.
         if timed_out:
             raise RuntimeError(
                 "run_until timed out after {} seconds".format(timeout)

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -64,11 +64,9 @@ class GuiTestAssistant:
             object.on_trait_change(stop_if_condition, trait, remove=True)
 
         if timed_out:
-            condition_at_timeout = condition(object)
-
             raise RuntimeError(
                 "run_until timed out after {} seconds. "
                 "At timeout, condition was {}.".format(
-                    timeout, condition_at_timeout
+                    timeout, condition(object)
                 )
             )


### PR DESCRIPTION
This PR rewrites the `GuiTestAssistant.run_until` method to react to the trait change rather than polling the condition. As a result, the tests run significantly faster than before (under a second, versus over ten seconds on master, on my machine).