### PR TITLE
Deprecate TraitsExecutor.submit_* methods; replace with functions

### DIFF
--- a/docs/source/examples/quick_start.py
+++ b/docs/source/examples/quick_start.py
@@ -12,11 +12,10 @@ from traits.api import (
     on_trait_change,
     Property,
     Str,
-    submit_call,
 )
 from traitsui.api import Item, UItem, View
 
-from traits_futures.api import CallFuture, TraitsExecutor
+from traits_futures.api import CallFuture, submit_call, TraitsExecutor
 
 
 def slow_square(n):

--- a/docs/source/examples/quick_start.py
+++ b/docs/source/examples/quick_start.py
@@ -12,6 +12,7 @@ from traits.api import (
     on_trait_change,
     Property,
     Str,
+    submit_call,
 )
 from traitsui.api import Item, UItem, View
 
@@ -52,7 +53,7 @@ class QuickStartExample(HasStrictTraits):
         input = self.input
         self.input_for_calculation = self.input
         self.message = "Calculating square of {} ...".format(input)
-        self.future = self.executor.submit_call(slow_square, input)
+        self.future = submit_call(self.executor, slow_square, input)
         # Keep a record so that we can present messages accurately.
         self.input_for_calculation = input
 

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -35,8 +35,8 @@ from ``traits_futures.api``:
   the |CallFuture| and related objects.
 
 - The |submit_iteration| function allows submission of an arbitrary iterable.
-  The user provides a callable which, when called, returns an iterable object. For
-  example::
+  The user provides a callable which, when called, returns an iterable object.
+  For example::
 
     submit_iteration(my_executor, range, 0, 5)
 

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -19,12 +19,13 @@ returns a corresponding "future" object that allows monitoring of the state of
 the background computation and retrieval of its results.
 
 We'll examine the future objects in the next section. This section deals with
-the executor's main top-level methods.
+the executor's main top-level methods and the task submission functions.
 
-To submit a task, use one of the |TraitsExecutor| top-level methods:
+To submit a task, use one of the convenience submission functions available
+from ``traits_futures.api``:
 
-- The |submit_call| method allows submission of a simple Python callable, with
-  given positional and named arguments. For example::
+- The |submit_call| function allows submission of a simple Python callable,
+  with given positional and named arguments. For example::
 
     submit_call(my_executor, int, "10101", base=2)
 
@@ -33,15 +34,15 @@ To submit a task, use one of the |TraitsExecutor| top-level methods:
   returns a |CallFuture| object. See the next section for more details on
   the |CallFuture| and related objects.
 
-- The |submit_iteration| method allows submission of an arbitrary iterable. The
-  user provides a callable which, when called, returns an iterable object. For
+- The |submit_iteration| function allows submission of an arbitrary iterable.
+  The user provides a callable which, when called, returns an iterable object. For
   example::
 
     submit_iteration(my_executor, range, 0, 5)
 
   It returns a |IterationFuture| object.
 
-- The |submit_progress| method allows submission of a progress-reporting
+- The |submit_progress| function allows submission of a progress-reporting
   callable, and returns a |ProgressFuture| object. The callable submitted
   *must* have a parameter called "progress".  A value for this parameter will
   be passed (by name) by the executor machinery. The value passed for the
@@ -136,7 +137,7 @@ Getting task results
 Background task results can be retrieved directly from the corresponding
 futures.
 
-The |submit_call| and |submit_progress| methods run callables that eventually
+The |submit_call| and |submit_progress| functions run callables that eventually
 expect to return a result. Once the state of the corresponding future reaches
 |COMPLETED|, the result of the call is available via the ``result`` attribute.
 Assuming that your calculation future is stored in a trait called ``future``,
@@ -161,7 +162,7 @@ trait like this::
         self.message = "{} of {} chunks processed. {} matches so far".format(
             current_step, max_steps, matches)
 
-The |submit_iteration| method is a little bit different: it produces a result
+The |submit_iteration| function is a little bit different: it produces a result
 on each iteration, but doesn't give any final result. Its ``result_event``
 trait is an ``Event`` that you can hook listeners up to in order to receive the
 results. For example::

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -40,7 +40,7 @@ from ``traits_futures.api``:
 
     submit_iteration(my_executor, range, 0, 5)
 
