### PR TITLE
More copyright header consistency fixes

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,2 +1,0 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
-# All rights reserved.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+
 # Traits Futures documentation build configuration file, created by
 # sphinx-quickstart on Sun Jul 29 10:49:55 2018.
 #

--- a/traits_futures/null/__init__.py
+++ b/traits_futures/null/__init__.py
@@ -1,2 +1,0 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
-# All rights reserved.

--- a/traits_futures/qt/__init__.py
+++ b/traits_futures/qt/__init__.py
@@ -1,2 +1,0 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
-# All rights reserved.

--- a/traits_futures/tests/__init__.py
+++ b/traits_futures/tests/__init__.py
@@ -1,2 +1,0 @@
-# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
-# All rights reserved.


### PR DESCRIPTION
This PR adds some more consistency fixes for copyright headers for *.py files

- Add missing copyright header for the documentation configuration file. While we're there, remove the unnecessary shebang and coding cookie lines.
- Remove copyright headers from files that would otherwise be completely empty.