### PR TITLE
Update changelog to mention read-only state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Features
 Changes
 ~~~~~~~
 
+* The ``state`` trait of ``CallFuture``, ``IterationFuture`` and
+  ``ProgressFuture`` used to be writable. It's now a read-only property
+  that reflects the internal state. (#???)
 * The default number of workers in an owned worker pool (that is, a worker pool
   created by a :class:`TraitsExecutor`) has changed. Previously it was
   hard-coded as ``4``. Now it defaults to whatever Python's

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,7 @@ Changes
 
 * The ``state`` trait of ``CallFuture``, ``IterationFuture`` and
   ``ProgressFuture`` used to be writable. It's now a read-only property
-  that reflects the internal state. (#???)
+  that reflects the internal state. (#163)
 * The default number of workers in an owned worker pool (that is, a worker pool
   created by a :class:`TraitsExecutor`) has changed. Previously it was
   hard-coded as ``4``. Now it defaults to whatever Python's


### PR DESCRIPTION
The `state` trait of the various `Future` types changed from writable to read-only as part of the refactoring in #163. This broke at least one downstream application. While this change won't be reverted (the state trait should have been treated as read-only from the beginning), it's useful to note the change in the changelog.

This PR updates the changelog accordingly.

Closes #222 