### PR TITLE
Fix install_requires, add extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ def get_long_description():
 
 install_requires = [
     "pyface",
-    "setuptools",
     "traits",
 ]
 
@@ -47,6 +46,11 @@ setup(
     long_description_content_type="text/x-rst",
     keywords="background concurrency futures gui traits traitsui",
     install_requires=install_requires,
+    extras_require={
+        "null": [],
+        "pyqt5": ["pyqt5"],
+        "pyside2": ["pyside2"],
+    },
     packages=find_packages(exclude=["ci"]),
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR:

- removes `setuptools` from the `install_requires` list; it might have been needed once (for `pkg_resources), but it's not longer  a runtime dependency
- adds an `extras_require` section to make it easy to install Traits Futures with the support for a particular GUI toolkit; this will be useful when setting up the GitHub Actions continuous integration.

Note that we deliberately include a "null" toolkit list, even though it's empty, for the convenience of the upcoming GitHub Actions CI.

Fixes #238.

