### PR TITLE
Update edm version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=2.5.0
+    - INSTALL_EDM_VERSION=3.0.1
       PYTHONUNBUFFERED="1"
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform: x64
 environment:
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "2.5.0"
+    INSTALL_EDM_VERSION: "3.0.1"
 
   matrix:
     - CI_PYTHON_VERSION: "py36"


### PR DESCRIPTION
This PR updates the EDM version in CI (travis/appveyor) from version 2.5.0 to 3.0.1