### PR TITLE
Fix documentation build

### DIFF
--- a/traits_futures/wx/pinger.py
+++ b/traits_futures/wx/pinger.py
@@ -18,8 +18,15 @@ the main thread execute a (fixed, parameterless) callback.
 import wx.lib.newevent
 
 
-#: Create new event type that's unique to the Pinger infrastructure.
-_PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
+#: New event type that's unique to the Pinger infrastructure.
+
+# Note: we're not using the more obvious spelling
+#   PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
+# here because that confuses Sphinx's autodoc mocking.
+
+_PingEventPair = wx.lib.newevent.NewEvent()
+_PingEvent = _PingEventPair[0]
+_PingEventBinder = _PingEventPair[1]
 
 
 class Pinger:

--- a/traits_futures/wx/pinger.py
+++ b/traits_futures/wx/pinger.py
@@ -18,12 +18,12 @@ the main thread execute a (fixed, parameterless) callback.
 import wx.lib.newevent
 
 
-#: New event type that's unique to the Pinger infrastructure.
-
 # Note: we're not using the more obvious spelling
-#   PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
+#   _PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
 # here because that confuses Sphinx's autodoc mocking.
+# Ref: enthought/traits-futures#263.
 
+#: New event type that's unique to the Pinger infrastructure.
 _PingEventPair = wx.lib.newevent.NewEvent()
 _PingEvent = _PingEventPair[0]
 _PingEventBinder = _PingEventPair[1]


### PR DESCRIPTION
PR #256 broke the documentation build:

```
(traits-futures) mdickinson@mirzakhani docs % python -m sphinx -b html -d doctrees -W source buildRunning Sphinx v3.3.1
making output directory... done
loading intersphinx inventory from https://docs.enthought.com/pyface/objects.inv...
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://docs.enthought.com/traits/objects.inv...
loading intersphinx inventory from https://docs.enthought.com/traitsui/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 35 source files that are out of date
updating environment: [new config] 35 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                          

Warning, treated as error:
autodoc: failed to import module 'pinger' from module 'traits_futures.wx'; the following exception was raised:
Traceback (most recent call last):
  File "/Users/mdickinson/.venvs/traits-futures/lib/python3.9/site-packages/sphinx/ext/autodoc/importer.py", line 66, in import_module
    return importlib.import_module(modname)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/mdickinson/.venvs/traits-futures/lib/python3.9/site-packages/traits_futures/wx/pinger.py", line 22, in <module>
    _PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
ValueError: not enough values to unpack (expected 2, got 0)
```

The issue is with the Sphinx mocking of `wx` imports for autodoc purposes.

I can't see any good solution here:

- Changing the business logic is the wrong way to fix this - the right way is to alter the Sphinx config
- Fixing the Sphinx config requires more or less doing all the mocking ourselves, which copies a ton of code from Sphinx itself
- Requiring wxPython to be installed for doc builds is another possible fix, but given the non-triviality of installing wxPython, that's a no-go.
- We could simply not add API documentation for the `wx` subpackage, but that's not really ideal

This PR adds a workaround, taking the first of the not-good solutions listed above.