### PR TITLE
Fix message_router module docstring

### DIFF
--- a/traits_futures/null/message_router.py
+++ b/traits_futures/null/message_router.py
@@ -9,7 +9,9 @@
 # Thanks for using Enthought open source!
 
 """
-Message routing for the Qt toolkit.
+Message routing for the null toolkit.
+
+Messages are dispatched onto the asyncio event loop.
 """
 import asyncio
 import collections.abc


### PR DESCRIPTION
The module docstring incorrectly referred to "Qt"; in fact, it's for the null toolkit.