### PR TITLE
Turn off macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,6 @@ matrix:
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyside2"
   - os: linux
     env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="wxpython"
-  - os: osx
-    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="null"
-  - os: osx
-    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt"
-  - os: osx
-    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyqt5"
-  - os: osx
-    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="pyside2"
-  - os: osx
-    env: CI_PYTHON_VERSION="py36" CI_TOOLKIT="wxpython"
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"


### PR DESCRIPTION
This PR removes the (expensive) macOS builds on Travis CI, pending transition to GitHub Actions