### PR TITLE
Bump version for the 0.2.0 release

### DIFF
--- a/traits_futures/version.py
+++ b/traits_futures/version.py
@@ -12,4 +12,4 @@
 Version information for the traits_futures package.
 """
 #: Version of the traits_futures package, as a string.
-version = "0.2.0.dev0"
+version = "0.2.0"


### PR DESCRIPTION
This PR updates the version for the 0.2.0 release.

The release date in the changelog is already correct, and doesn't need an update.