-  It returns a |IterationFuture| object.
+  It returns an |IterationFuture| object.
 
 - The |submit_progress| function allows submission of a progress-reporting
   callable, and returns a |ProgressFuture| object. The callable submitted

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -26,7 +26,7 @@ To submit a task, use one of the |TraitsExecutor| top-level methods:
 - The |submit_call| method allows submission of a simple Python callable, with
   given positional and named arguments. For example::
 
-    my_executor.submit_call(int, "10101", base=2)
+    submit_call(my_executor, int, "10101", base=2)
 
   will execute ``int("10101", base=2)`` in the background. |submit_call|
   doesn't wait for the background task to finish; instead, it immediately
@@ -37,7 +37,7 @@ To submit a task, use one of the |TraitsExecutor| top-level methods:
   user provides a callable which, when called, returns an iterable object. For
   example::
 
-    my_executor.submit_iteration(range, 0, 5)
+    submit_iteration(my_executor, range, 0, 5)
 
   It returns a |IterationFuture| object.
 
@@ -266,9 +266,6 @@ needed.
 .. |traits_futures.api| replace:: :mod:`traits_futures.api`
 
 .. |TraitsExecutor| replace:: :class:`~traits_futures.traits_executor.TraitsExecutor`
-.. |submit_call| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.submit_call`
-.. |submit_iteration| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.submit_iteration`
-.. |submit_progress| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.submit_progress`
 .. |stop| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.stop`
 
 .. |ExecutorState| replace:: :meth:`~traits_futures.traits_executor.ExecutorState`
@@ -277,10 +274,14 @@ needed.
 .. |STOPPED| replace:: :meth:`~traits_futures.traits_executor.STOPPED`
 
 .. |CallFuture| replace:: :class:`~traits_futures.background_call.CallFuture`
-.. |IterationFuture| replace:: :class:`~traits_futures.background_iteration.IterationFuture`
-.. |ProgressFuture| replace:: :class:`~traits_futures.background_progress.ProgressFuture`
-
+.. |submit_call| replace:: :func:`~traits_futures.background_call.submit_call`
 .. |cancel| replace:: :class:`~traits_futures.background_call.CallFuture.cancel`
+
+.. |IterationFuture| replace:: :class:`~traits_futures.background_iteration.IterationFuture`
+.. |submit_iteration| replace:: :func:`~traits_futures.background_iteration.submit_iteration`
+
+.. |ProgressFuture| replace:: :class:`~traits_futures.background_progress.ProgressFuture`
+.. |submit_progress| replace:: :func:`~traits_futures.background_progress.submit_progress`
 
 .. |FutureState| replace:: :data:`~traits_futures.future_states.FutureState`
 .. |WAITING| replace:: :data:`~traits_futures.future_states.WAITING`

--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -28,6 +28,7 @@ from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
 
 from traits_futures.api import (
     IterationFuture,
+    submit_iteration,
     TraitsExecutor,
 )
 
@@ -116,8 +117,8 @@ class PiIterator(Handler):
         super(PiIterator, self).closed(info, is_ok)
 
     def _approximate_fired(self):
