### PR TITLE
Simplify the wx event code

### DIFF
--- a/traits_futures/tests/test_pinger.py
+++ b/traits_futures/tests/test_pinger.py
@@ -13,7 +13,14 @@ import queue
 import threading
 import unittest
 
-from traits.api import Event, HasStrictTraits, Instance, Int
+from traits.api import (
+    Event,
+    HasStrictTraits,
+    Instance,
+    Int,
+    List,
+    on_trait_change,
+)
 
 from traits_futures.toolkit_support import toolkit
 
@@ -104,6 +111,28 @@ class PingListener(HasStrictTraits):
         )
 
 
+class MultipleListeners(HasStrictTraits):
+    """
+    Listener for PingListeners, accumulating pings from all listeners.
+    """
+
+    # The individual PingListeners to listen to.
+    listeners = List(Instance(PingListener))
+
+    #: Event fired every time a ping is received.
+    ping = Event()
+
+    #: Total number of pings received from all listeners.
+    ping_count = Int(0)
+
+    def _ping_fired(self):
+        self.ping_count += 1
+
+    @on_trait_change("listeners:ping")
+    def _transmit_ping(self):
+        self.ping = True
+
+
 class TestPinger(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
@@ -147,6 +176,23 @@ class TestPinger(GuiTestAssistant, unittest.TestCase):
             self.assertEventuallyPinged(ping_count=15)
 
         self.assertEqual(self.listener.ping_count, 15)
+
+    def test_multiple_pingees(self):
+        listener1 = PingListener()
+        listener2 = PingListener()
+        listeners = MultipleListeners(listeners=[listener1, listener2])
+
+        with BackgroundPinger(listener1.pingee) as pinger1:
+            with BackgroundPinger(listener2.pingee) as pinger2:
+                pinger1.ping(3)
+                pinger2.ping(4)
+
+            self.run_until(
+                listeners, "ping", lambda obj: obj.ping_count >= 7
+            )
+
+        self.assertEqual(listener1.ping_count, 3)
+        self.assertEqual(listener2.ping_count, 4)
 
     def test_background_threads_finish_before_event_loop_starts(self):
         # Previous tests keep the background threads running until we've

--- a/traits_futures/wx/pinger.py
+++ b/traits_futures/wx/pinger.py
@@ -15,18 +15,11 @@ This module provides a way for a background thread to request that
 the main thread execute a (fixed, parameterless) callback.
 """
 
-import wx
+import wx.lib.newevent
 
 
-#: Event type that's unique to the Pinger infrastructure.
-_PING_EVENT_TYPE = wx.NewEventType()
-
-
-class _PingEvent(wx.PyCommandEvent):
-    """ wx event used to signal that a message has been sent """
-
-    def __init__(self):
-        wx.PyCommandEvent.__init__(self, _PING_EVENT_TYPE)
+#: Create new event type that's unique to the Pinger infrastructure.
+_PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
 
 
 class Pinger:
@@ -77,8 +70,7 @@ class Pingee(wx.EvtHandler):
     def __init__(self, on_ping):
         wx.EvtHandler.__init__(self)
         self._on_ping = on_ping
-        self._binder = wx.PyEventBinder(_PING_EVENT_TYPE)
-        self.Bind(self._binder, self._on_ping_event)
+        self.Bind(_PingEventBinder, self._on_ping_event)
 
     def _on_ping_event(self, event):
         """


### PR DESCRIPTION
This PR simplifies the wx implementation of `Pingee` and `Pinger` slightly:

- Make the custom event a plain `wx.Event` instead of a `wx.CommandEvent`. From the documentation at https://wxpython.org/Phoenix/docs/html/events_overview.html, it looks as though we have no need for this event to be a `CommandEvent`: we don't need propagation, and if it does occur somehow then that could be potentially confusing.

- Make the event binder a module global - it apparently doesn't need to be per-object.

- Use `wx.lib.newevent` to create the new event type and corresponding binder (following [these](https://wxpython.org/Phoenix/docs/html/events_overview.html#custom-event-summary) docs)

- Add a test that instantiates multiple pingees, and verifies that pingers are only sending pings to the appropriate pingees.