### PR TITLE
Fix Sphinx autodoc warnings about multiple targets

### DIFF
--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -64,7 +64,7 @@ class IParallelContext(abc.ABC):
 
         Returns
         -------
-        message_router : MessageRouter
+        message_router : traits_futures.qt.message_router.MessageRouter
         """
 
     @abc.abstractmethod

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -60,7 +60,7 @@ class MultithreadingContext(IParallelContext):
 
         Returns
         -------
-        message_router : MessageRouter
+        message_router : traits_futures.qt.message_router.MessageRouter
         """
         router_class = toolkit("message_router:MessageRouter")
         return router_class()

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -89,7 +89,7 @@ class BackgroundTaskWrapper:
     background_task : collections.abc.Callable
         Callable representing the background task. This will be called
         with arguments ``send`` and ``cancelled``.
-    sender : MessageSender
+    sender : traits_futures.qt.message_router.MessageSender
         Object used to send messages.
     cancelled : collections.abc.Callable
         Zero-argument callable returning bool. This can be called to check


### PR DESCRIPTION
Fix some autodoc warnings about multiple targets, by the simple expedient of always referring to the Qt version of the class.

Note that this is something of a workaround. It will be fixed properly by #231, but it's a prerequisite for getting the GitHub Actions doc build up and running in #237.