-        self.future = self.traits_executor.submit_iteration(
-            pi_iterations, chunk_size=self.chunk_size
+        self.future = submit_iteration(
+            self.traits_executor, pi_iterations, chunk_size=self.chunk_size
         )
 
     def _cancel_fired(self):

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -24,6 +24,7 @@ from traits_futures.api import (
     CANCELLED,
     COMPLETED,
     ProgressFuture,
+    submit_progress,
     TraitsExecutor,
 )
 
@@ -200,8 +201,11 @@ class PrimeCounter(Handler):
 
     def _count_fired(self):
         self._last_limit = self.limit
-        self.future = self.traits_executor.submit_progress(
-            count_primes_less_than, self.limit, chunk_size=self.chunk_size
+        self.future = submit_progress(
+            self.traits_executor,
+            count_primes_less_than,
+            self.limit,
+            chunk_size=self.chunk_size,
         )
         self.result_message = "Counting ..."
 

--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -23,6 +23,7 @@ from traits_futures.api import (
     COMPLETED,
     EXECUTING,
     FAILED,
+    submit_call,
     TraitsExecutor,
     WAITING,
 )
@@ -103,7 +104,7 @@ class SquaringHelper(Handler):
         super(SquaringHelper, self).closed(info, is_ok)
 
     def _square_fired(self):
-        future = self.traits_executor.submit_call(slow_square, self.input)
+        future = submit_call(self.traits_executor, slow_square, self.input)
         self.current_futures.append(future)
 
     def _cancel_all_fired(self):

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -4,9 +4,18 @@
 """
 Core API for the traits_futures package.
 """
-from traits_futures.background_call import CallFuture
-from traits_futures.background_iteration import IterationFuture
-from traits_futures.background_progress import ProgressFuture
+from traits_futures.background_call import (
+    CallFuture,
+    submit_call,
+)
+from traits_futures.background_iteration import (
+    IterationFuture,
+    submit_iteration,
+)
+from traits_futures.background_progress import (
+    ProgressFuture,
+    submit_progress,
+)
 from traits_futures.future_states import (
     CANCELLED,
     CANCELLING,
@@ -44,4 +53,8 @@ __all__ = [
     "RUNNING",
     "STOPPING",
     "STOPPED",
+    # Convenience submission functions for job types that we define
+    "submit_call",
+    "submit_iteration",
+    "submit_progress",
 ]

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -266,3 +266,27 @@ class BackgroundCall(HasStrictTraits):
             cancel_event=cancel_event,
         )
         return future, runner
+
+
+def submit_call(executor, callable, *args, **kwargs):
+    """
+    Convenience function to submit a background call to an executor.
+
+    Parameters
+    ----------
+    executor : TraitsExecutor
+        Executor to submit the call to.
+    callable : an arbitrary callable
+        Function to execute in the background.
+    *args
+        Positional arguments to pass to that function.
+    **kwargs
+        Named arguments to pass to that function.
+
+    Returns
+    -------
+    future : CallFuture
+        Object representing the state of the background call.
+    """
+    task = BackgroundCall(callable=callable, args=args, kwargs=kwargs)
+    return executor.submit(task)

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -303,3 +303,27 @@ class BackgroundIteration(HasStrictTraits):
             cancel_event=cancel_event,
         )
         return future, runner
+
+
+def submit_iteration(executor, callable, *args, **kwargs):
+    """
+    Convenience function to submit a background iteration to an executor.
+
+    Parameters
+    ----------
+    executor : TraitsExecutor
+        Executor to submit the call to.
+    callable : an arbitrary callable
+        Function executed in the background to provide the iterable.
+    *args
+        Positional arguments to pass to that function.
+    **kwargs
+        Named arguments to pass to that function.
+
+    Returns
+    -------
+    future : IterationFuture
+        Object representing the state of the background iteration.
+    """
+    task = BackgroundIteration(callable=callable, args=args, kwargs=kwargs)
+    return executor.submit(task)

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -319,3 +319,30 @@ class BackgroundProgress(HasStrictTraits):
             cancel_event=cancel_event,
         )
         return future, runner
+
+
+def submit_progress(executor, callable, *args, **kwargs):
+    """
+    Convenience function to submit a background progress call.
+
+    Parameters
+    ----------
+    executor : TraitsExecutor
+        Executor to submit the call to.
+    callable : callable accepting a "progress" named argument
+        Function executed in the background to provide the iterable. This
+        should accept a "progress" named argument. The callable can then
+        call the "progress" object to report progress.
+    *args
+        Positional arguments to pass to that function.
+    **kwargs
+        Named arguments to pass to that function. These should not include
+        "progress".
+
+    Returns
+    -------
+    future : ProgressFuture
+        Object representing the state of the background task.
+    """
+    task = BackgroundProgress(callable=callable, args=args, kwargs=kwargs)
+    return executor.submit(task)

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -11,6 +11,7 @@ from traits_futures.api import (
     EXECUTING,
     FAILED,
     FutureState,
+    submit_call,
     WAITING,
 )
 
@@ -63,7 +64,7 @@ class BackgroundCallTests:
     """ Mixin class containing tests for the background call. """
 
     def test_successful_call(self):
-        future = self.executor.submit_call(pow, 2, 3)
+        future = submit_call(self.executor, pow, 2, 3)
         listener = CallFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -75,7 +76,7 @@ class BackgroundCallTests:
         )
 
     def test_failed_call(self):
-        future = self.executor.submit_call(fail)
+        future = submit_call(self.executor, fail)
         listener = CallFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -90,7 +91,7 @@ class BackgroundCallTests:
         # Simulate situation where a STARTED message arrives post-cancellation.
         event = self.Event()
 
-        future = self.executor.submit_call(event.set)
+        future = submit_call(self.executor, event.set)
         listener = CallFutureListener(future=future)
 
         # Ensure the background task is past the cancel_event.is_set() check.
