### PR TITLE
Add missing copyright headers to existing .rst files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
 Changelog for Traits Futures
 ============================
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
 Traits Futures
 --------------
 


### PR DESCRIPTION
Tiny documentation fix: add missing copyright headers to `.rst` files. With this PR, all `.rst` files (including the autogenerated ones) have the copyright headers. (Verified manually using `find . -name \*.rst -exec head -3 {} \;`.)