### PR TITLE
CHG: Rename BaseFuture._dispatch_message

### DIFF
--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -98,14 +98,14 @@ Now we define a dedicated future class ``FizzBuzzFuture`` for this background
 task type. The most convenient way to do this is to inherit from the
 |BaseFuture| class, which is a |HasStrictTraits| subclass that provides the
 |IFuture| interface. Messages coming into the |BaseFuture| instance from the
-background task are processed by the |dispatch_message| method. The default
+background task are processed by the |task_sent| method. The default
 implementation of this method does a couple of things:
 
 - it dispatches the argument of each message to a method named
   ``_process_<message_type>``.
 - it suppresses any messages that arrive after cancellation has been requested
 
-The |dispatch_message| method can be safely overridden by subclasses if some
+The |task_sent| method can be safely overridden by subclasses if some
 other dispatch mechanism is wanted. For this example, we use the default
 dispatch mechanism, so all we need to do is to define methods
 ``_process_fizz``, ``_process_buzz`` and ``_process_fizz_buzz`` to handle
@@ -163,7 +163,6 @@ background task type:
    substitutions
 
 .. |BaseFuture| replace:: :class:`~.BaseFuture`
-.. |dispatch_message| replace:: :meth:`~.BaseFuture._dispatch_message`
 .. |exception| replace:: :attr:`~traits_futures.i_future.IFuture.exception`
 .. |HasStrictTraits| replace:: :class:`~traits.has_traits.HasStrictTraits`
 .. |IFuture| replace:: :class:`~.IFuture`
@@ -173,4 +172,5 @@ background task type:
 .. |submit_call| replace:: :func:`~.submit_call`
 .. |submit_iteration| replace:: :func:`~.submit_iteration`
 .. |submit_progress| replace:: :func:`~.submit_progress`
+.. |task_sent| replace:: :meth:`~.BaseFuture._task_sent`
 .. |TraitsExecutor| replace:: :class:`~.TraitsExecutor`

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -206,7 +206,7 @@ class BaseFuture(HasStrictTraits):
     # events. They're used by the FutureWrapper, but are not intended for use
     # by the users of Traits Futures.
 
-    def _dispatch_message(self, message):
+    def _task_sent(self, message):
         """
         Automate dispatch of different types of message.
 

--- a/traits_futures/tests/test_base_future.py
+++ b/traits_futures/tests/test_base_future.py
@@ -50,8 +50,8 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         future = self.future_class()
         future._executor_initialized(dummy_cancel_callback)
         future._task_started(None)
-        future._dispatch_message(("ping", 123))
-        future._dispatch_message(("ping", 999))
+        future._task_sent(("ping", 123))
+        future._task_sent(("ping", 999))
         future._task_returned(1729)
 
         self.assertEqual(future.pings, [123, 999])
@@ -65,7 +65,7 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         future._task_started(None)
         future._user_cancelled()
 
-        future._dispatch_message(message)
+        future._task_sent(message)
         future._task_returned(1729)
 
         self.assertEqual(future.pings, [])
@@ -78,18 +78,18 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         future = self.future_class()
 
         with self.assertRaises(_StateTransitionError):
-            future._dispatch_message(message)
+            future._task_sent(message)
 
         future._executor_initialized(dummy_cancel_callback)
 
         with self.assertRaises(_StateTransitionError):
-            future._dispatch_message(message)
+            future._task_sent(message)
 
         future._task_started(None)
         future._task_returned(1729)
 
         with self.assertRaises(_StateTransitionError):
-            future._dispatch_message(message)
+            future._task_sent(message)
 
     def test_impossible_ping_cancelled_task(self):
         message = ("ping", 32)
@@ -100,4 +100,4 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         future._user_cancelled()
 
         with self.assertRaises(_StateTransitionError):
-            future._dispatch_message(message)
+            future._task_sent(message)

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -72,7 +72,7 @@ class FutureWrapper(HasStrictTraits):
         message_kind, message = message
 
         if message_kind == CUSTOM:
-            self.future._dispatch_message(message)
+            self.future._task_sent(message)
         else:
             assert message_kind == CONTROL
             message_type, message_arg = message


### PR DESCRIPTION
We're planning to make the semi-private interface of `BaseFuture` public, for help with unit testing. (See #225.) So this is a good opportunity to review the method names and decide whether they're fit for public consumption - after we've make them public, it'll be harder to change them.

This PR makes one name change: `_dispatch_message` to `_task_sent`. This is primarily for consistency, making it clear where the external interactions come from in this semi-private interface. The other names will remain the same.

Notes:

- there's at least one project already using some of these methods, but it's not using `_dispatch_message`
- `_dispatch_message` _is_ documented, so could potentially have users, but I'm fairly sure that no-one is yet using it. It doesn't seem worth putting a deprecation warning in place for this, and I'm willing to risk the fallout from any resulting breakage.