### PR TITLE
Add MultiprocessingContext, and adapt existing classes to use it.

### DIFF
--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -36,7 +36,7 @@ class MultiprocessingContext(IParallelContext):
         ----------
         max_workers : int, optional
             Maximum number of workers to use. If not given, the choice is
-            delegated to the ThreadPoolExecutor.
+            delegated to the ProcessPoolExecutor.
 
         Returns
         -------
@@ -61,7 +61,7 @@ class MultiprocessingContext(IParallelContext):
 
         Returns
         -------
-        message_router : MultithreadingRouter
+        message_router : MultiprocessingRouter
         """
         return MultiprocessingRouter(manager=self._manager)
 

--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -1,0 +1,80 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Context providing multiprocessing-friendly worker pools, events, and routers.
+"""
+
+import concurrent.futures
+import multiprocessing
+
+from traits_futures.i_parallel_context import IParallelContext
+from traits_futures.multiprocessing_router import MultiprocessingRouter
+
+
+class MultiprocessingContext(IParallelContext):
+    """
+    Context for multiprocessing, suitable for use with the TraitsExecutor.
+    """
+
+    def __init__(self):
+        self._closed = False
+        self._manager = multiprocessing.Manager()
+
+    def worker_pool(self, *, max_workers=None):
+        """
+        Provide a new worker pool suitable for this context.
+
+        Parameters
+        ----------
+        max_workers : int, optional
+            Maximum number of workers to use. If not given, the choice is
+            delegated to the ThreadPoolExecutor.
+
+        Returns
+        -------
+        executor : concurrent.futures.Executor
+        """
+        return concurrent.futures.ProcessPoolExecutor(max_workers=max_workers)
+
+    def event(self):
+        """
+        Return a shareable event suitable for this context.
+
+        Returns
+        -------
+        event : event-like
+            An event that can be shared safely with workers.
+        """
+        return self._manager.Event()
+
+    def message_router(self):
+        """
+        Return a message router suitable for use in this context.
+
+        Returns
+        -------
+        message_router : MultithreadingRouter
+        """
+        return MultiprocessingRouter(manager=self._manager)
+
+    def close(self):
+        """
+        Do any cleanup necessary before disposal of the context.
+        """
+        self._manager.shutdown()
+        self._closed = True
+
+    @property
+    def closed(self):
+        """
+        True if this context is closed, else False.
+        """
+        return self._closed

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -283,7 +283,6 @@ class MultiprocessingRouter(HasRequiredTraits):
         # down when the manager is shut down. That's the responsibility of
         # whoever provided that manager. Here we just remove the local
         # reference.
-        self.manager = None
         self._process_message_queue = None
 
         self._pingee.disconnect()

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -21,7 +21,7 @@ following machinery:
 - A process-safe process message queue that's shared between processes
   (:attr:`MultiprocessingRouter._process_message_queue`). This queue runs in
   its own manager server process (the manager is
-  :attr:`MultiprocessingRouter._manager`), and the main process and worker
+  :attr:`MultiprocessingRouter.manager`), and the main process and worker
   processes use proxy objects to communicate with the queue.
 - A thread-safe local message queue
   (:attr:`MultiprocessingRouter._local_message_queue`) in the main process.
