### PR TITLE
Make sure we use Python ints in pi_iterations example

### DIFF
--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -67,7 +67,7 @@ def pi_iterations(chunk_size):
     while True:
         samples = np.random.random(size=(chunk_size, 2))
         nsamples += chunk_size
-        ninside += np.sum((samples * samples).sum(axis=1) <= 1.0)
+        ninside += int(np.sum((samples * samples).sum(axis=1) <= 1.0))
 
         # Compute approximation along with a two-sided error giving
         # a ~95% confidence interval on that approximation.


### PR DESCRIPTION
The `pi_iterations` example was using numpy integers where it should have been using Python integers. That led to it giving incorrect results due to overflow.

Should fix #248. @rahulporuri: when you get a moment, could you please test on your machine?