### PR TITLE
API documentation fixes and updates

### DIFF
--- a/docs/source/api/traits_futures.api.rst
+++ b/docs/source/api/traits_futures.api.rst
@@ -6,6 +6,50 @@ traits\_futures\.api module
 ===========================
 
 .. automodule:: traits_futures.api
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+This module re-exports the following constants, functions and classes:
+
+Executor
+--------
+
+- :class:`~.TraitsExecutor`
+
+Task submission functions
+-------------------------
+
+- :func:`~.submit_call`
+- :func:`~.submit_iteration`
+- :func:`~.submit_progress`
+
+Types of futures
+----------------
+
+- :class:`~.IFuture`
+- :class:`~.CallFuture`
+- :class:`~.IterationFuture`
+- :class:`~.ProgressFuture`
+
+Future states
+-------------
+
+- :attr:`~.FutureState`
+- :data:`~.CANCELLED`
+- :data:`~.CANCELLING`
+- :data:`~.COMPLETED`
+- :data:`~.EXECUTING`
+- :data:`~.FAILED`
+- :data:`~.WAITING`
+
+Executor states
+---------------
+
+- :attr:`~.ExecutorState`
+- :data:`~.RUNNING`
+- :data:`~.STOPPING`
+- :data:`~.STOPPED`
+
+Parallelism contexts
+--------------------
+
+- :class:`~.IParallelContext`
+- :class:`~.MultithreadingContext`

--- a/docs/source/api/traits_futures.i_future.rst
+++ b/docs/source/api/traits_futures.i_future.rst
@@ -1,0 +1,11 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
+traits\_futures\.i\_future module
+=================================
+
+.. automodule:: traits_futures.i_future
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/traits_futures.i_parallel_context.rst
+++ b/docs/source/api/traits_futures.i_parallel_context.rst
@@ -1,0 +1,11 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
+traits\_futures\.i\_parallel\_context module
+============================================
+
+.. automodule:: traits_futures.i_parallel_context
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/traits_futures.multithreading_context.rst
+++ b/docs/source/api/traits_futures.multithreading_context.rst
@@ -1,0 +1,11 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
+traits\_futures\.multithreading\_context module
+===============================================
+
+.. automodule:: traits_futures.multithreading_context
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/traits_futures.rst
+++ b/docs/source/api/traits_futures.rst
@@ -14,6 +14,9 @@ traits\_futures package
    traits_futures.background_progress
    traits_futures.exception_handling
    traits_futures.future_states
+   traits_futures.i_future
+   traits_futures.i_parallel_context
+   traits_futures.multithreading_context
    traits_futures.toolkit_support
    traits_futures.traits_executor
    traits_futures.version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ import traits_futures.version
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "traits.util.trait_documenter",
@@ -173,3 +174,12 @@ texinfo_documents = [
         "Miscellaneous",
     ),
 ]
+
+# Options for intersphinx extension
+# ---------------------------------
+
+intersphinx_mapping = {
+    "pyface": ("https://docs.enthought.com/pyface", None),
+    "python": ("https://docs.python.org/3", None),
+    "traits": ("https://docs.enthought.com/traits", None),
+}

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -3,6 +3,10 @@
 
 """
 Core API for the traits_futures package.
+
+This module contains everything that's expected to be used by users, and
+represents the supported API of Traits Futures. Users importing from other
+modules do so at their own risk.
 """
 from traits_futures.background_call import (
     CallFuture,

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -140,7 +140,7 @@ class TraitsExecutor(HasStrictTraits):
         Convenience function to submit a background call.
 
         .. deprecated:: 0.2
-           Use the :func:`submit_call` function instead.
+           Use the :func:`~.submit_call` function instead.
 
         Parameters
         ----------
@@ -169,7 +169,7 @@ class TraitsExecutor(HasStrictTraits):
         Convenience function to submit a background iteration.
 
         .. deprecated:: 0.2
-           Use the :func:`submit_iteration` function instead.
+           Use the :func:`~.submit_iteration` function instead.
 
         Parameters
         ----------
@@ -198,7 +198,7 @@ class TraitsExecutor(HasStrictTraits):
         Convenience function to submit a background progress call.
 
         .. deprecated:: 0.2
-           Use the :func:`submit_progress` function instead.
+           Use the :func:`~.submit_progress` function instead.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR:

- adds some missing API documentation modules
- removes duplicate index entries resulting from the autodoc of the api module
- adds intersphinx configuration
- fixes some broken references in docstrings