@@ -61,6 +61,7 @@ from traits.api import (
     Bool,
     Dict,
     Event,
+    HasRequiredTraits,
     HasStrictTraits,
     Instance,
     Int,
@@ -203,10 +204,15 @@ class MultiprocessingReceiver(HasStrictTraits):
 
 
 @provides(IMessageRouter)
-class MultiprocessingRouter(HasStrictTraits):
+class MultiprocessingRouter(HasRequiredTraits):
     """
     Implementation of the IMessageRouter interface for the case where the
     sender will be in a background process.
+
+    Parameters
+    ----------
+    manager : multiprocessing.Manager
+        Manager to be used for creating the shared-process queue.
     """
 
     def start(self):
@@ -226,9 +232,8 @@ class MultiprocessingRouter(HasStrictTraits):
         if self._running:
             raise RuntimeError("Router is already running")
 
-        self._manager = multiprocessing.Manager()
         self._local_message_queue = queue.Queue()
-        self._process_message_queue = self._manager.Queue()
+        self._process_message_queue = self.manager.Queue()
 
         self._pingee = Pingee(on_ping=self._route_message)
         self._pingee.connect()
@@ -274,10 +279,11 @@ class MultiprocessingRouter(HasStrictTraits):
         self._monitor_thread.join()
         self._monitor_thread = None
 
-        # No shutdown required for the process_message_queue: it's enough
-        # to shut down the manager.
-        self._manager.shutdown()
-        self._manager = None
+        # No shutdown required for the process_message_queue: it'll be shut
+        # down when the manager is shut down. That's the responsibility of
+        # whoever provided that manager. Here we just remove the local
+        # reference.
+        self.manager = None
         self._process_message_queue = None
 
         self._pingee.disconnect()
@@ -346,6 +352,11 @@ class MultiprocessingRouter(HasStrictTraits):
         connection_id = receiver.connection_id
         self._receivers.pop(connection_id)
 
+    # Public traits ###########################################################
+
+    #: Manager, used to create message queues.
+    manager = Instance(multiprocessing.managers.BaseManager, required=True)
+
     # Private traits ##########################################################
 
     #: Queue receiving messages from child processes.
@@ -365,9 +376,6 @@ class MultiprocessingRouter(HasStrictTraits):
 
     #: Receiver for the "message_sent" signal.
     _pingee = Instance(Pingee)
-
-    #: Manager, used to create message queues.
-    _manager = Instance(multiprocessing.managers.BaseManager)
 
     #: Router status: True if running, False if stopped.
     _running = Bool(False)

--- a/traits_futures/tests/i_message_router_tests.py
+++ b/traits_futures/tests/i_message_router_tests.py
@@ -12,7 +12,6 @@
 Common tests for testing implementations of the IMessageRouter interface.
 """
 
-import concurrent.futures
 import contextlib
 import logging
 import threading
@@ -27,7 +26,7 @@ from traits.api import (
 )
 
 from traits_futures.i_message_router import IMessageReceiver
-from traits_futures.i_message_router import IMessageRouter
+from traits_futures.i_parallel_context import IParallelContext
 
 
 #: Safety timeout, in seconds, for blocking operations, to prevent
@@ -109,20 +108,21 @@ class IMessageRouterTests:
     Should be used in conjunction with the GuiTestAssistant.
     """
 
-    #: Factory providing the routers under test.
+    #: Factory providing the parallelism context.
     # Override this in implementations. It should be a zero-argument
-    # callable that produces the appropriate IMessageRouter instances
+    # callable that produces the appropriate IParallelContext instance
     # when called.
-    router_factory = IMessageRouter
+    context_factory = IParallelContext
 
-    #: Factory providing worker pools for the tests.
-    # Override this in implementations. It should be a zero-argument
-    # callback that produces something that follows the concurrent.futures
-    # Executor API.
-    executor_factory = concurrent.futures.Executor
+    def setUp(self):
+        self.context = self.context_factory()
+
+    def tearDown(self):
+        self.context.close()
+        del self.context
 
     def test_send_and_receive(self):
-        with self.executor_factory() as worker_pool:
+        with self.context.worker_pool() as worker_pool:
             with self.started_router() as router:
                 # Given
                 sender, receiver = router.pipe()
@@ -145,7 +145,7 @@ class IMessageRouterTests:
         # Labels used to identify tasks.
         tasks = range(64)
 
-        with self.executor_factory() as worker_pool:
+        with self.context.worker_pool() as worker_pool:
             with self.started_router() as router:
                 # Senders, receivers, listeners and messages, keyed by task.
                 sender, receiver, listener, messages = {}, {}, {}, {}
@@ -196,12 +196,12 @@ class IMessageRouterTests:
                 router.start()
 
     def test_stop_unstarted_router(self):
-        router = self.router_factory()
+        router = self.context.message_router()
         with self.assertRaises(RuntimeError):
             router.stop()
 
     def test_pipe_for_unstarted_router(self):
-        router = self.router_factory()
+        router = self.context.message_router()
         with self.assertRaises(RuntimeError):
             router.pipe()
 
@@ -319,7 +319,7 @@ class IMessageRouterTests:
 
         Stops the router on context manager exit.
         """
-        router = self.router_factory()
+        router = self.context.message_router()
         router.start()
         try:
             yield router

--- a/traits_futures/tests/test_multiprocessing_router.py
+++ b/traits_futures/tests/test_multiprocessing_router.py
@@ -15,6 +15,7 @@ Tests for the MultiprocessingRouter class.
 import concurrent.futures
 import unittest
 
+from traits_futures.multiprocessing_context import MultiprocessingContext
 from traits_futures.multiprocessing_router import MultiprocessingRouter
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
 from traits_futures.toolkit_support import toolkit
@@ -29,6 +30,9 @@ class TestMultiprocessingRouter(
     Test that MultiprocessingRouter implements the IMessageRouter interface.
     """
 
+    #: Factory providing the parallelism context
+    context_factory = MultiprocessingContext
+
     #: Factory providing the routers under test.
     router_factory = MultiprocessingRouter
 
@@ -37,6 +41,8 @@ class TestMultiprocessingRouter(
 
     def setUp(self):
         GuiTestAssistant.setUp(self)
+        IMessageRouterTests.setUp(self)
 
     def tearDown(self):
+        IMessageRouterTests.tearDown(self)
         GuiTestAssistant.tearDown(self)

--- a/traits_futures/tests/test_multiprocessing_router.py
+++ b/traits_futures/tests/test_multiprocessing_router.py
@@ -12,11 +12,9 @@
 Tests for the MultiprocessingRouter class.
 """
 
-import concurrent.futures
 import unittest
 
 from traits_futures.multiprocessing_context import MultiprocessingContext
-from traits_futures.multiprocessing_router import MultiprocessingRouter
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
 from traits_futures.toolkit_support import toolkit
 
@@ -32,12 +30,6 @@ class TestMultiprocessingRouter(
 
     #: Factory providing the parallelism context
     context_factory = MultiprocessingContext
-
-    #: Factory providing the routers under test.
-    router_factory = MultiprocessingRouter
-
-    #: Factory providing worker pools for the tests.
-    executor_factory = concurrent.futures.ProcessPoolExecutor
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/traits_futures/tests/test_multithreading_router.py
+++ b/traits_futures/tests/test_multithreading_router.py
@@ -15,6 +15,7 @@ Tests for the MultithreadingRouter class.
 import concurrent.futures
 import unittest
 
+from traits_futures.multithreading_context import MultithreadingContext
 from traits_futures.multithreading_router import MultithreadingRouter
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
 from traits_futures.toolkit_support import toolkit
@@ -29,6 +30,9 @@ class TestMultithreadingRouter(
     Test that MultithreadingRouter implements the IMessageRouter interface.
     """
 
+    #: Factory providing the parallelism context
+    context_factory = MultithreadingContext
+
     #: Factory providing the routers under test.
     router_factory = MultithreadingRouter
 
@@ -37,6 +41,8 @@ class TestMultithreadingRouter(
 
     def setUp(self):
         GuiTestAssistant.setUp(self)
+        IMessageRouterTests.setUp(self)
 
     def tearDown(self):
+        IMessageRouterTests.tearDown(self)
         GuiTestAssistant.tearDown(self)

--- a/traits_futures/tests/test_multithreading_router.py
+++ b/traits_futures/tests/test_multithreading_router.py
@@ -12,11 +12,9 @@
 Tests for the MultithreadingRouter class.
 """
 
-import concurrent.futures
 import unittest
 
 from traits_futures.multithreading_context import MultithreadingContext
-from traits_futures.multithreading_router import MultithreadingRouter
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
 from traits_futures.toolkit_support import toolkit
 
@@ -32,12 +30,6 @@ class TestMultithreadingRouter(
 
     #: Factory providing the parallelism context
     context_factory = MultithreadingContext
-
-    #: Factory providing the routers under test.
-    router_factory = MultithreadingRouter
-
-    #: Factory providing worker pools for the tests.
-    executor_factory = concurrent.futures.ThreadPoolExecutor
 
     def setUp(self):
         GuiTestAssistant.setUp(self)


### PR DESCRIPTION
[Code extracted from #173]

## Context

This is PR `<n>` in a series  of `<n+1>` PRs aimed at adding multiprocessing  support to Traits Futures. Previous PRs in the series are  #231, #282 and #283. There will be at least one more PR after this one, adding tests at the level of the Traits executor, and adding  `traits_futures.api`-level support.

## Details of this PR

This PR:

- Adds a new `MultiprocessingContext` class, parallel to the existing `MultithreadingContext` class, and implementing the existing `IParallelContext` interface.
- Adapts the existing message router tests to use a single context factory instead of using separate factories for the worker pool and message router
- Modifies the `MultiprocessingRouter` to require a manager to be passed in, instead  of having the router manage its own manager. This avoids having two auxiliary manager processes instead of just one.

I considered making the manager optional in the `MultiprocessingRouter`, but I don't currently have a use-case for _not_ passing in a manager. Right now, and in the foreseeable future in #173, all creations of the router go through the context. In effect, that context is part of the same layer as the message router, and using a context is the right way to work with that layer at user level.

The `MultiprocessingContext` is reasonably well tested through  the router tests, but at this point the `event` method isn't exercised. That will change when the rest of #173 gets merged in.

(At some point, I'm considering re-organizing the package structure to make the layers clearer. But not in this PR.)