### PR TITLE
Support -h for getting help

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -28,6 +28,11 @@ from ci.python_environment import (
 )
 
 
+# Ensure that "-h" is supported for getting help.
+CONTEXT_SETTINGS = dict(
+    help_option_names=["-h", "--help"],
+)
+
 # Common options for the commands.
 python_version_option = click.option(
     "--python-version",
@@ -53,7 +58,7 @@ verbose_option = click.option(
 
 
 # All commands are implemented as subcommands of the cli group.
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     """
     Development and continuous integration helpers for Traits Futures.


### PR DESCRIPTION
Currently `python -m ci --help` works for getting help, but `python -m ci -h` does not. This breaks expectations of some users of command-line tools.

This PR makes `python -m ci -h` work for getting help.

(For @achabotl.)