@@ -111,7 +112,7 @@ class BackgroundCallTests:
         # Case where cancellation occurs before the future even starts
         # executing.
         with self.block_worker_pool():
-            future = self.executor.submit_call(pow, 2, 3)
+            future = submit_call(self.executor, pow, 2, 3)
             listener = CallFutureListener(future=future)
             self.assertTrue(future.cancellable)
             future.cancel()
@@ -128,7 +129,7 @@ class BackgroundCallTests:
         signal = self.Event()
         test_ready = self.Event()
 
-        future = self.executor.submit_call(ping_pong, signal, test_ready)
+        future = submit_call(self.executor, ping_pong, signal, test_ready)
         listener = CallFutureListener(future=future)
 
         # Wait for executing state; the test_ready event ensures we
@@ -151,7 +152,7 @@ class BackgroundCallTests:
         signal = self.Event()
         test_ready = self.Event()
 
-        future = self.executor.submit_call(ping_pong_fail, signal, test_ready)
+        future = submit_call(self.executor, ping_pong_fail, signal, test_ready)
         listener = CallFutureListener(future=future)
 
         # Wait for executing state; the test_ready event ensures we
@@ -171,7 +172,7 @@ class BackgroundCallTests:
         )
 
     def test_cannot_cancel_after_success(self):
-        future = self.executor.submit_call(pow, 2, 3)
+        future = submit_call(self.executor, pow, 2, 3)
         listener = CallFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -187,7 +188,7 @@ class BackgroundCallTests:
         )
 
     def test_cannot_cancel_after_failure(self):
-        future = self.executor.submit_call(fail)
+        future = submit_call(self.executor, fail)
         listener = CallFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -203,7 +204,7 @@ class BackgroundCallTests:
         )
 
     def test_cannot_cancel_after_cancel(self):
-        future = self.executor.submit_call(pow, 2, 3)
+        future = submit_call(self.executor, pow, 2, 3)
         listener = CallFutureListener(future=future)
 
         self.assertTrue(future.cancellable)
@@ -224,7 +225,7 @@ class BackgroundCallTests:
         signal = self.Event()
         test_ready = self.Event()
 
-        future = self.executor.submit_call(ping_pong, signal, test_ready)
+        future = submit_call(self.executor, ping_pong, signal, test_ready)
         listener = CallFutureListener(future=future)
 
         # Wait for executing state; the test_ready event ensures we

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -16,6 +16,7 @@ from traits_futures.api import (
     FAILED,
     FutureState,
     IterationFuture,
+    submit_iteration,
     WAITING,
 )
 
@@ -126,7 +127,7 @@ class IterationFutureListener(HasStrictTraits):
 class BackgroundIterationTests:
     def test_successful_iteration(self):
         # A simple case.
-        future = self.executor.submit_iteration(reciprocals, start=1, stop=4)
+        future = submit_iteration(self.executor, reciprocals, start=1, stop=4)
         listener = IterationFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -137,7 +138,7 @@ class BackgroundIterationTests:
 
     def test_general_iterable(self):
         # Any call that returns an iterable should be accepted
-        future = self.executor.submit_iteration(range, 0, 10, 2)
+        future = submit_iteration(self.executor, range, 0, 10, 2)
         listener = IterationFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -149,7 +150,7 @@ class BackgroundIterationTests:
     def test_bad_iteration_setup(self):
         # Deliberately passing a callable that returns
         # something non-iterable.
-        future = self.executor.submit_iteration(pow, 2, 5)
+        future = submit_iteration(self.executor, pow, 2, 5)
         listener = IterationFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -160,7 +161,7 @@ class BackgroundIterationTests:
 
     def test_failing_iteration(self):
         # Iteration that eventually fails.
-        future = self.executor.submit_iteration(reciprocals, start=-2, stop=2)
+        future = submit_iteration(self.executor, reciprocals, start=-2, stop=2)
         listener = IterationFutureListener(future=future)
 
         self.wait_until_done(future)
@@ -175,7 +176,7 @@ class BackgroundIterationTests:
         # the STARTED message.
         event = self.Event()
 
-        future = self.executor.submit_iteration(set_then_yield, event)
+        future = submit_iteration(self.executor, set_then_yield, event)
         listener = IterationFutureListener(future=future)
 
         self.assertTrue(event.wait(timeout=TIMEOUT))
