### PR TITLE
Fix trivial typo in comment: reources -> resources.

### DIFF
--- a/traits_futures/null/init.py
+++ b/traits_futures/null/init.py
@@ -13,5 +13,5 @@ Entry point for finding toolkit specific classes.
 """
 from pyface.base_toolkit import Toolkit
 
-#: The toolkit object used to find toolkit-specific reources.
+#: The toolkit object used to find toolkit-specific resources.
 toolkit_object = Toolkit("traits_futures", "null", "traits_futures.null")

--- a/traits_futures/qt/init.py
+++ b/traits_futures/qt/init.py
@@ -15,5 +15,5 @@ Entry point for finding toolkit-specific classes.
 from pyface.base_toolkit import Toolkit
 from pyface.qt import QtCore  # noqa: F401
 
-#: The toolkit object used to find toolkit-specific reources.
+#: The toolkit object used to find toolkit-specific resources.
 toolkit_object = Toolkit("traits_futures", "qt", "traits_futures.qt")


### PR DESCRIPTION
Fix two occurrences of a trivial typo.