### PR TITLE
CLN: Add import order checker

### DIFF
--- a/ci/config.py
+++ b/ci/config.py
@@ -101,6 +101,7 @@ VERSION_CORE_DEPS = {}
 # Additional packages needed for running tests under CI.
 ADDITIONAL_CI_DEPS = [
     "flake8",
+    "flake8_import_order",
     "pip",
 ]
 

--- a/ci/data/edm.yml
+++ b/ci/data/edm.yml
@@ -3,3 +3,4 @@ store_url: https://packages.enthought.com
 
 repositories:
 - enthought/free
+- enthought/lgpl

--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -17,13 +17,13 @@ from traitsui.api import (
 from traitsui.tabular_adapter import TabularAdapter
 
 from traits_futures.api import (
-    TraitsExecutor,
     CallFuture,
     CANCELLED,
     CANCELLING,
+    COMPLETED,
     EXECUTING,
     FAILED,
-    COMPLETED,
+    TraitsExecutor,
     WAITING,
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[flake8]
+
+import-order-style = appnexus
+application-package-names = chaco,enable,pyface,traits,traitsui
+application-import-names = ci,traits_futures

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -8,20 +8,20 @@ from traits_futures.background_call import CallFuture
 from traits_futures.background_iteration import IterationFuture
 from traits_futures.background_progress import ProgressFuture
 from traits_futures.future_states import (
-    FutureState,
     CANCELLED,
     CANCELLING,
+    COMPLETED,
     EXECUTING,
     FAILED,
-    COMPLETED,
+    FutureState,
     WAITING,
 )
 from traits_futures.traits_executor import (
-    TraitsExecutor,
     ExecutorState,
     RUNNING,
-    STOPPING,
     STOPPED,
+    STOPPING,
+    TraitsExecutor,
 )
 
 __all__ = [

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -20,15 +20,15 @@ from traits.api import (
 
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
+    CANCELLABLE_STATES,
     CANCELLED,
     CANCELLING,
+    COMPLETED,
+    DONE_STATES,
     EXECUTING,
     FAILED,
-    COMPLETED,
-    WAITING,
-    CANCELLABLE_STATES,
-    DONE_STATES,
     FutureState,
+    WAITING,
 )
 
 # Message types for messages from CallBackgroundTask to CallFuture.

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -23,15 +23,15 @@ from traits.api import (
 
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
+    CANCELLABLE_STATES,
     CANCELLED,
     CANCELLING,
+    COMPLETED,
+    DONE_STATES,
     EXECUTING,
     FAILED,
-    COMPLETED,
-    WAITING,
-    CANCELLABLE_STATES,
-    DONE_STATES,
     FutureState,
+    WAITING,
 )
 
 # Message types for messages from IterationBackgroundTask to IterationFuture.

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -29,15 +29,15 @@ from traits.api import (
 
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import (
+    CANCELLABLE_STATES,
     CANCELLED,
     CANCELLING,
+    COMPLETED,
+    DONE_STATES,
     EXECUTING,
     FAILED,
-    COMPLETED,
-    WAITING,
-    CANCELLABLE_STATES,
-    DONE_STATES,
     FutureState,
+    WAITING,
 )
 
 

--- a/traits_futures/qt/init.py
+++ b/traits_futures/qt/init.py
@@ -4,9 +4,8 @@
 """
 Entry point for finding toolkit-specific classes.
 """
+# We import QtCore to force an ImportError if Qt is not installed.
 from pyface.base_toolkit import Toolkit
-
-# Force an ImportError if Qt is not installed.
 from pyface.qt import QtCore  # noqa: F401
 
 #: The toolkit object used to find toolkit-specific reources.

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -5,12 +5,12 @@ from traits.api import HasStrictTraits, Instance, List, on_trait_change
 
 from traits_futures.api import (
     CallFuture,
-    FutureState,
     CANCELLED,
     CANCELLING,
     COMPLETED,
     EXECUTING,
     FAILED,
+    FutureState,
     WAITING,
 )
 

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -9,13 +9,13 @@ import weakref
 from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
 
 from traits_futures.api import (
-    IterationFuture,
-    FutureState,
     CANCELLED,
     CANCELLING,
+    COMPLETED,
     EXECUTING,
     FAILED,
-    COMPLETED,
+    FutureState,
+    IterationFuture,
     WAITING,
 )
 

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -4,13 +4,13 @@
 from traits.api import Any, HasStrictTraits, Instance, List, on_trait_change
 
 from traits_futures.api import (
-    FutureState,
-    ProgressFuture,
     CANCELLED,
     CANCELLING,
     COMPLETED,
     EXECUTING,
     FAILED,
+    FutureState,
+    ProgressFuture,
     WAITING,
 )
 

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -8,20 +8,20 @@ class TestApi(unittest.TestCase):
     def test_imports(self):
         from traits_futures.api import (  # noqa: F401
             CallFuture,
-            IterationFuture,
-            ProgressFuture,
-            FutureState,
             CANCELLED,
             CANCELLING,
-            EXECUTING,
-            FAILED,
             COMPLETED,
-            WAITING,
-            TraitsExecutor,
+            EXECUTING,
             ExecutorState,
+            FAILED,
+            FutureState,
+            IterationFuture,
+            ProgressFuture,
             RUNNING,
-            STOPPING,
             STOPPED,
+            STOPPING,
+            TraitsExecutor,
+            WAITING,
         )
 
     def test___all__(self):

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -24,11 +24,11 @@ from traits_futures.api import (
     CANCELLED,
     CANCELLING,
     EXECUTING,
-    TraitsExecutor,
     ExecutorState,
     RUNNING,
-    STOPPING,
     STOPPED,
+    STOPPING,
+    TraitsExecutor,
 )
 from traits_futures.toolkit_support import toolkit
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -106,7 +106,8 @@ class TraitsExecutor(HasStrictTraits):
         own_worker_pool = worker_pool is None
         if own_worker_pool:
             worker_pool = concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers)
+                max_workers=max_workers
+            )
         elif max_workers is not None:
             raise TypeError(
                 "at most one of 'worker_pool' and 'max_workers' "


### PR DESCRIPTION
Import orders are starting to be a cause of merge conflicts in refactoring; let's standardize them.