### PR TITLE
Tweak Sphinx configuration: no .nojekyll, mock external imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,6 @@ import traits_futures.version
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.githubpages",
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
@@ -197,6 +196,12 @@ texinfo_documents = [
         "Miscellaneous",
     ),
 ]
+
+# Options for autodoc extension
+# -----------------------------
+
+autodoc_mock_imports = ["pyface.qt", "wx"]
+
 
 # Options for intersphinx extension
 # ---------------------------------


### PR DESCRIPTION
This PR adds two tweaks to the Sphinx configuration, in preparation for the documentation autobuilding machinery:

- Remove the "githubpages" extension, which was giving us a top-level .nojekyll file. Now that the documentation has moved down a level in the directory structure in the gh-pages branch, we don't need that file any more.
- Mock `wx` and `pyface.qt` imports, so that we don't need to have wxPython and PySide2 installed when building the documentation.