### PR TITLE
Apply black's styling to the codebase

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -65,7 +65,9 @@ def cli():
 @python_version_option
 @toolkit_option
 @click.argument(
-    "mode", type=click.Choice(["ci", "develop"]), default="develop",
+    "mode",
+    type=click.Choice(["ci", "develop"]),
+    default="develop",
 )
 def build(python_version, toolkit, mode):
     """
@@ -113,9 +115,7 @@ def build(python_version, toolkit, mode):
 @toolkit_option
 def shell(python_version, toolkit):
     pyenv = _get_devenv(python_version, toolkit)
-    shell_cmd = [
-        "shell", "-e", pyenv.environment_name
-    ]
+    shell_cmd = ["shell", "-e", pyenv.environment_name]
     pyenv.edm(shell_cmd)
 
 
@@ -219,7 +219,8 @@ def doc(python_version, toolkit):
 @python_version_option
 @toolkit_option
 @click.argument(
-    "example-name", type=click.Choice(cfg.EXAMPLES),
+    "example-name",
+    type=click.Choice(cfg.EXAMPLES),
 )
 def example(python_version, toolkit, example_name):
     """
@@ -303,7 +304,9 @@ def _get_devenv(python_version, toolkit):
 
     runtime_version = cfg.RUNTIME_VERSION[python_version]
     environment_name = cfg.ENVIRONMENT_TEMPLATE.format(
-        prefix=cfg.PREFIX, python_version=python_version, toolkit=toolkit,
+        prefix=cfg.PREFIX,
+        python_version=python_version,
+        toolkit=toolkit,
     )
 
     return PythonEnvironment(

--- a/ci/python_environment.py
+++ b/ci/python_environment.py
@@ -283,7 +283,8 @@ def current_platform():
 
 
 def _edm_version():
-    """ Determine the EDM version.
+    """
+    Determine the EDM version.
 
     Returns the EDM version as a tuple of integers.
     """

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -217,7 +217,8 @@ class PrimeCounter(Handler):
         self.result_message = "Counting ..."
 
         dialog = ProgressDialog(
-            title="Counting primes\N{HORIZONTAL ELLIPSIS}", future=self.future,
+            title="Counting primes\N{HORIZONTAL ELLIPSIS}",
+            future=self.future,
         )
         dialog.open()
 
@@ -228,7 +229,8 @@ class PrimeCounter(Handler):
     def _report_result(self, future, name, done):
         if future.state == COMPLETED:
             self.result_message = "There are {} primes smaller than {}".format(
-                future.result, self._last_limit,
+                future.result,
+                self._last_limit,
             )
         elif future.state == CANCELLED:
             self.result_message = "Run cancelled"

--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -137,7 +137,8 @@ class SquaringHelper(Handler):
                     UItem(
                         "current_futures",
                         editor=TabularEditor(
-                            adapter=JobTabularAdapter(), auto_update=True,
+                            adapter=JobTabularAdapter(),
+                            auto_update=True,
                         ),
                     ),
                 ),

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -77,7 +77,9 @@ class BackgroundCall(HasStrictTraits):
             check whether cancellation has been requested.
         """
         return CallBackgroundTask(
-            callable=self.callable, args=self.args, kwargs=self.kwargs.copy(),
+            callable=self.callable,
+            args=self.args,
+            kwargs=self.kwargs.copy(),
         )
 
 

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -113,7 +113,9 @@ class BackgroundIteration(HasStrictTraits):
             check whether cancellation has been requested.
         """
         return IterationBackgroundTask(
-            callable=self.callable, args=self.args, kwargs=self.kwargs.copy(),
+            callable=self.callable,
+            args=self.args,
+            kwargs=self.kwargs.copy(),
         )
 
 

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -153,7 +153,9 @@ class BackgroundProgress(HasStrictTraits):
             raise TypeError("progress may not be passed as a named argument")
 
         return ProgressBackgroundTask(
-            callable=self.callable, args=self.args, kwargs=self.kwargs.copy(),
+            callable=self.callable,
+            args=self.args,
+            kwargs=self.kwargs.copy(),
         )
 
 

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -79,7 +79,8 @@ class BackgroundCallTests:
         self.assertResult(future, 8)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, COMPLETED],
+            listener.states,
+            [WAITING, EXECUTING, COMPLETED],
         )
 
     def test_failed_call(self):
@@ -91,7 +92,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertException(future, ZeroDivisionError)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, FAILED],
+            listener.states,
+            [WAITING, EXECUTING, FAILED],
         )
 
     def test_cancellation_vs_started_race_condition(self):
@@ -112,7 +114,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, CANCELLING, CANCELLED],
         )
 
     def test_cancellation_before_execution(self):
@@ -129,7 +132,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, CANCELLING, CANCELLED],
         )
 
     def test_cancellation_before_success(self):
@@ -152,7 +156,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cancellation_before_failure(self):
@@ -175,7 +180,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cannot_cancel_after_success(self):
@@ -191,7 +197,8 @@ class BackgroundCallTests:
         self.assertResult(future, 8)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, COMPLETED],
+            listener.states,
+            [WAITING, EXECUTING, COMPLETED],
         )
 
     def test_cannot_cancel_after_failure(self):
@@ -207,7 +214,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertException(future, ZeroDivisionError)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, FAILED],
+            listener.states,
+            [WAITING, EXECUTING, FAILED],
         )
 
     def test_cannot_cancel_after_cancel(self):
@@ -225,7 +233,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, CANCELLING, CANCELLED],
         )
 
     def test_double_cancel_variant(self):
@@ -253,7 +262,8 @@ class BackgroundCallTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     # Helper functions

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -231,7 +231,8 @@ class BackgroundIterationTests:
         self.assertNoException(future)
         self.assertEqual(listener.results, [1729])
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cancel_before_exhausted(self):
@@ -254,7 +255,8 @@ class BackgroundIterationTests:
         self.assertNoException(future)
         self.assertEqual(listener.results, [1])
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cancel_before_start(self):
@@ -290,7 +292,8 @@ class BackgroundIterationTests:
         self.assertNoException(future)
         self.assertEqual(listener.results, [1729])
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cancel_before_failure(self):
@@ -308,7 +311,8 @@ class BackgroundIterationTests:
         self.assertNoException(future)
         self.assertEqual(listener.results, [])
         self.assertEqual(
-            listener.states, [WAITING, EXECUTING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, EXECUTING, CANCELLING, CANCELLED],
         )
 
     def test_cancel_bad_job(self):

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -184,7 +184,8 @@ class BackgroundProgressTests:
         self.assertNoResult(future)
         self.assertNoException(future)
         self.assertEqual(
-            listener.states, [WAITING, CANCELLING, CANCELLED],
+            listener.states,
+            [WAITING, CANCELLING, CANCELLED],
         )
 
     def test_cancellation_before_background_task_starts(self):

--- a/traits_futures/tests/test_base_future.py
+++ b/traits_futures/tests/test_base_future.py
@@ -31,6 +31,7 @@ class PingFuture(BaseFuture):
     BaseFuture subclass that interpretes "ping"
     messages from the background.
     """
+
     #: Accumulate ping messages
     pings = List(Int)
 

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -67,14 +67,19 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
 
         executor.stop()
         self.run_until(
-            executor, "stopped", condition=lambda executor: executor.stopped,
+            executor,
+            "stopped",
+            condition=lambda executor: executor.stopped,
         )
 
     def test_run_until_timeout_with_true_condition(self):
         # Trait never fired, but condition true anyway.
         dummy = Dummy()
         self.run_until(
-            dummy, "never_fired", condition=lambda object: True, timeout=10.0,
+            dummy,
+            "never_fired",
+            condition=lambda object: True,
+            timeout=10.0,
         )
 
     def test_run_until_success(self):
@@ -84,13 +89,17 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
         # Case 1: condition true on second trait change event.
         future = submit_call(executor, slow_return)
         self.run_until(
-            future, "state", condition=lambda future: future.done,
+            future,
+            "state",
+            condition=lambda future: future.done,
         )
         self.assertTrue(future.done)
 
         # Case 2: condition true on the first trait firing.
         executor.stop()
         self.run_until(
-            executor, "stopped", condition=lambda executor: executor.stopped,
+            executor,
+            "stopped",
+            condition=lambda executor: executor.stopped,
         )
         self.assertTrue(executor.stopped)

--- a/traits_futures/tests/test_message_router.py
+++ b/traits_futures/tests/test_message_router.py
@@ -95,7 +95,8 @@ class TestMessageRouter(GuiTestAssistant, unittest.TestCase):
 
         # Send messages from a background thread.
         worker = threading.Thread(
-            target=send_messages, args=(sender, messages),
+            target=send_messages,
+            args=(sender, messages),
         )
         worker.start()
         worker.join()
@@ -128,7 +129,8 @@ class TestMessageRouter(GuiTestAssistant, unittest.TestCase):
             listeners.append(ReceiverListener(receiver=receiver))
             workers.append(
                 threading.Thread(
-                    target=send_messages, args=(sender, messages),
+                    target=send_messages,
+                    args=(sender, messages),
                 )
             )
 

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -139,11 +139,12 @@ class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
             msg="Message router unexpectedly created",
         )
         self.assertFalse(
-            executor._context_created, msg="Context unexpectedly created",
+            executor._context_created,
+            msg="Context unexpectedly created",
         )
 
     def wait_until_stopped(self, executor):
