### PR TITLE
Fix autodoc templates to avoid missing newline at EOF

### DIFF
--- a/docs/source/api/templates/module.rst_t
+++ b/docs/source/api/templates/module.rst_t
@@ -14,7 +14,7 @@
 {%- for option in options %}
    :{{ option }}:
 {%- endfor %}
-{%- endmacro -%}
+{% endmacro -%}
 
 {{ [basename, "module"] | join(' ') | e | heading }}
 

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -14,7 +14,7 @@
 {%- for option in options %}
    :{{ option }}:
 {%- endfor %}
-{%- endmacro -%}
+{% endmacro -%}
 
 {%- macro toctree(docnames) -%}
 .. toctree::


### PR DESCRIPTION
This is a nitpicky documentation PR, intended to be used as a test of the documentation autobuilding. Do not merge before #257 is merged!

Currently, the autodoc templates used mean that the autogenerated module pages are missing a final newline: for example, see  the file at https://docs.enthought.com/traits-futures/dev/_sources/api/traits_futures.future_states.rst.txt . If you download and examine that file, you'll see a missing newline at the end. (Shock! Horror!)

This PR should fix that.