### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -182,4 +182,5 @@ intersphinx_mapping = {
     "pyface": ("https://docs.enthought.com/pyface", None),
     "python": ("https://docs.python.org/3", None),
     "traits": ("https://docs.enthought.com/traits", None),
+    "traitsui": ("https://docs.enthought.com/traitsui", None),
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Features
   - facilities to (cooperatively) cancel a long-running background task
   - access to result(s) arriving from the background task
 
-- Future objects are ``HasTraits`` instances, suitable for integration
+- Future objects are |HasTraits| instances, suitable for integration
   into a TraitsUI application.
 - No need to be a threading expert! Incoming results arrive as trait changes in
   the main thread. This eliminates a large class of potential issues with
@@ -36,7 +36,7 @@ Features
 Limitations
 -----------
 
-- By design, and unlike `concurrent_futures`_, |traits_futures| requires the
+- By design, and unlike :mod:`concurrent.futures`, |traits_futures| requires the
   UI event loop to be running in order to process results.
 - For the moment, |traits_futures| requires Qt. Support for wxPython
   may arrive in a future release.
@@ -72,11 +72,13 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+..
+   external links
 
-.. _TraitsUI: https://github.com/enthought/traitsui
-.. _concurrent_futures: https://docs.python.org/3/library/concurrent.futures.html
+.. _TraitsUI: https://docs.enthought.com/traitsui
 
 ..
    substitutions
 
 .. |traits_futures| replace:: :mod:`traits_futures`
+.. |HasTraits| replace:: :class:`~traits.has_traits.HasTraits`

--- a/traits_futures/null/gui_test_assistant.py
+++ b/traits_futures/null/gui_test_assistant.py
@@ -34,7 +34,7 @@ class GuiTestAssistant:
 
         Parameters
         ----------
-        object : HasTraits
+        object : traits.has_traits.HasTraits
             Object whose trait we want to listen to.
         trait : str
             Name of the trait to listen to.

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -32,7 +32,7 @@ class GuiTestAssistant:
 
         Parameters
         ----------
-        object : HasTraits
+        object : traits.has_traits.HasTraits
             Object whose trait we monitor.
         trait : str
             Name of the trait to monitor for changes.


### PR DESCRIPTION
This PR is a small collection of minor fixes:

- Add TraitsUI to intersphinx. We're not using it yet, but we'll likely need to shortly.
- Link directly to `concurrent.futures`
- Link properly to `HasTraits`
- Fix uses of `HasTraits` in docstrings so that Sphinx can resolve them properly.