### PR TITLE
CLN: Clean up of the base_future module

### DIFF
--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -102,13 +102,6 @@ _CANCELLABLE_INTERNAL_STATES = {
 }
 
 
-def _state_from_internal_state(internal_state):
-    """
-    Convert an internal state to the corresponding future state.
-    """
-    return _INTERNAL_STATE_TO_STATE[internal_state]
-
-
 #: Exception used to indicate a bad state transition. This should
 #: never happen as a result of user error, only as a result of
 #: a coding error in this repository.

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -372,8 +372,8 @@ class BaseFuture(HasStrictTraits):
         return self._state in _DONE_INTERNAL_STATES
 
     def __state_changed(self, old__state, new__state):
-        old_state = _state_from_internal_state(old__state)
-        new_state = _state_from_internal_state(new__state)
+        old_state = _INTERNAL_STATE_TO_STATE[old__state]
+        new_state = _INTERNAL_STATE_TO_STATE[new__state]
         if old_state != new_state:
             self.trait_property_changed("state", old_state, new_state)
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -87,6 +87,20 @@ _INTERNAL_STATE_TO_STATE = {
     CANCELLED: CANCELLED,
 }
 
+#: Internal states corresponding to completed futures.
+_DONE_INTERNAL_STATES = {
+    internal_state
+    for internal_state, state in _INTERNAL_STATE_TO_STATE.items()
+    if state in DONE_STATES
+}
+
+#: Internal states corresponding to cancellable futures.
+_CANCELLABLE_INTERNAL_STATES = {
+    internal_state
+    for internal_state, state in _INTERNAL_STATE_TO_STATE.items()
+    if state in CANCELLABLE_STATES
+}
+
 
 def _state_from_internal_state(internal_state):
     """
@@ -352,10 +366,10 @@ class BaseFuture(HasStrictTraits):
         return _state_from_internal_state(self._state)
 
     def _get_cancellable(self):
-        return _state_from_internal_state(self._state) in CANCELLABLE_STATES
+        return self._state in _CANCELLABLE_INTERNAL_STATES
 
     def _get_done(self):
-        return _state_from_internal_state(self._state) in DONE_STATES
+        return self._state in _DONE_INTERNAL_STATES
 
     def __state_changed(self, old__state, new__state):
         old_state = _state_from_internal_state(old__state)

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -247,6 +247,11 @@ class BaseFuture(HasStrictTraits):
     def _task_started(self, none):
         """
         Update state when the background task has started processing.
+
+        Parameters
+        ----------
+        none : NoneType
+            This parameter is unused.
         """
         if self._internal_state == _INITIALIZED:
             self._internal_state = EXECUTING
@@ -262,6 +267,11 @@ class BaseFuture(HasStrictTraits):
     def _task_returned(self, result):
         """
         Update state when background task reports completing successfully.
+
+        Parameters
+        ----------
+        result : any
+            The object returned by the background task.
         """
         if self._internal_state == EXECUTING:
             self._cancel = None
@@ -279,6 +289,12 @@ class BaseFuture(HasStrictTraits):
     def _task_raised(self, exception_info):
         """
         Update state when the background task reports completing with an error.
+
+        Parameters
+        ----------
+        exception_info : tuple(str, str, str)
+            Tuple containing exception information in string form:
+            (exception type, exception value, formatted traceback).
         """
         if self._internal_state == EXECUTING:
             self._cancel = None

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -110,7 +110,6 @@ class _StateTransitionError(Exception):
     sequence of operations received by the future from the background
     task, from the executor, or from the user.
     """
-    pass
 
 
 @provides(IFuture)
@@ -252,7 +251,9 @@ class BaseFuture(HasStrictTraits):
             getattr(self, method_name)(message_arg)
         else:
             raise _StateTransitionError(
-                "Unexpected custom message in internal state {!r}".format(self._internal_state)
+                "Unexpected custom message in internal state {!r}".format(
+                    self._internal_state
+                )
             )
 
     def _task_started(self, none):
@@ -299,7 +300,9 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = CANCELLED
         else:
             raise _StateTransitionError(
-                "Unexpected 'raised' message in internal state {!r}".format(self._internal_state)
+                "Unexpected 'raised' message in internal state {!r}".format(
+                    self._internal_state
+                )
             )
 
     def _user_cancelled(self):
