### PR TITLE
Fix user guide documentation headings

### DIFF
--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -2,8 +2,8 @@
    (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
    All rights reserved.
 
-User guide
-==========
+Introduction
+============
 
 In this guide we'll introduce the key players in the |traits_futures|
 package. All classes and data items mentioned here can be imported directly

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,8 +54,8 @@ result when it arrives.
 .. literalinclude:: examples/quick_start.py
 
 
-User Documentation
-==================
+User Guide
+==========
 
 .. toctree::
    :maxdepth: 4


### PR DESCRIPTION
The current docs have the heading "User Guide" nested under "User Documentation". This PR replaces the top-level heading with "User Guide", and the subheading with "Introduction". (This will work a bit better once #188 is merged.)