### PR TITLE
Refactor to simplify provision of background task types

### DIFF
--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -46,8 +46,17 @@ class BackgroundCall(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str())
 
-    #: Factory for futures
-    future = CallFuture
+    def future(self):
+        """
+        Return a Future for the background task.
+
+        Returns
+        -------
+        future : CallFuture
+            Future object that can be used to monitor the status of the
+            background task.
+        """
+        return CallFuture()
 
     def background_task(self):
         """

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -82,8 +82,17 @@ class BackgroundIteration(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str())
 
-    #: Factory for futures.
-    future = IterationFuture
+    def future(self):
+        """
+        Return a Future for the background task.
+
+        Returns
+        -------
+        future : IterationFuture
+            Future object that can be used to monitor the status of the
+            background task.
+        """
+        return IterationFuture()
 
     def background_task(self):
         """

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -119,8 +119,17 @@ class BackgroundProgress(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str())
 
-    #: Factory for futures.
-    future = ProgressFuture
+    def future(self):
+        """
+        Return a Future for the background task.
+
+        Returns
+        -------
+        future : ProgressFuture
+            Future object that can be used to monitor the status of the
+            background task.
+        """
+        return ProgressFuture()
 
     def background_task(self):
         """

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -48,6 +48,8 @@ class CommonFutureTests:
 
         # Record state when any of the three traits changes.
         future = self.future_class()
+        future._executor_initialized(lambda: None)
+
         future.on_trait_change(record_states, "cancellable")
         future.on_trait_change(record_states, "done")
         future.on_trait_change(record_states, "state")
@@ -65,6 +67,8 @@ class CommonFutureTests:
 
     def test_cancellable_and_done_success(self):
         future = self.future_class()
+        future._executor_initialized(lambda: None)
+
         listener = FutureListener(future=future)
 
         future._task_started(None)
@@ -75,6 +79,8 @@ class CommonFutureTests:
 
     def test_cancellable_and_done_failure(self):
         future = self.future_class()
+        future._executor_initialized(lambda: None)
+
         listener = FutureListener(future=future)
 
         future._task_started(None)
@@ -85,6 +91,8 @@ class CommonFutureTests:
 
     def test_cancellable_and_done_cancellation(self):
         future = self.future_class()
+        future._executor_initialized(lambda: None)
+
         listener = FutureListener(future=future)
 
         future._task_started(None)
@@ -96,6 +104,8 @@ class CommonFutureTests:
 
     def test_cancellable_and_done_early_cancellation(self):
         future = self.future_class()
+        future._executor_initialized(lambda: None)
+
         listener = FutureListener(future=future)
 
         future._user_cancelled()

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -237,7 +237,8 @@ class TraitsExecutor(HasStrictTraits):
         sender, receiver = self._message_router.pipe()
         try:
             runner = task.background_task()
-            future = task.future(_cancel=cancel_event.set)
+            future = task.future()
+            future._executor_initialized(cancel_event.set)
         except Exception:
             self._message_router.close_pipe(sender, receiver)
             raise


### PR DESCRIPTION
This is a minor refactor to make it easier for people to add their own background task types. (Related: #198.)

In the current code, a user who wants to create a new background task type writes a task specification class, and an instance `task` of that class must provide an attribute `future` that then gets called with `task.future(_cancel)`, to create  a future for the task.

The original issue in #200 was to rename the `_cancel` parameter so that it doesn't look like a private detail, but since the future method typically does nothing with that parameter except to pass it through to the `BaseFuture`, there's no real need for the task specification to know about it all. Instead, the `_cancel` callback can be provided to the future object _after_ creation.

Moreover, the current `ITaskSpecification` interface doesn't mention the `_cancel` parameter. That's a bug, and we're fixing it here by not needing the parameter any more (rather  than by fixing the `ITaskSpecification`  interface).

This PR:

- removes the need for the cancellation callback to be provided at `Future` creation time
- has the Traits Executor machinery inject the callback after creation instead, via a new private method on the `BaseFuture`
- adds a new internal state to `BaseFuture` that keeps track of whether the callback has been provided or not
- refactors the existing task specification types to fix possible confusion from the fact that we're providing what's documented as  a `future` method on the `ITaskSpecification` by providing a  callable class variable instead.

Fixes #200