### PR TITLE
Add a per-PR workflow to test the documentation build

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,34 @@
+name: Check that documentation builds cleanly
+
+on:
+  pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install necessary apt-get packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install graphviz
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install necessary Python packages
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install sphinx enthought-sphinx-theme
+    - name: Check out the PR branch
+      uses: actions/checkout@v2
+    - name: Install local package
+      run: |
+        python -m pip install .
+    - name: Autogenerate API documentation
+      run: |
+        python -m sphinx.ext.apidoc -e -T -o docs/source/api -t docs/source/api/templates traits_futures */tests
+    - name: Build HTML documentation
+      run: |
+        cd docs
+        python -m sphinx -b html -d doctrees -W source build


### PR DESCRIPTION
We'd like to detect potential automated documentation build failures _before_ they happen, rather than after.

This PR adds a per-PR test documentation build. The commands match the per-push-to-master documentation generation, except that this workflow is slightly stricter: it uses the "-W" option in the Sphinx build so that warnings get discovered sooner.