### PR TITLE
In submit_iteration, don't send None values to the future

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,19 @@
 Changelog for Traits Futures
 ============================
 
+Release 0.3.0
+-------------
+
+Changes
+~~~~~~~
+
+* For an iteration submitted via ``submit_iteration``, a plain ``yield``
+  statement in the submitted iterator marks a cancellation point (as before)
+  but no longer sends a ``None`` value to the future. A ``yield expr``
+  statement with a non-``None`` value both marks a cancellation point and
+  sends a value to the future, as before.
+
+
 Release 0.2.0
 -------------
 

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -117,6 +117,17 @@ def iteration_with_result():
     return 45
 
 
+def iteration_with_plain_yields():
+    """
+    Iteration using plain yields to mark cancellation points.
+    """
+    yield 17
+    yield
+    yield None  # same as plain yield
+    yield 29
+    yield
+
+
 class IterationFutureListener(HasStrictTraits):
     #: The object we're listening to.
     future = Instance(IterationFuture)
@@ -418,6 +429,17 @@ class BackgroundIterationTests:
         self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
         self.assertEqual(listener.results, [1, 2])
         self.assertResult(future, 45)
+        self.assertNoException(future)
+
+    def test_plain_yields_dont_send_a_message(self):
+        future = submit_iteration(self.executor, iteration_with_plain_yields)
+        listener = IterationFutureListener(future=future)
+
+        self.wait_until_done(future)
+
+        self.assertEqual(listener.states, [WAITING, EXECUTING, COMPLETED])
+        self.assertEqual(listener.results, [17, 29])
+        self.assertResult(future, None)
         self.assertNoException(future)
 
     # Helper functions


### PR DESCRIPTION
The `submit_iteration` function provides a way to run a generator in the background, with `yield` statements in that generator marking potential cancellation points.

Currently, each `yield` statement also sends a message to the foreground future, making those `yield`s somewhat heavyweight.

This PR modifies the code so that:
- a plain `yield` (or equivalently, a `yield None`) marks a cancellation point, but does not send a value to the future
- a statement of the form `yield value` with `value` non-`None` both marks a cancellation point _and_ sends a value to the future

This is a significant change in user-visible behaviour. Technically it's backwards incompatible, but the likelihood of breakage seems small (and the fix for any such breakage should be very easy). Nevertheless, we need to advertise the change properly, so I've added a changelog entry to make sure that this doesn't get neglected at release time.

Closes #229.