### PR TITLE
Support PySide2 Qt backend in Travis CI and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,16 @@ matrix:
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt"
   - os: linux
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt5"
+  - os: linux
+    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyside2"
   - os: osx
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="null"
   - os: osx
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt"
   - os: osx
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt5"
+  - os: osx
+    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyside2"
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
       CI_TOOLKIT: "pyqt"
     - CI_PYTHON_VERSION: "py36"
       CI_TOOLKIT: "pyqt5"
+    - CI_PYTHON_VERSION: "py36"
+      CI_TOOLKIT: "pyside2"
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt

--- a/ci/config.py
+++ b/ci/config.py
@@ -32,7 +32,8 @@ PYTHON_VERSIONS = [PYTHON36]
 NULL = "null"  # no GUI toolkit; a simulated event loop is used for tests
 PYQT = "pyqt"  # Qt 4, PyQt
 PYQT5 = "pyqt5"  # Qt 5, PyQt
-TOOLKITS = [NULL, PYQT, PYQT5]
+PYSIDE2 = "pyside2"  # Qt 5, Qt for Python
+TOOLKITS = [NULL, PYQT, PYQT5, PYSIDE2]
 
 # Default Python version and toolkit.
 DEFAULT_PYTHON = PYTHON36
@@ -92,6 +93,9 @@ PLATFORMS = [
     (MACOS, PYTHON36, PYQT5),
     (LINUX, PYTHON36, PYQT5),
     (WINDOWS, PYTHON36, PYQT5),
+    (MACOS, PYTHON36, PYSIDE2),
+    (LINUX, PYTHON36, PYSIDE2),
+    (WINDOWS, PYTHON36, PYSIDE2),
 ]
 
 # Dependencies needed for all platforms, toolkits and Python versions.
@@ -117,6 +121,7 @@ ADDITIONAL_CI_DEPS = [
 TOOLKIT_CI_DEPS = {
     PYQT: ["pyqt", "traitsui"],
     PYQT5: ["pyqt5", "traitsui"],
+    PYSIDE2: ["pyside2", "traitsui"],
 }
 
 # Additional packages needed for local development, examples.

--- a/ci/config.py
+++ b/ci/config.py
@@ -37,7 +37,7 @@ TOOLKITS = [NULL, PYQT, PYQT5, PYSIDE2]
 
 # Default Python version and toolkit.
 DEFAULT_PYTHON = PYTHON36
-DEFAULT_TOOLKIT = PYQT5
+DEFAULT_TOOLKIT = PYSIDE2
 
 # Location of repository root. Assumes that the ci script is being
 # run from the root of the repository.


### PR DESCRIPTION
We're slowly moving towards making PySide2 the "standard" Qt backend, in preference to PyQt. And now that PySide2 is available under EDM, we can easily add it to the existing CI infrastructure.

This PR:

- updates the `ci` machinery to support PySide2 ("Qt for Python") in addition to PyQt4 and PyQt5
- adds Travis CI and Appveyor runs with the PySide2 toolkit
- makes PySide2 the default toolkit for users of `ci` (previously it was PyQt5)