### PR TITLE
Use an appropriate context in tests

### DIFF
--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -89,7 +89,7 @@ class BackgroundCallTests:
 
     def test_cancellation_vs_started_race_condition(self):
         # Simulate situation where a STARTED message arrives post-cancellation.
-        event = self.Event()
+        event = self._context.event()
 
         future = submit_call(self.executor, event.set)
         listener = CallFutureListener(future=future)
@@ -126,8 +126,8 @@ class BackgroundCallTests:
         )
 
     def test_cancellation_before_success(self):
-        signal = self.Event()
-        test_ready = self.Event()
+        signal = self._context.event()
+        test_ready = self._context.event()
 
         future = submit_call(self.executor, ping_pong, signal, test_ready)
         listener = CallFutureListener(future=future)
@@ -149,8 +149,8 @@ class BackgroundCallTests:
         )
 
     def test_cancellation_before_failure(self):
-        signal = self.Event()
-        test_ready = self.Event()
+        signal = self._context.event()
+        test_ready = self._context.event()
 
         future = submit_call(self.executor, ping_pong_fail, signal, test_ready)
         listener = CallFutureListener(future=future)
@@ -222,8 +222,8 @@ class BackgroundCallTests:
         )
 
     def test_double_cancel_variant(self):
-        signal = self.Event()
-        test_ready = self.Event()
+        signal = self._context.event()
+        test_ready = self._context.event()
 
         future = submit_call(self.executor, ping_pong, signal, test_ready)
         listener = CallFutureListener(future=future)

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -185,7 +185,7 @@ class BackgroundIterationTests:
         # Simulate race condition where we cancel after the background
         # iteration has checked the cancel event, but before we process
         # the STARTED message.
-        event = self.Event()
+        event = self._context.event()
 
         future = submit_iteration(self.executor, set_then_yield, event)
         listener = IterationFutureListener(future=future)
@@ -203,7 +203,7 @@ class BackgroundIterationTests:
         # Exercise code path where the cancel event is set during the
         # iteration.
 
-        blocker = self.Event()
+        blocker = self._context.event()
 
         future = submit_iteration(self.executor, wait_midway, blocker)
         listener = IterationFutureListener(future=future)
@@ -228,7 +228,7 @@ class BackgroundIterationTests:
         )
 
     def test_cancel_before_exhausted(self):
-        blocker = self.Event()
+        blocker = self._context.event()
         future = submit_iteration(self.executor, yield_then_wait, blocker)
         listener = IterationFutureListener(future=future)
 
@@ -264,7 +264,7 @@ class BackgroundIterationTests:
         self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
 
     def test_cancel_after_start(self):
-        blocker = self.Event()
+        blocker = self._context.event()
 
         future = submit_iteration(self.executor, wait_midway, blocker)
         listener = IterationFutureListener(future=future)
@@ -287,7 +287,7 @@ class BackgroundIterationTests:
         )
 
     def test_cancel_before_failure(self):
-        blocker = self.Event()
+        blocker = self._context.event()
 
         future = submit_iteration(self.executor, wait_then_fail, blocker)
         listener = IterationFutureListener(future=future)
@@ -337,9 +337,9 @@ class BackgroundIterationTests:
             future.cancel()
 
     def test_generator_closed_on_cancellation(self):
