### PR TITLE
Add coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,26 @@
+[run]
+branch = True
+source = traits_futures
+omit = */tests/*
+
+[paths]
+source =
+    ./traits_futures
+    */traits_futures
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    if __name__ == .__main__.:
+
+ignore_errors = True

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 !/docs/source/api/traits_futures.api.rst
 /docs/build/
 /coverage/
+.coverage*
 *.egg-info/

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -14,6 +14,7 @@ the top-level repository README for more detailed instructions on how to use
 these.
 """
 import contextlib
+import glob
 import os
 import shutil
 import stat
@@ -408,11 +409,17 @@ def in_coverage_directory():
         shutil.rmtree(coverage_directory, onerror=_remove_readonly)
     os.makedirs(coverage_directory)
 
+    # Copy coverage config.
+    shutil.copy('.coveragerc', coverage_directory)
+
     old_cwd = os.getcwd()
     os.chdir(coverage_directory)
     try:
         yield
     finally:
+        # Bring back coverage reports.
+        for filepath in glob.iglob('./.coverage*'):
+            shutil.copy(filepath, old_cwd)
         os.chdir(old_cwd)
 
 


### PR DESCRIPTION
This PR adds a coverage configuration. The coverage report now excludes the testsuite. Additionally, the ci module was updated to move the coverage config file to the directory from which we run coverage - and then bring back the coverage report to the root directory of this repository. Finally, gitignore has been updated to ignore the coverage reports.

The coverage config file has been borrowed and updated from the one in traits and the changes made in the ci module are similar to what is seen in the etstool utility in traitsui.