### PR TITLE
Note deprecation of submit_call and friends in the changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Changes
   ``worker_pool``. The old name ``thread_pool`` continues to work, but its
   use is deprecated.
 
+- The ``submit_call``, ``submit_iteration`` and ``submit_progress`` methods
+  on the ``TraitsExecutor`` have been deprecated. Use the new top-level
+  convenience functions with the same names instead.
+
 - The default number of workers in the worker pool has changed. Previously
   it was hard-coded as ``4``. Now it defaults to whatever Python's
   ``concurrent.futures`` executors give (but it can be controlled by


### PR DESCRIPTION
Add a changelog entry for the deprecation of the `TraitsExecutor.submit_*` methods.

This is really a dummy PR to test the new Appveyor CI configuration.