-        resource_acquired = self.Event()
-        blocker = self.Event()
-        resource_released = self.Event()
+        resource_acquired = self._context.event()
+        blocker = self._context.event()
+        resource_released = self._context.event()
 
         future = submit_iteration(
             self.executor,
@@ -368,8 +368,8 @@ class BackgroundIterationTests:
     def test_prompt_result_deletion(self):
         # Check that we're not hanging onto result references needlessly in the
         # background task.
-        test_ready = self.Event()
-        midpoint = self.Event()
+        test_ready = self._context.event()
+        midpoint = self._context.event()
 
         future = submit_iteration(
             self.executor, ping_pong, test_ready, midpoint

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -164,7 +164,7 @@ class BackgroundProgressTests:
         self.assertEqual(listener.progress, expected_progress)
 
     def test_cancellation_before_execution(self):
-        event = self.Event()
+        event = self._context.event()
 
         future = submit_progress(self.executor, event_set_with_progress, event)
         listener = ProgressFutureListener(future=future)
@@ -183,7 +183,7 @@ class BackgroundProgressTests:
     def test_cancellation_before_background_task_starts(self):
         # Test case where the background task is cancelled before
         # it even starts executing.
-        event = self.Event()
+        event = self._context.event()
 
         with self.block_worker_pool():
             future = submit_progress(
@@ -201,8 +201,8 @@ class BackgroundProgressTests:
         self.assertEqual(listener.states, [WAITING, CANCELLING, CANCELLED])
 
     def test_progress_allows_cancellation(self):
-        test_ready = self.Event()
-        raised = self.Event()
+        test_ready = self._context.event()
+        raised = self._context.event()
 
         future = submit_progress(
             self.executor, syncing_progress, test_ready, raised
@@ -240,7 +240,7 @@ class BackgroundProgressTests:
             future.cancel()
 
     def test_cancel_raising_task(self):
-        signal = self.Event()
+        signal = self._context.event()
         future = submit_progress(self.executor, wait_then_fail, signal)
 
         self.wait_for_state(future, EXECUTING)
@@ -254,7 +254,7 @@ class BackgroundProgressTests:
         self.assertNoException(future)
 
     def test_progress_messages_after_cancellation(self):
-        signal = self.Event()
+        signal = self._context.event()
         future = submit_progress(self.executor, progress_then_signal, signal)
         listener = ProgressFutureListener(future=future)
 
@@ -272,9 +272,9 @@ class BackgroundProgressTests:
         self.assertEqual(listener.progress, [])
 
     def test_progress_cleanup_on_cancellation(self):
-        acquired = self.Event()
-        ready = self.Event()
-        checkpoint = self.Event()
+        acquired = self._context.event()
+        ready = self._context.event()
+        checkpoint = self._context.event()
 
         try:
             future = submit_progress(

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -6,10 +6,9 @@ Tests for the background iteration functionality.
 """
 import concurrent.futures
 import contextlib
-import threading
 import unittest
 
-from traits_futures.api import TraitsExecutor
+from traits_futures.api import MultithreadingContext, TraitsExecutor
 from traits_futures.tests.background_iteration_tests import (
     BackgroundIterationTests,
 )
@@ -27,14 +26,13 @@ class TestBackgroundIteration(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self.executor = TraitsExecutor()
+        self._context = MultithreadingContext()
+        self.executor = TraitsExecutor(context=self._context)
 
     def tearDown(self):
         self.halt_executor()
+        self._context.close()
         GuiTestAssistant.tearDown(self)
-
-    #: Factory for a shared event that can be passed to a worker.
-    Event = threading.Event
 
     @contextlib.contextmanager
     def block_worker_pool(self):
@@ -44,7 +42,7 @@ class TestBackgroundIteration(
         worker_pool = self.executor._worker_pool
         max_workers = worker_pool._max_workers
 
-        event = self.Event()
+        event = self._context.event()
 
         futures = []
         for _ in range(max_workers):

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -6,10 +6,9 @@ Tests for the background progress functionality.
 """
 import concurrent.futures
 import contextlib
-import threading
 import unittest
 
-from traits_futures.api import TraitsExecutor
+from traits_futures.api import MultithreadingContext, TraitsExecutor
 from traits_futures.tests.background_progress_tests import (
     BackgroundProgressTests,
 )
@@ -27,14 +26,13 @@ class TestBackgroundProgress(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self.executor = TraitsExecutor()
+        self._context = MultithreadingContext()
+        self.executor = TraitsExecutor(context=self._context)
 
     def tearDown(self):
         self.halt_executor()
+        self._context.close()
         GuiTestAssistant.tearDown(self)
-
-    #: Factory for a shared event that can be passed to a worker.
-    Event = threading.Event
 
     @contextlib.contextmanager
     def block_worker_pool(self):
@@ -44,7 +42,7 @@ class TestBackgroundProgress(
         worker_pool = self.executor._worker_pool
         max_workers = worker_pool._max_workers
 
-        event = self.Event()
+        event = self._context.event()
 
         futures = []
         for _ in range(max_workers):


### PR DESCRIPTION
This is another small step towards multiprocessing support: use the `MultithreadingContext` in tests, so that it's easy to switch it out for the future `MultiprocessingContext`.