@@ -193,7 +194,7 @@ class BackgroundIterationTests:
 
         blocker = self.Event()
 
-        future = self.executor.submit_iteration(wait_midway, blocker)
+        future = submit_iteration(self.executor, wait_midway, blocker)
         listener = IterationFutureListener(future=future)
 
         self.run_until(
@@ -217,7 +218,7 @@ class BackgroundIterationTests:
 
     def test_cancel_before_exhausted(self):
         blocker = self.Event()
-        future = self.executor.submit_iteration(yield_then_wait, blocker)
+        future = submit_iteration(self.executor, yield_then_wait, blocker)
         listener = IterationFutureListener(future=future)
 
         # Make sure we've got the single result.
@@ -240,7 +241,7 @@ class BackgroundIterationTests:
 
     def test_cancel_before_start(self):
         with self.block_worker_pool():
-            future = self.executor.submit_iteration(squares, 0, 10)
+            future = submit_iteration(self.executor, squares, 0, 10)
             listener = IterationFutureListener(future=future)
             self.assertTrue(future.cancellable)
             future.cancel()
@@ -254,7 +255,7 @@ class BackgroundIterationTests:
     def test_cancel_after_start(self):
         blocker = self.Event()
 
-        future = self.executor.submit_iteration(wait_midway, blocker)
+        future = submit_iteration(self.executor, wait_midway, blocker)
         listener = IterationFutureListener(future=future)
 
         self.run_until(
@@ -277,7 +278,7 @@ class BackgroundIterationTests:
     def test_cancel_before_failure(self):
         blocker = self.Event()
 
-        future = self.executor.submit_iteration(wait_then_fail, blocker)
+        future = submit_iteration(self.executor, wait_then_fail, blocker)
         listener = IterationFutureListener(future=future)
 
         self.wait_for_state(future, EXECUTING)
@@ -293,7 +294,7 @@ class BackgroundIterationTests:
         )
 
     def test_cancel_bad_job(self):
-        future = self.executor.submit_iteration(pow, 10, 3)
+        future = submit_iteration(self.executor, pow, 10, 3)
         listener = IterationFutureListener(future=future)
 
         self.assertTrue(future.cancellable)
@@ -306,7 +307,7 @@ class BackgroundIterationTests:
         self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
 
     def test_double_cancel(self):
-        future = self.executor.submit_iteration(squares, 0, 10)
+        future = submit_iteration(self.executor, squares, 0, 10)
 
         self.assertTrue(future.cancellable)
         future.cancel()
@@ -316,7 +317,7 @@ class BackgroundIterationTests:
             future.cancel()
 
     def test_completed_cancel(self):
-        future = self.executor.submit_iteration(squares, 0, 10)
+        future = submit_iteration(self.executor, squares, 0, 10)
 
         self.wait_until_done(future)
 
@@ -329,7 +330,8 @@ class BackgroundIterationTests:
         blocker = self.Event()
         resource_released = self.Event()
 
-        future = self.executor.submit_iteration(
+        future = submit_iteration(
+            self.executor,
             resource_acquiring_iteration,
             resource_acquired,
             resource_released,
@@ -358,8 +360,8 @@ class BackgroundIterationTests:
         test_ready = self.Event()
         midpoint = self.Event()
 
-        future = self.executor.submit_iteration(
-            ping_pong, test_ready, midpoint
+        future = submit_iteration(
+            self.executor, ping_pong, test_ready, midpoint
         )
         listener = IterationFutureListener(future=future)
 

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -20,6 +20,9 @@ class TestApi(unittest.TestCase):
             RUNNING,
             STOPPED,
             STOPPING,
+            submit_call,
+            submit_iteration,
+            submit_progress,
             TraitsExecutor,
             WAITING,
         )

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -9,7 +9,7 @@ import unittest
 
 from traits.api import Event, HasStrictTraits
 
-from traits_futures.api import CANCELLED, TraitsExecutor
+from traits_futures.api import CANCELLED, submit_call, TraitsExecutor
 from traits_futures.toolkit_support import toolkit
 
 
@@ -49,7 +49,7 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
     def test_run_until_timeout_trait_fired(self):
         # Trait fired, but condition still never true.
         executor = TraitsExecutor()
-        future = executor.submit_call(int, "111")
+        future = submit_call(executor, int, "111")
         with self.assertRaises(RuntimeError):
             self.run_until(
                 future,
@@ -75,7 +75,7 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
         executor = TraitsExecutor()
 
         # Case 1: condition true on second trait change event.
-        future = executor.submit_call(slow_return)
+        future = submit_call(executor, slow_return)
         self.run_until(
             future, "state", condition=lambda future: future.done,
         )

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -28,6 +28,7 @@ from traits_futures.api import (
     RUNNING,
     STOPPED,
     STOPPING,
+    submit_call,
     TraitsExecutor,
 )
 from traits_futures.toolkit_support import toolkit
@@ -168,12 +169,12 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             self.assertEqual(executor.state, STOPPING)
 
             with self.assertRaises(RuntimeError):
-                executor.submit_call(len, (1, 2, 3))
+                submit_call(executor, len, (1, 2, 3))
 
         self.wait_until_stopped(executor)
         self.assertEqual(executor.state, STOPPED)
         with self.assertRaises(RuntimeError):
-            executor.submit_call(int)
+            submit_call(executor, int)
 
     def test_stop_cancels_running_futures(self):
         executor = TraitsExecutor()
@@ -246,11 +247,12 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             cf_future = worker_pool.submit(int)
             self.assertEqual(cf_future.result(), 0)
 
-    def test_submit_call(self):
+    def test_submit_call_method(self):
         self.executor = TraitsExecutor()
-        future = self.executor.submit_call(
-            test_call, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2"
-        )
+        with self.assertWarns(DeprecationWarning) as warning_info:
+            future = self.executor.submit_call(
+                test_call, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2"
+            )
 
         self.wait_until_done(future)
 
@@ -259,11 +261,18 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             (("arg1", "arg2"), {"kwd1": "kwd1", "kwd2": "kwd2"}),
         )
 
-    def test_submit_iteration(self):
-        self.executor = TraitsExecutor()
-        future = self.executor.submit_iteration(
-            test_iteration, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2"
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warning_info.filename)
+        self.assertIn(
+            "submit_call method is deprecated", str(warning_info.warning),
         )
+
+    def test_submit_iteration_method(self):
+        self.executor = TraitsExecutor()
+        with self.assertWarns(DeprecationWarning) as warning_info:
+            future = self.executor.submit_iteration(
+                test_iteration, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2",
+            )
 
         results = []
         future.on_trait_change(
@@ -275,16 +284,29 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
             results, [("arg1", "arg2"), {"kwd1": "kwd1", "kwd2": "kwd2"}],
         )
 
-    def test_submit_progress(self):
-        self.executor = TraitsExecutor()
-        future = self.executor.submit_progress(
-            test_progress, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2"
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warning_info.filename)
+        self.assertIn(
+            "submit_iteration method is deprecated", str(warning_info.warning),
         )
+
+    def test_submit_progress_method(self):
+        self.executor = TraitsExecutor()
+        with self.assertWarns(DeprecationWarning) as warning_info:
+            future = self.executor.submit_progress(
+                test_progress, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2",
+            )
 
         self.wait_until_done(future)
 
         self.assertEqual(
             future.result, ("arg1", "arg2", "kwd1", "kwd2"),
+        )
+
+        _, _, this_module = __name__.rpartition(".")
+        self.assertIn(this_module, warning_info.filename)
+        self.assertIn(
+            "submit_progress method is deprecated", str(warning_info.warning),
         )
 
     def test_states_consistent(self):
@@ -298,7 +320,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         executor.on_trait_change(record_states, "running")
         executor.on_trait_change(record_states, "stopped")
         executor.on_trait_change(record_states, "state")
-        executor.submit_call(int)
+        submit_call(executor, int)
 
         # Record states before, during, and after stopping.
         record_states()
@@ -314,7 +336,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         executor = TraitsExecutor()
         listener = ExecutorListener(executor=executor)
 
-        executor.submit_call(int)
+        submit_call(executor, int)
         executor.stop()
         self.wait_until_stopped(executor)
 
@@ -338,7 +360,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
 
         futures = []
         for i in range(100):
-            futures.append(self.executor.submit_call(str, i))
+            futures.append(submit_call(self.executor, str, i))
 
         listener = FuturesListener(futures=futures)
 
@@ -355,7 +377,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
 
         futures = []
         for i in range(100):
-            futures.append(executor.submit_call(str, i))
+            futures.append(submit_call(executor, str, i))
 
         executor.stop()
         self.wait_until_stopped(executor)
@@ -386,7 +408,7 @@ class TestTraitsExecutor(GuiTestAssistant, unittest.TestCase):
         """
         event = threading.Event()
         try:
-            yield executor.submit_call(event.wait)
+            yield submit_call(executor, event.wait)
         finally:
             event.set()
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -20,6 +20,9 @@ from traits.api import (
     Property,
 )
 
+from traits_futures.background_call import submit_call
+from traits_futures.background_iteration import submit_iteration
+from traits_futures.background_progress import submit_progress
 from traits_futures.toolkit_support import toolkit
 
 
@@ -132,8 +135,6 @@ class TraitsExecutor(HasStrictTraits):
         future : CallFuture
             Object representing the state of the background call.
         """
-        from traits_futures.background_call import submit_call
-
         warnings.warn(
             "The submit_call method is deprecated. Use the submit_call "
             "convenience function instead.",
@@ -160,8 +161,6 @@ class TraitsExecutor(HasStrictTraits):
         future : IterationFuture
             Object representing the state of the background iteration.
         """
-        from traits_futures.background_iteration import submit_iteration
-
         warnings.warn(
             "The submit_iteration method is deprecated. Use the "
             "submit_iteration convenience function instead.",
@@ -191,8 +190,6 @@ class TraitsExecutor(HasStrictTraits):
         future : ProgressFuture
             Object representing the state of the background task.
         """
-        from traits_futures.background_progress import submit_progress
-
         warnings.warn(
             "The submit_progress method is deprecated. Use the "
             "submit_progress convenience function instead.",

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -20,9 +20,6 @@ from traits.api import (
     Property,
 )
 
-from traits_futures.background_call import BackgroundCall
-from traits_futures.background_iteration import BackgroundIteration
-from traits_futures.background_progress import BackgroundProgress
 from traits_futures.toolkit_support import toolkit
 
 
@@ -135,8 +132,15 @@ class TraitsExecutor(HasStrictTraits):
         future : CallFuture
             Object representing the state of the background call.
         """
-        task = BackgroundCall(callable=callable, args=args, kwargs=kwargs)
-        return self.submit(task)
+        from traits_futures.background_call import submit_call
+
+        warnings.warn(
+            "The submit_call method is deprecated. Use the submit_call "
+            "convenience function instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return submit_call(self, callable, *args, **kwargs)
 
     def submit_iteration(self, callable, *args, **kwargs):
         """
@@ -156,10 +160,15 @@ class TraitsExecutor(HasStrictTraits):
         future : IterationFuture
             Object representing the state of the background iteration.
         """
-        task = BackgroundIteration(
-            callable=callable, args=args, kwargs=kwargs,
+        from traits_futures.background_iteration import submit_iteration
+
+        warnings.warn(
+            "The submit_iteration method is deprecated. Use the "
+            "submit_iteration convenience function instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return self.submit(task)
+        return submit_iteration(self, callable, *args, **kwargs)
 
     def submit_progress(self, callable, *args, **kwargs):
         """
@@ -182,8 +191,15 @@ class TraitsExecutor(HasStrictTraits):
         future : ProgressFuture
             Object representing the state of the background task.
         """
-        task = BackgroundProgress(callable=callable, args=args, kwargs=kwargs)
-        return self.submit(task)
+        from traits_futures.background_progress import submit_progress
+
+        warnings.warn(
+            "The submit_progress method is deprecated. Use the "
+            "submit_progress convenience function instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return submit_progress(self, callable, *args, **kwargs)
 
     def submit(self, task):
         """


### PR DESCRIPTION
[Pulled out of #163]

The `submit_*` convenience methods on the `TraitsExecutor` don't scale well: if we want to add a new background job type, we need to modify the `TraitsExecutor`. This particularly applies to 3rd party projects wanting to use their own background job type - those projects should be able to do so without feeling the need to modify the `traits_futures` source.

In effect, what we have is a violation of the OCP.

This PR deprecates the `submit_call`, `submit_iteration` and `submit_progress` methods of the `TraitsExecutor`, replacing them with convenience functions that are defined in the same place as the background jobs. It also updates all of the internal code and tests to use the new convenience functions (apart from three tests in `test_traits_executor.py` that have been adapted to include checks for the expected `DeprecationWarning`).

Still to do before merging:

- [x] Check documentation appears as expected.
- [x] Check that examples still work as expected.