-        """"
+        """
         Wait for the executor to reach STOPPED state.
         """
         self.run_until(executor, "stopped", lambda executor: executor.stopped)

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -201,13 +201,18 @@ class TraitsExecutorTests:
         _, _, this_module = __name__.rpartition(".")
         self.assertIn(this_module, warning_info.filename)
         self.assertIn(
-            "submit_call method is deprecated", str(warning_info.warning),
+            "submit_call method is deprecated",
+            str(warning_info.warning),
         )
 
     def test_submit_iteration_method(self):
         with self.assertWarns(DeprecationWarning) as warning_info:
             future = self.executor.submit_iteration(
-                test_iteration, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2",
+                test_iteration,
+                "arg1",
+                "arg2",
+                kwd1="kwd1",
+                kwd2="kwd2",
             )
 
         results = []
@@ -217,31 +222,39 @@ class TraitsExecutorTests:
 
         self.wait_until_done(future)
         self.assertEqual(
-            results, [("arg1", "arg2"), {"kwd1": "kwd1", "kwd2": "kwd2"}],
+            results,
+            [("arg1", "arg2"), {"kwd1": "kwd1", "kwd2": "kwd2"}],
         )
 
         _, _, this_module = __name__.rpartition(".")
         self.assertIn(this_module, warning_info.filename)
         self.assertIn(
-            "submit_iteration method is deprecated", str(warning_info.warning),
+            "submit_iteration method is deprecated",
+            str(warning_info.warning),
         )
 
     def test_submit_progress_method(self):
         with self.assertWarns(DeprecationWarning) as warning_info:
             future = self.executor.submit_progress(
-                test_progress, "arg1", "arg2", kwd1="kwd1", kwd2="kwd2",
+                test_progress,
+                "arg1",
+                "arg2",
+                kwd1="kwd1",
+                kwd2="kwd2",
             )
 
         self.wait_until_done(future)
 
         self.assertEqual(
-            future.result, ("arg1", "arg2", "kwd1", "kwd2"),
+            future.result,
+            ("arg1", "arg2", "kwd1", "kwd2"),
         )
 
         _, _, this_module = __name__.rpartition(".")
         self.assertIn(this_module, warning_info.filename)
         self.assertIn(
-            "submit_progress method is deprecated", str(warning_info.warning),
+            "submit_progress method is deprecated",
+            str(warning_info.warning),
         )
 
     def test_states_consistent(self):
@@ -318,7 +331,7 @@ class TraitsExecutorTests:
     # Helper methods and assertions ###########################################
 
     def wait_until_stopped(self, executor):
-        """"
+        """
         Wait for the executor to reach STOPPED state.
         """
         self.run_until(executor, "stopped", lambda executor: executor.stopped)


### PR DESCRIPTION
This PR brings the codebase back to black-compatible styling and applies a couple of other style fixes discovered while applying `black`.

- apply `black -l79 -tpy36 .`
- revert the changes to `docs/source/guide/examples/fizz_buzz_task.py`, to avoid extra blank lines in the built documentation
- fix two instances of `""""` to `"""`
- fix one docstring that starts on the same line as the opening `"""`. (That's not wrong, but it's inconsistent with all other docstrings in the package.)