### PR TITLE
Fix inconsistent state markup in docstrings

### DIFF
--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -196,7 +196,8 @@ class BaseFuture(HasStrictTraits):
         that method. Subclasses then only need to provide the appropriate
         ``_process_<msgtype>`` methods.
 
-        If the future is already in CANCELLING state, no message is dispatched.
+        If the future is already in ``CANCELLING`` state, no message is
+        dispatched.
         """
         if self._state == CANCELLING_AFTER_STARTED:
             # Ignore messages that arrive after a cancellation request.
@@ -267,7 +268,8 @@ class BaseFuture(HasStrictTraits):
         """
         Update state when the user requests cancellation.
 
-        A future in WAITING or EXECUTING state moves to CANCELLING state.
+        A future in ``WAITING`` or ``EXECUTING`` state moves to ``CANCELLING``
+        state.
         """
         if self._state == WAITING:
             self._cancel = None


### PR DESCRIPTION
This is a drive-by nitpick-level fix, fixing inconsistent use of markup for future states in docstrings. No functional code was touched in the making of this PR.