### PR TITLE
Update super usage

### DIFF
--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -114,7 +114,7 @@ class PiIterator(Handler):
     def closed(self, info, is_ok):
         # Stopping the executor cancels any running future.
         self.traits_executor.stop()
-        super(PiIterator, self).closed(info, is_ok)
+        super().closed(info, is_ok)
 
     def _approximate_fired(self):
         self.future = submit_iteration(

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -197,7 +197,7 @@ class PrimeCounter(Handler):
     def closed(self, info, is_ok):
         # Stopping the executor cancels any running future.
         self.traits_executor.stop()
-        super(PrimeCounter, self).closed(info, is_ok)
+        super().closed(info, is_ok)
 
     def _count_fired(self):
         self._last_limit = self.limit

--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -101,7 +101,7 @@ class SquaringHelper(Handler):
     def closed(self, info, is_ok):
         # Cancel all jobs at shutdown.
         self.traits_executor.stop()
-        super(SquaringHelper, self).closed(info, is_ok)
+        super().closed(info, is_ok)
 
     def _square_fired(self):
         future = submit_call(self.traits_executor, slow_square, self.input)

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -93,7 +93,7 @@ class TraitsExecutor(HasStrictTraits):
         context=None,
         **traits,
     ):
-        super(TraitsExecutor, self).__init__(**traits)
+        super().__init__(**traits)
 
         if thread_pool is not None:
             warnings.warn(


### PR DESCRIPTION
Now that traits-futures does not support Python 2, we can get rid of the old way of calling `super`.
~Not sure if this needs to go into the release. I can update this PR again after #212 is merged.~