### PR TITLE
Require Python 3.6 or later

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,18 @@
 Changelog for Traits Futures
 ============================
 
+Release 0.3.0
+-------------
+
+Release date: XXX
+
+Changes
+-------
+
+* Python 3.5 is no longer supported. Traits Futures requires Python 3.6
+  or later.
+
+
 Release 0.2.0
 -------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,7 @@ Limitations
 - For the moment, |traits_futures| requires Qt. Support for wxPython
   may arrive in a future release.
 - No multiprocessing support yet. Maybe one day.
-- Requires Python 3.5 or later.
+- Requires Python 3.6 or later.
 
 
 Quick start

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -67,6 +66,6 @@ setup(
             "qt = traits_futures.qt.init:toolkit_object",
         ],
     },
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     license="BSD",
 )


### PR DESCRIPTION
Officially drop Python 3.5 support. Traits, which we depend on, has dropped Python 3.5 support, and that's a good enough reason for Traits Futures to also drop it.