### PR TITLE
Make internal details of base_future private

### DIFF
--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -95,7 +95,7 @@ def _state_from_internal_state(internal_state):
 #: Exception used to indicate a bad state transition. This should
 #: never happen as a result of user error, only as a result of
 #: a coding error in this repository.
-class StateTransitionError(Exception):
+class _StateTransitionError(Exception):
     pass
 
 
@@ -232,7 +232,7 @@ class BaseFuture(HasStrictTraits):
             method_name = "_process_{}".format(message_type)
             getattr(self, method_name)(message_arg)
         else:
-            raise StateTransitionError(
+            raise _StateTransitionError(
                 "Unexpected custom message in state {!r}".format(self._state)
             )
 
@@ -251,7 +251,7 @@ class BaseFuture(HasStrictTraits):
         elif self._state == _CANCELLING_BEFORE_STARTED:
             self._state = _CANCELLING_AFTER_STARTED
         else:
-            raise StateTransitionError(
+            raise _StateTransitionError(
                 "Unexpected 'started' message in state {!r}".format(
                     self._state
                 )
@@ -268,7 +268,7 @@ class BaseFuture(HasStrictTraits):
         elif self._state == _CANCELLING_AFTER_STARTED:
             self._state = CANCELLED
         else:
-            raise StateTransitionError(
+            raise _StateTransitionError(
                 "Unexpected 'returned' message in state {!r}".format(
                     self._state
                 )
@@ -285,7 +285,7 @@ class BaseFuture(HasStrictTraits):
         elif self._state == _CANCELLING_AFTER_STARTED:
             self._state = CANCELLED
         else:
-            raise StateTransitionError(
+            raise _StateTransitionError(
                 "Unexpected 'raised' message in state {!r}".format(self._state)
             )
 
@@ -303,7 +303,7 @@ class BaseFuture(HasStrictTraits):
             self._cancel = None
             self._state = _CANCELLING_AFTER_STARTED
         else:
-            raise StateTransitionError(
+            raise _StateTransitionError(
                 "Unexpected 'cancelled' message in state {!r}".format(
                     self._state
                 )
@@ -323,7 +323,7 @@ class BaseFuture(HasStrictTraits):
             self._cancel = cancel
             self._state = _INITIALIZED
         else:
-            raise StateTransitionError(
+            raise _StateTransitionError(
                 "Unexpected initialization in state {!r}".format(self._state)
             )
 

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -14,7 +14,7 @@ Test methods run for all future types.
 from traits.api import Any, Bool, HasStrictTraits, List, on_trait_change, Tuple
 
 from traits_futures.api import IFuture
-from traits_futures.base_future import StateTransitionError
+from traits_futures.base_future import _StateTransitionError
 from traits_futures.exception_handling import marshal_exception
 from traits_futures.future_states import CANCELLABLE_STATES, DONE_STATES
 
@@ -155,7 +155,7 @@ class CommonFutureTests:
         invalid_sequences = continuations - valid_initial_sequences
         for sequence in invalid_sequences:
             with self.subTest(sequence=sequence):
-                with self.assertRaises(StateTransitionError):
+                with self.assertRaises(_StateTransitionError):
                     self.send_message_sequence(sequence)
 
     def test_interface(self):


### PR DESCRIPTION
This PR improves the distinction between public code (essentially, the `BaseFuture` class) and the private details in the `base_future` module.  That's important because we're now encouraging people to subclass `BaseFuture` for their own background task types.

It does mean that we've now got another private import in the test suite. Possibly the relevant test should be moved to test_base_future.