### PR TITLE
Bump version for development towards version 0.2.1

### DIFF
--- a/traits_futures/version.py
+++ b/traits_futures/version.py
@@ -12,4 +12,4 @@
 Version information for the traits_futures package.
 """
 #: Version of the traits_futures package, as a string.
-version = "0.2.0.dev0"
+version = "0.2.1.dev0"


### PR DESCRIPTION
Now that 0.2.0 is released, the `maint/0.2.x` branch is aimed at the next bugfix release, 0.2.1. This PR bumps the version number accordingly.