@@ -337,7 +340,9 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = _INITIALIZED
         else:
             raise _StateTransitionError(
-                "Unexpected initialization in internal state {!r}".format(self._internal_state)
+                "Unexpected initialization in internal state {!r}".format(
+                    self._internal_state
+                )
             )
 
     # Private traits ##########################################################

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -39,7 +39,7 @@ from traits_futures.i_future import IFuture
 
 
 # The BaseFuture class maintains an internal state. That internal state maps to
-# the user-facing state, but is more fine grained, allowing-the class to keep
+# the user-facing state, but is more fine-grained, allowing the class to keep
 # track of the internal consistency and invariants. For example, the
 # user-facing CANCELLING state doesn't indicate whether the task has started
 # or not; if it *has* already started, then a "start" message from the

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -102,10 +102,14 @@ _CANCELLABLE_INTERNAL_STATES = {
 }
 
 
-#: Exception used to indicate a bad state transition. This should
-#: never happen as a result of user error, only as a result of
-#: a coding error in this repository.
 class _StateTransitionError(Exception):
+    """
+    Exception used to indicate a bad state transition.
+
+    Users should never see this exception. It indicates an error in the
+    sequence of operations received by the future from the background
+    task, from the executor, or from the user.
+    """
     pass
 
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -363,7 +363,7 @@ class BaseFuture(HasStrictTraits):
     # Private methods #########################################################
 
     def _get_state(self):
-        return _state_from_internal_state(self._state)
+        return _INTERNAL_STATE_TO_STATE[self._state]
 
     def _get_cancellable(self):
         return self._state in _CANCELLABLE_INTERNAL_STATES

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -74,20 +74,25 @@ _InternalState = Enum(
     CANCELLED,
 )
 
+#: Mapping from each internal state to the corresponding user-visible
+#: state.
+_INTERNAL_STATE_TO_STATE = {
+    _NOT_INITIALIZED: WAITING,
+    _INITIALIZED: WAITING,
+    EXECUTING: EXECUTING,
+    COMPLETED: COMPLETED,
+    FAILED: FAILED,
+    _CANCELLING_BEFORE_STARTED: CANCELLING,
+    _CANCELLING_AFTER_STARTED: CANCELLING,
+    CANCELLED: CANCELLED,
+}
+
 
 def _state_from_internal_state(internal_state):
     """
     Convert an internal state to the corresponding future state.
     """
-    if internal_state in (
-        _CANCELLING_AFTER_STARTED,
-        _CANCELLING_BEFORE_STARTED,
-    ):
-        return CANCELLING
-    elif internal_state in (_NOT_INITIALIZED, _INITIALIZED):
-        return WAITING
-    else:
-        return internal_state
+    return _INTERNAL_STATE_TO_STATE[internal_state]
 
 
 #: Exception used to indicate a bad state transition. This should

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -366,9 +366,9 @@ class BaseFuture(HasStrictTraits):
     def _get_done(self):
         return self._internal_state in _DONE_INTERNAL_STATES
 
-    def __internal_state_changed(self, old__internal_state, new__internal_state):
-        old_state = _INTERNAL_STATE_TO_STATE[old__internal_state]
-        new_state = _INTERNAL_STATE_TO_STATE[new__internal_state]
+    def __internal_state_changed(self, old_internal_state, new_internal_state):
+        old_state = _INTERNAL_STATE_TO_STATE[old_internal_state]
+        new_state = _INTERNAL_STATE_TO_STATE[new_internal_state]
         if old_state != new_state:
             self.trait_property_changed("state", old_state, new_state)
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -367,15 +367,19 @@ class BaseFuture(HasStrictTraits):
     # Private methods #########################################################
 
     def _get_state(self):
+        """ Property getter for the "state" trait. """
         return _INTERNAL_STATE_TO_STATE[self._internal_state]
 
     def _get_cancellable(self):
+        """ Property getter for the "cancellable" trait. """
         return self._internal_state in _CANCELLABLE_INTERNAL_STATES
 
     def _get_done(self):
+        """ Property getter for the "done" trait. """
         return self._internal_state in _DONE_INTERNAL_STATES
 
     def __internal_state_changed(self, old_internal_state, new_internal_state):
