### PR TITLE
Refactor for more pluggable background jobs

### DIFF
--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -30,6 +30,7 @@ from traits_futures.future_states import (
     DONE_STATES,
     FutureState,
 )
+from traits_futures.i_job_specification import IJobSpecification
 
 # Message types for messages from CallBackgroundTask to CallFuture.
 # The background task will emit exactly one of the following
@@ -64,10 +65,6 @@ class CallBackgroundTask:
         self.kwargs = kwargs
 
     def __call__(self, send, cancelled):
-        if cancelled():
-            send(INTERRUPTED)
-            return
-
         send(STARTED)
         try:
             result = self.callable(*self.args, **self.kwargs)
@@ -147,14 +144,14 @@ class CallFuture(HasStrictTraits):
         # to a warning, or just do nothing on an invalid cancellation.
         if not self.cancellable:
             raise RuntimeError("Can only cancel a queued or executing task.")
-        self._cancel_event.set()
+        self._cancel()
         self.state = CANCELLING
 
     # Private traits ##########################################################
 
-    #: Private event used to request cancellation of this task. Users
-    #: should call the cancel() method instead of using this event.
-    _cancel_event = Any()
+    #: Callable called with no arguments to request cancellation of the
+    #: background task.
+    _cancel = Callable()
 
     #: Result from the background task.
     _result = Any()
@@ -218,6 +215,7 @@ class CallFuture(HasStrictTraits):
             self.trait_property_changed("done", old_done, new_done)
 
 
+@IJobSpecification.register
 class BackgroundCall(HasStrictTraits):
     """
     Object representing the background call to be executed.
@@ -251,14 +249,15 @@ class BackgroundCall(HasStrictTraits):
             kwargs=dict(self.kwargs),
         )
 
-    def future(self, cancel_event, message_receiver):
+    def future(self, cancel, message_receiver):
         """
         Return a future for a background job.
 
         Parameters
         ----------
-        cancel_event : threading.Event
-            Event used to request cancellation of the background job.
+        cancel : callable
+            Callable called with no arguments to request cancellation
+            of the background task.
         message_receiver : MessageReceiver
             Object that remains in the main thread and receives messages sent
             by the message sender. This is a HasTraits subclass with
@@ -271,6 +270,4 @@ class BackgroundCall(HasStrictTraits):
             Foreground object representing the state of the running
             calculation.
         """
-        return CallFuture(
-            _cancel_event=cancel_event, _message_receiver=message_receiver,
-        )
+        return CallFuture(_cancel=cancel, _message_receiver=message_receiver,)

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -232,9 +232,28 @@ class BackgroundCall(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str(), Any())
 
-    def future_and_callable(self, cancel_event, message_receiver):
+    def background_job(self):
         """
