### PR TITLE
Fix prog_name in ci helper

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -299,4 +299,4 @@ def in_coverage_directory():
 
 
 if __name__ == "__main__":
-    cli()
+    cli(prog_name="python -m ci")


### PR DESCRIPTION
Trivial quality of life PR: improve the `ci` help message.

Before:
```
mirzakhani:traits-futures mdickinson$ python -m ci
Usage: __main__.py [OPTIONS] COMMAND [ARGS]...

  Development and continuous integration helpers for Traits Futures.

Options:
  --help  Show this message and exit.

...
```


After:
```
mirzakhani:traits-futures mdickinson$ python -m ci
Usage: python -m ci [OPTIONS] COMMAND [ARGS]...

  Development and continuous integration helpers for Traits Futures.

Options:
  --help  Show this message and exit.

...
```