+        """ Trait change handler for the "_internal_state" trait. """
         old_state = _INTERNAL_STATE_TO_STATE[old_internal_state]
         new_state = _INTERNAL_STATE_TO_STATE[new_internal_state]
         if old_state != new_state:

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -372,14 +372,14 @@ class BaseFuture(HasStrictTraits):
         if old_state != new_state:
             self.trait_property_changed("state", old_state, new_state)
 
-        old_cancellable = old_state in CANCELLABLE_STATES
-        new_cancellable = new_state in CANCELLABLE_STATES
+        old_cancellable = old_internal_state in _CANCELLABLE_INTERNAL_STATES
+        new_cancellable = new_internal_state in _CANCELLABLE_INTERNAL_STATES
         if old_cancellable != new_cancellable:
             self.trait_property_changed(
                 "cancellable", old_cancellable, new_cancellable
             )
 
-        old_done = old_state in DONE_STATES
-        new_done = new_state in DONE_STATES
+        old_done = old_internal_state in _DONE_INTERNAL_STATES
+        new_done = new_internal_state in _DONE_INTERNAL_STATES
         if old_done != new_done:
             self.trait_property_changed("done", old_done, new_done)

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -248,7 +248,7 @@ class BaseFuture(HasStrictTraits):
             getattr(self, method_name)(message_arg)
         else:
             raise _StateTransitionError(
-                "Unexpected custom message in state {!r}".format(self._internal_state)
+                "Unexpected custom message in internal state {!r}".format(self._internal_state)
             )
 
     def _task_started(self, none):
@@ -261,7 +261,7 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = _CANCELLING_AFTER_STARTED
         else:
             raise _StateTransitionError(
-                "Unexpected 'started' message in state {!r}".format(
+                "Unexpected 'started' message in internal state {!r}".format(
                     self._internal_state
                 )
             )
@@ -278,7 +278,7 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = CANCELLED
         else:
             raise _StateTransitionError(
-                "Unexpected 'returned' message in state {!r}".format(
+                "Unexpected 'returned' message in internal state {!r}".format(
                     self._internal_state
                 )
             )
@@ -295,7 +295,7 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = CANCELLED
         else:
             raise _StateTransitionError(
-                "Unexpected 'raised' message in state {!r}".format(self._internal_state)
+                "Unexpected 'raised' message in internal state {!r}".format(self._internal_state)
             )
 
     def _user_cancelled(self):
@@ -313,7 +313,7 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = _CANCELLING_AFTER_STARTED
         else:
             raise _StateTransitionError(
-                "Unexpected 'cancelled' message in state {!r}".format(
+                "Unexpected 'cancelled' message in internal state {!r}".format(
                     self._internal_state
                 )
             )
@@ -333,7 +333,7 @@ class BaseFuture(HasStrictTraits):
             self._internal_state = _INITIALIZED
         else:
             raise _StateTransitionError(
-                "Unexpected initialization in state {!r}".format(self._internal_state)
+                "Unexpected initialization in internal state {!r}".format(self._internal_state)
             )
 
     # Private traits ##########################################################

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -307,11 +307,9 @@ class BaseFuture(HasStrictTraits):
         """
         if self._state == _INITIALIZED:
             self._cancel()
-            self._cancel = None
             self._state = _CANCELLING_BEFORE_STARTED
         elif self._state == EXECUTING:
             self._cancel()
-            self._cancel = None
             self._state = _CANCELLING_AFTER_STARTED
         else:
             raise _StateTransitionError(


### PR DESCRIPTION
This PR represents some minor non-functionality-changing cleanups of the contents of the `base_future` module, motivated by the discussion in #224 

Closes #224 

Should be reviewable commit-by-commit, or in its entirety. Highlights:

- `_state` renamed to `_internal_state`, to avoid confusion between `state` and `_state`, and because the internal state is no longer simply a mirror for the user-facing state (unlike `_result` and `result`, or `_exception` and `exception`)
- replaced increasingly-complicated logic for computing the user-facing state from the internal state with a simple dictionary lookup
- simplified getters for the `done` and `cancellable` traits
- simplified and inlined `_InternalState`
- improved docstrings and comments
