### PR TITLE
A few naming nitpicks and other minor changes extracted from #163

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,9 @@ something like this:
   is running.
 - The UI should update (e.g., show a plot, or show results) in response to the
   background calculation completing normally.
-- The background job should be cancellable.
-- The UI should react appropriately if the background job raises an exception.
+- The background calculation should be cancellable.
+- The UI should react appropriately if the background calculation raises an
+  exception.
 
 And there are some further ease-of-development requirements:
 

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -163,9 +163,9 @@ trait like this::
             current_step, max_steps, matches)
 
 The |submit_iteration| function is a little bit different: it produces a result
-on each iteration, but doesn't give any final result. Its ``result_event``
-trait is an ``Event`` that you can hook listeners up to in order to receive the
-results. For example::
+on each iteration, but doesn't necessarily give a final result. Its
+``result_event`` trait is an ``Event`` that you can hook listeners up to in
+order to receive the iteration results. For example::
 
     @on_trait_change('future:result_event')
     def _record_result(self, result):

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -57,7 +57,7 @@ __all__ = [
     "RUNNING",
     "STOPPING",
     "STOPPED",
-    # Convenience submission functions for job types that we define
+    # Convenience submission functions for task types that we define
     "submit_call",
     "submit_iteration",
     "submit_progress",

--- a/traits_futures/future_states.py
+++ b/traits_futures/future_states.py
@@ -28,7 +28,7 @@ CANCELLED = "cancelled"
 CANCELLABLE_STATES = EXECUTING, WAITING
 
 #: Final states. If the future is in one of these states,
-#: no more messages will be received from the background job.
+#: no more messages will be received from the background task.
 DONE_STATES = CANCELLED, COMPLETED, FAILED
 
 #: Trait type representing a future state.

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -7,7 +7,7 @@ Interface for futures returned by the executor.
 
 import abc
 
-from traits.api import Any, Bool, Event, Interface, Property
+from traits.api import Bool, Interface, Property
 
 from traits_futures.future_states import FutureState
 

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -7,7 +7,7 @@ Interface for futures returned by the executor.
 
 import abc
 
-from traits.api import Bool, Interface, Property
+from traits.api import Any, Bool, Event, Interface, Property
 
 from traits_futures.future_states import FutureState
 
@@ -17,21 +17,68 @@ class IFuture(Interface):
     Interface for futures returned by the executor.
     """
 
-    #: The known state of the background task. One of the six constants
-    #: ``WAITING``, ``EXECUTING``, ``COMPLETED``, ``FAILED``, ``CANCELLING``
-    #: or ``CANCELLED``.
+    #: The state of the background task, to the best of the knowledge of
+    #: this future. One of the six constants ``WAITING``, ``EXECUTING``,
+    #: ``COMPLETED``, ``FAILED``, ``CANCELLING`` or ``CANCELLED``.
     state = FutureState
 
-    #: True if this task can be cancelled, else False. A task can be
-    #: cancelled only if ``state`` is ``WAITING`` or ``EXECUTING``. The
-    #: observed value of this trait will always be consistent with ``state``.
+    #: True if cancellation of the background task can be requested,
+    #: else False. Cancellation of the background task can be requested
+    #: only if the ``state`` is one of ``WAITING`` or ``EXECUTING``.
     cancellable = Property(Bool())
 
-    #: True if the task has finished and no further state changes will occur.
-    #: The value of ``done`` is ``True`` if and only if the ``state`` attribute
-    #: is one of ``COMPLETED``, ``FAILED``, or ``CANCELLED``. It's safe to
-    #: listen to this trait for changes: it will always fire exactly once.
+    #: True when communications from the background task are complete.
+    #: At that point, no further state changes can occur for this future.
+    #: This trait has value True if the ``state`` is one of ``COMPLETED``,
+    #: ``FAILED``, or ``CANCELLED``. It's safe to listen to this trait
+    #: for changes: it will always fire exactly once, and when it fires
+    #: it will be consistent with the ``state``.
     done = Property(Bool())
+
+    @property
+    @abc.abstractmethod
+    def result(self):
+        """
+        Result of the background task.
+
+        This attribute is only available if the state of the future is
+        ``COMPLETED``. If the future has not reached the ``COMPLETED`` state,
+        any attempt to access this attribute will raise an ``AttributeError``.
+
+        Returns
+        -------
+        result : object
+            The result obtained from the background task.
+
+        Raises
+        ------
+        AttributeError
+            If the task is still executing, or was cancelled, or raised an
+            exception instead of returning a result.
+        """
+
+    @property
+    @abc.abstractmethod
+    def exception(self):
+        """
+        Information about any exception raised by the background task.
+
+        This attribute is only available if the state of this future is
+        ``FAILED``. If the future has not reached the ``FAILED`` state, any
+        attempt to access this attribute will raise an ``AttributeError.``
+
+        Returns
+        -------
+        exc_info : tuple(str, str, str)
+            Tuple containing exception information in string form:
+            (exception type, exception value, formatted traceback).
+
+        Raises
+        ------
+        AttributeError
+            If the task is still executing, or was cancelled, or completed
+            without raising an exception.
+        """
 
     @abc.abstractmethod
     def cancel(self):
@@ -45,28 +92,6 @@ class IFuture(Interface):
         Raises
         ------
         RuntimeError
-            If the task has already completed, or cancellation has already
+            If the task has already completed or cancellation has already
             been requested.
-        """
-
-    @property
-    @abc.abstractmethod
-    def result(self):
-        """
-        Result of the background task.
-
-        This attribute is only available if the state of the future is
-        COMPLETED. If the future has not reached the COMPLETED state, any
-        attempt to access this attribute will give AttributeError.
-        """
-
-    @property
-    @abc.abstractmethod
-    def exception(self):
-        """
-        Exception raised by the background task.
-
-        This attribute is only available if the state of the future is
-        FAILED. If the future has not reached the FAILED state, any
-        attempt to access this attribute will give AttributeError.
         """

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -85,9 +85,9 @@ class IFuture(Interface):
         """
         Request cancellation of the background task.
 
-        A task in WAITING or EXECUTING state will immediately be moved to
-        CANCELLING state. If the task is not in WAITING or EXECUTING state,
-        this function will raise ``RuntimeError``.
+        A task in ``WAITING`` or ``EXECUTING`` state will immediately be moved
+        to ``CANCELLING`` state. If the task is not in ``WAITING`` or
+        ``EXECUTING`` state, this function will raise ``RuntimeError``.
 
         Raises
         ------

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -181,7 +181,7 @@ class BackgroundProgressTests:
         )
 
     def test_cancellation_before_background_task_starts(self):
-        # Test case where the background job is cancelled before
+        # Test case where the background task is cancelled before
         # it even starts executing.
         event = self.Event()
 


### PR DESCRIPTION
Also updates the `IFuture` docstrings and shuffles the order of the data and methods in `IFuture`.