### PR TITLE
Add a new shell click cmd

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -113,12 +113,8 @@ def build(python_version, toolkit, mode):
 @toolkit_option
 def shell(python_version, toolkit):
     pyenv = _get_devenv(python_version, toolkit)
-    environment_name = cfg.ENVIRONMENT_TEMPLATE.format(
-        prefix=cfg.PREFIX, python_version=python_version, toolkit=toolkit,
-    )
-
     shell_cmd = [
-        "shell", "-e", environment_name
+        "shell", "-e", pyenv.environment_name
     ]
     pyenv.edm(shell_cmd)
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -111,6 +111,21 @@ def build(python_version, toolkit, mode):
 @cli.command()
 @python_version_option
 @toolkit_option
+def shell(python_version, toolkit):
+    pyenv = _get_devenv(python_version, toolkit)
+    environment_name = cfg.ENVIRONMENT_TEMPLATE.format(
+        prefix=cfg.PREFIX, python_version=python_version, toolkit=toolkit,
+    )
+
+    shell_cmd = [
+        "shell", "-e", environment_name
+    ]
+    pyenv.edm(shell_cmd)
+
+
+@cli.command()
+@python_version_option
+@toolkit_option
 @verbose_option
 @click.option(
     "--branch/--no-branch",


### PR DESCRIPTION
This PR adds a new `shell` click command - which when run activates the development environment for traits. The usual command line options are available to choose the runtime version/toolkit of the development environment. Underneath the hood, the click command just uses the `edm shell` command with the appropriate environment name, which is why the docstring for the click command is _almost_ the same as that of `edm shell`.