-        Return a future and a linked background callable.
+        Return a background callable for this job specification.
+
+        Returns
+        -------
+        background : callable
+            Callable accepting arguments ``sender`` and ``cancelled``, and
+            returning nothing. The callable will use ``sender`` to send
+            messages and ``cancelled` to check whether the job has been
+            cancelled.
+        """
+        return CallBackgroundTask(
+            callable=self.callable,
+            args=self.args,
+            # Convert TraitsDict to a regular dict
+            kwargs=dict(self.kwargs),
+        )
+
+    def future(self, cancel_event, message_receiver):
+        """
+        Return a future for a background job.
 
         Parameters
         ----------
@@ -251,16 +270,7 @@ class BackgroundCall(HasStrictTraits):
         future : CallFuture
             Foreground object representing the state of the running
             calculation.
-        runner : CallBackgroundTask
-            Callable to be executed in the background.
         """
-        future = CallFuture(
+        return CallFuture(
             _cancel_event=cancel_event, _message_receiver=message_receiver,
         )
-        runner = CallBackgroundTask(
-            callable=self.callable,
-            args=self.args,
-            # Convert TraitsDict to a regular dict
-            kwargs=dict(self.kwargs),
-        )
-        return future, runner

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -58,14 +58,13 @@ class CallBackgroundTask:
     task that will be submitted to the concurrent.futures executor
     """
 
-    def __init__(self, callable, args, kwargs, cancel_event):
+    def __init__(self, callable, args, kwargs):
         self.callable = callable
         self.args = args
         self.kwargs = kwargs
-        self.cancel_event = cancel_event
 
-    def __call__(self, send):
-        if self.cancel_event.is_set():
+    def __call__(self, send, cancelled):
+        if cancelled():
             send(INTERRUPTED)
             return
 
@@ -263,6 +262,5 @@ class BackgroundCall(HasStrictTraits):
             args=self.args,
             # Convert TraitsDict to a regular dict
             kwargs=dict(self.kwargs),
-            cancel_event=cancel_event,
         )
         return future, runner

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -70,14 +70,13 @@ class IterationBackgroundTask:
     Iteration to be executed in the background.
     """
 
-    def __init__(self, callable, args, kwargs, cancel_event):
+    def __init__(self, callable, args, kwargs):
         self.callable = callable
         self.args = args
         self.kwargs = kwargs
-        self.cancel_event = cancel_event
 
-    def __call__(self, send):
-        if self.cancel_event.is_set():
+    def __call__(self, send, cancelled):
+        if cancelled():
             send(INTERRUPTED)
             return
 
@@ -89,7 +88,7 @@ class IterationBackgroundTask:
             return
 
         while True:
-            if self.cancel_event.is_set():
+            if cancelled():
                 message, message_args = INTERRUPTED, None
                 break
 
@@ -300,6 +299,5 @@ class BackgroundIteration(HasStrictTraits):
             args=self.args,
             # Convert TraitsDict to a regular dict
             kwargs=dict(self.kwargs),
-            cancel_event=cancel_event,
         )
         return future, runner

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -8,19 +8,15 @@ import types
 
 from traits.api import (
     Any,
-    Bool,
     Callable,
     Dict,
     Event,
     HasStrictTraits,
-    HasTraits,
-    Instance,
-    on_trait_change,
-    Property,
     Str,
     Tuple,
 )
 
+from traits_futures.base_future import BaseFuture
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
     CANCELLED,
@@ -29,9 +25,6 @@ from traits_futures.future_states import (
     FAILED,
     COMPLETED,
     WAITING,
-    CANCELLABLE_STATES,
-    DONE_STATES,
-    FutureState,
 )
 from traits_futures.i_job_specification import IJobSpecification
 
@@ -50,9 +43,6 @@ from traits_futures.i_job_specification import IJobSpecification
 #: Iteration was cancelled either before it started or during the
 #: iteration. No arguments.
 INTERRUPTED = "interrupted"
-
-#: Iteration started executing. No arguments.
-STARTED = "started"
 
 #: Iteration failed with an exception, or there was
 #: an exception on creation of the iterator. Argument gives
@@ -78,7 +68,6 @@ class IterationBackgroundTask:
         self.kwargs = kwargs
 
     def __call__(self, send, cancelled):
-        send(STARTED)
         try:
             iterable = iter(self.callable(*self.args, **self.kwargs))
         except BaseException as e:
@@ -131,23 +120,11 @@ class IterationBackgroundTask:
 # no results events will be fired after cancelling.
 
 
-class IterationFuture(HasStrictTraits):
+class IterationFuture(BaseFuture):
     """
     Foreground representation of an iteration executing in the
     background.
     """
-
-    #: The state of the background iteration, to the best of the knowledge of
-    #: this future.
-    state = FutureState
-
-    #: True if this task can be cancelled, else False.
-    cancellable = Property(Bool())
-
-    #: True if we've received the final message from the background iteration,
-    #: else False. `True` indicates either that the background iteration
-    #: succeeded, or that it raised, or that it was cancelled.
-    done = Property(Bool())
 
     #: Event fired whenever a result arrives from the background
     #: iteration.
@@ -168,48 +145,12 @@ class IterationFuture(HasStrictTraits):
             raise AttributeError("No exception has been raised for this call.")
         return self._exception
 
-    def cancel(self):
-        """
-        Method called from the main thread to request cancellation
-        of the background job.
-        """
-        # In the interests of catching coding errors early in client
-        # code, we're strict about what states we allow cancellation
-        # from. Some applications may want to weaken the error below
-        # to a warning, or just do nothing on an invalid cancellation.
-        if not self.cancellable:
-            raise RuntimeError("Can only cancel a queued or executing task.")
-        self._cancel()
-        self.state = CANCELLING
-
     # Private traits ##########################################################
-
-    #: Callable called with no arguments to request cancellation of the
-    #: background task.
-    _cancel = Callable()
 
     #: Exception information from the background task.
     _exception = Tuple(Str(), Str(), Str())
 
-    #: Object that receives messages from the background task.
-    _message_receiver = Instance(HasTraits)
-
     # Private methods #########################################################
-
-    @on_trait_change("_message_receiver:message")
-    def _process_message(self, message):
-        message_type, message_arg = message
-        method_name = "_process_{}".format(message_type)
-        getattr(self, method_name)(message_arg)
-
-    def _process_interrupted(self, none):
-        assert self.state in (CANCELLING,)
-        self.state = CANCELLED
-
-    def _process_started(self, none):
-        assert self.state in (WAITING, CANCELLING)
-        if self.state == WAITING:
-            self.state = EXECUTING
 
     def _process_raised(self, exception_info):
         assert self.state in (WAITING, EXECUTING, CANCELLING)
@@ -232,25 +173,6 @@ class IterationFuture(HasStrictTraits):
         # Any results arriving after a cancellation request are ignored.
         if self.state == EXECUTING:
             self.result_event = result
-
-    def _get_cancellable(self):
-        return self.state in CANCELLABLE_STATES
-
-    def _get_done(self):
-        return self.state in DONE_STATES
-
-    def _state_changed(self, old_state, new_state):
-        old_cancellable = old_state in CANCELLABLE_STATES
-        new_cancellable = new_state in CANCELLABLE_STATES
-        if old_cancellable != new_cancellable:
-            self.trait_property_changed(
-                "cancellable", old_cancellable, new_cancellable
-            )
-
-        old_done = old_state in DONE_STATES
-        new_done = new_state in DONE_STATES
-        if old_done != new_done:
-            self.trait_property_changed("done", old_done, new_done)
 
 
 @IJobSpecification.register

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -8,6 +8,7 @@ import types
 
 from traits.api import (
     Any,
+    Bool,
     Callable,
     Dict,
     Event,
@@ -141,11 +142,14 @@ class IterationFuture(BaseFuture):
         Trait, to discourage users from attaching Traits listeners to
         it. Listen to the state or its derived traits instead.
         """
-        if self.state != FAILED:
+        if not self._have_exception:
             raise AttributeError("No exception has been raised for this call.")
         return self._exception
 
     # Private traits ##########################################################
+
+    #: Boolean indicating whether we have exception information available.
+    _have_exception = Bool(False)
 
     #: Exception information from the background task.
     _exception = Tuple(Str(), Str(), Str())
@@ -155,6 +159,7 @@ class IterationFuture(BaseFuture):
     def _process_raised(self, exception_info):
         assert self.state in (WAITING, EXECUTING, CANCELLING)
         if self.state in (EXECUTING, WAITING):
+            self._have_exception = True
             self._exception = exception_info
             self.state = FAILED
         else:

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -1,0 +1,107 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+"""
+Base class providing common pieces of the Future machinery.
+"""
+
+from traits.api import (
+    Bool,
+    Callable,
+    HasStrictTraits,
+    HasTraits,
+    Instance,
+    on_trait_change,
+    Property,
+)
+
+from traits_futures.future_states import (
+    CANCELLABLE_STATES,
+    CANCELLED,
+    CANCELLING,
+    DONE_STATES,
+    EXECUTING,
+    WAITING,
+    FutureState,
+)
+
+
+class BaseFuture(HasStrictTraits):
+    """
+    Convenience base class for the various flavours of Future.
+
+    This isn't yet well-defined enough, documented enough or tested enough
+    to be considered a formal abstract base class.
+    """
+
+    #: The state of the background task, to the best of the knowledge of
+    #: this future.
+    state = FutureState
+
+    #: True if this task can be cancelled, else False.
+    cancellable = Property(Bool())
+
+    #: True if we've received the final message from the background task,
+    #: else False. `True` indicates either that the background task
+    #: succeeded, or that it raised, or that it was cancelled.
+    done = Property(Bool())
+
+    def cancel(self):
+        """
+        Method that can be called from the main thread to
+        indicate that the task should be cancelled (provided
+        it hasn't already started running).
+        """
+        # In the interests of catching coding errors early in client
+        # code, we're strict about what states we allow cancellation
+        # from. Some applications may want to weaken the error below
+        # to a warning, or just do nothing on an invalid cancellation.
+        if not self.cancellable:
+            raise RuntimeError("Can only cancel a queued or executing task.")
+        self._cancel()
+        self.state = CANCELLING
+
+    # Private traits ##########################################################
+
+    #: Callable called with no arguments to request cancellation of the
+    #: background task.
+    _cancel = Callable()
+
+    #: Object that receives messages from the background task.
+    _message_receiver = Instance(HasTraits)
+
+    # Private methods #########################################################
+
+    @on_trait_change("_message_receiver:message")
+    def _process_message(self, message):
+        message_type, message_arg = message
+        method_name = "_process_{}".format(message_type)
+        getattr(self, method_name)(message_arg)
+
+    def _process_interrupted(self, none):
+        assert self.state in (CANCELLING,)
+        self.state = CANCELLED
+
+    def _process_started(self, none):
+        assert self.state in (WAITING, CANCELLING)
+        if self.state == WAITING:
+            self.state = EXECUTING
+
+    def _get_cancellable(self):
+        return self.state in CANCELLABLE_STATES
+
+    def _get_done(self):
+        return self.state in DONE_STATES
+
+    def _state_changed(self, old_state, new_state):
+        old_cancellable = old_state in CANCELLABLE_STATES
+        new_cancellable = new_state in CANCELLABLE_STATES
+        if old_cancellable != new_cancellable:
+            self.trait_property_changed(
+                "cancellable", old_cancellable, new_cancellable
+            )
+
+        old_done = old_state in DONE_STATES
+        new_done = new_state in DONE_STATES
+        if old_done != new_done:
+            self.trait_property_changed("done", old_done, new_done)

--- a/traits_futures/i_job_specification.py
+++ b/traits_futures/i_job_specification.py
@@ -41,8 +41,9 @@ class IJobSpecification(ABC):
         returns no useful result.
 
         The ``cancelled`` argument may be used by the background job to check
-        whether cancellation has been requested. It returns either ``True``
-        to indicate that cancellation has been requested, or ``False``.
+        whether cancellation has been requested. When called with no arguments,
+        it returns either ``True`` to indicate that cancellation has been
+        requested, or ``False``.
 
         Note that there's no obligation for the background job to check the
         cancellation status.

--- a/traits_futures/i_job_specification.py
+++ b/traits_futures/i_job_specification.py
@@ -1,0 +1,64 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+"""
+Interface for a job specification. The job specification is the object
+that the TraitsExecutor knows how to deal with.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class IJobSpecification(ABC):
+    @abstractmethod
+    def background_job(self):
+        """
+        Return the callable that will be invoked as the background job.
+
+        This callable should be pickleable, should have the signature
+
+            job(send, cancelled)
+
+        Any return value from the callable will be ignored.
+
+        The ``send`` argument can be used by the background job to send
+        messages back to the main thread of execution. It's a callable that can
+        be used either in the form ``send(message_type)`` or in the form
+        ``send(message_type, message_args)``. Here ``message_type`` is a simple
+        constant (typically a string), and ``message_args`` is a single Python
+        object containing optional arguments for the message. The arguments to
+        ``send`` should typically be both immutable and pickleable. ``send``
+        returns no useful result.
+
+        The ``cancelled`` argument may be used by the background job to check
+        whether cancellation has been requested. It returns either ``True``
+        to indicate that cancellation has been requested, or ``False``.
+
+        Note that there's no obligation for the background job to check the
+        cancellation status.
+
+        Returns
+        -------
+        job : callable
+        """
+
+    @abstractmethod
+    def future(self, cancel, message_receiver):
+        """
+        Return a Future for the background job.
+
+        Parameters
+        ----------
+        cancel : callable
+            Zero-argument callable that can be called to request cancellation
+            of the background task.
+        receiver : IMessageReceiver
+            HasTraits instance with a ``message`` trait, which can be listened
+            to in order to receive messages from the background job.
+
+        Returns
+        -------
+        future : IFuture
+            Future object that can be used to monitor the status of the
+            background job.
+        """

--- a/traits_futures/i_job_specification.py
+++ b/traits_futures/i_job_specification.py
@@ -10,6 +10,16 @@ from abc import ABC, abstractmethod
 
 
 class IJobSpecification(ABC):
+    """
+    Specify background job and foreground future for a task.
+
+    An object implementing the IJobSpecification interface describes how to
+    create a background job and a corresponding foreground future to execute a
+    particular type of background task. It's consumed by the TraitsExecutor
+    when submitting background tasks, and implemented by BackgroundCall,
+    BackgroundIteration and others.
+    """
+
     @abstractmethod
     def background_job(self):
         """

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -107,7 +107,8 @@ class TraitsExecutor(HasStrictTraits):
         own_worker_pool = worker_pool is None
         if own_worker_pool:
             worker_pool = concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers)
+                max_workers=max_workers
+            )
         elif max_workers is not None:
             raise TypeError(
                 "at most one of 'worker_pool' and 'max_workers' "
@@ -206,7 +207,8 @@ class TraitsExecutor(HasStrictTraits):
 
         sender, receiver = self._message_router.pipe()
         try:
-            future, runner = task.future_and_callable(
+            runner = task.background_job()
+            future = task.future(
                 cancel_event=cancel_event, message_receiver=receiver,
             )
         except Exception:
@@ -214,7 +216,8 @@ class TraitsExecutor(HasStrictTraits):
             raise
 
         self._worker_pool.submit(
-            _background_job_wrapper, runner, sender, cancel_event)
+            _background_job_wrapper, runner, sender, cancel_event
+        )
         self._futures[receiver] = future
         return future
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -28,11 +28,21 @@ from traits.api import (
 # foreground listener shouldn't have to deal with that message - the router
 # should intercept instead.
 
-from traits_futures.background_call import BackgroundCall, INTERRUPTED
+from traits_futures.background_call import BackgroundCall
 from traits_futures.background_iteration import BackgroundIteration
 from traits_futures.background_progress import BackgroundProgress
 from traits_futures.i_job_specification import IJobSpecification
 from traits_futures.toolkit_support import toolkit
+
+
+#: Common messages send by background jobs. These should be being imported
+#: from somewhere else.
+
+#: Call was cancelled before it started. No arguments.
+INTERRUPTED = "interrupted"
+
+#: Call started executing. No arguments.
+STARTED = "started"
 
 
 # Executor states.
@@ -64,6 +74,7 @@ def _background_job_wrapper(background_job, sender, cancel_event):
             send(INTERRUPTED)
             return
 
+        send(STARTED)
         background_job(send, cancelled)
 
 


### PR DESCRIPTION
[Superseded by #169, but this PR may be easier to review]

This is a POC PR aimed at making it easier for users to add new types of background jobs.

- Introduce new `IJobSpecification` interface. This describes the expected form of anything `submit` ed to the `TraitsExecutor`. (Essentially, it should have `background_job` and `future` methods. Bikeshed opportunity: `background_job` or `background_task`?)
- Add `BaseFuture` convenience base class for futures to inherit from.
- Adapt the existing background jobs to use these.
- Adapt the `TraitsExecutor` to expect something implementing `IJobSpecification`.

@jvkersch I'd really appreciate your comments on this, particularly on the `IJobSpecification` interface.

Not ready to merge: it would need additional tests and documentation.