### PR TITLE
Replace flake8-import-order with isort

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -15,9 +15,10 @@ jobs:
     - name: Install necessary Python packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install flake8 flake8-ets flake8-import-order
+        python -m pip install flake8 flake8-ets isort
     - name: Check out the PR branch
       uses: actions/checkout@v2
     - name: Run style checks
       run: |
         python -m flake8
+        python -m isort . --check --diff

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ To run tests under coverage::
 
 To run a style check::
 
-    python -m ci flake8
+    python -m ci style
 
 To build the documentation::
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -298,7 +298,9 @@ def style(edm, python_version, toolkit):
 
     if pyenv.python_return_code(["-m", "isort", ".", "--check", "--diff"]):
         click.echo()
-        raise click.ClickException("Import order check failed.")
+        raise click.ClickException(
+            "Import order check failed. Run 'python -m ci format' to fix."
+        )
     else:
         click.echo("Import order check succeeded.")
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -150,6 +150,9 @@ def build(edm, python_version, toolkit, mode):
 @python_version_option
 @toolkit_option
 def shell(edm, python_version, toolkit):
+    """
+    Enter the development environment.
+    """
     pyenv = _get_devenv(edm, python_version, toolkit)
     shell_cmd = ["shell", "-e", pyenv.environment_name]
     pyenv.edm(shell_cmd)
@@ -274,18 +277,34 @@ def example(edm, python_version, toolkit, example_name):
 @edm_option
 @python_version_option
 @toolkit_option
-def flake8(edm, python_version, toolkit):
+def format(edm, python_version, toolkit):
     """
-    Run flake8 on all Python files.
+    Run formatters on all Python files.
     """
-    targets = cfg.FLAKE8_TARGETS
-
     pyenv = _get_devenv(edm, python_version, toolkit)
-    if pyenv.python_return_code(["-m", "flake8"] + targets):
+    pyenv.python(["-m", "isort", "."])
+
+
+@cli.command()
+@edm_option
+@python_version_option
+@toolkit_option
+def style(edm, python_version, toolkit):
+    """
+    Run style checks on all Python files.
+    """
+    pyenv = _get_devenv(edm, python_version, toolkit)
+    if pyenv.python_return_code(["-m", "flake8"]):
         click.echo()
         raise click.ClickException("Flake8 check failed.")
     else:
         click.echo("Flake8 check succeeded.")
+
+    if pyenv.python_return_code(["-m", "isort", ".", "--check", "--diff"]):
+        click.echo()
+        raise click.ClickException("Import order check failed.")
+    else:
+        click.echo("Import order check succeeded.")
 
 
 @cli.command()

--- a/ci/config.py
+++ b/ci/config.py
@@ -12,8 +12,7 @@ import os
 
 import pkg_resources
 
-# Main package name, used for installing development sources
-# and as a flake8 target.
+# Main package name, used for installing development sources.
 PACKAGE_NAME = "traits_futures"
 
 # Prefix used for generated EDM environments.
@@ -73,15 +72,6 @@ RUNTIME_VERSION = {
     PYTHON36: "3.6",
 }
 
-# Directories and files that should be checked for flake8-cleanness.
-FLAKE8_TARGETS = [
-    "ci",
-    "docs",
-    "setup.py",
-    PACKAGE_NAME,
-    "examples",
-]
-
 # Platforms and Python versions that we support.
 # Triples (edm-platform-string, Python major.minor version, GUI toolkit)
 PLATFORMS = [
@@ -117,7 +107,7 @@ VERSION_CORE_DEPS = {}
 ADDITIONAL_CI_DEPS = [
     "flake8",
     "flake8_ets",
-    "flake8_import_order",
+    "isort",
     "pip",
 ]
 

--- a/ci/config.py
+++ b/ci/config.py
@@ -103,7 +103,7 @@ CORE_DEPS = [
 # to list of requirements.
 VERSION_CORE_DEPS = {}
 
-# Additional packages needed for running tests under CI.
+# Additional packages needed for running tests and style checks.
 ADDITIONAL_CI_DEPS = [
     "flake8",
     "flake8_ets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 79
+target-version = ['py36']
+exclude = "/docs/source/guide/examples"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[flake8]
+per-file-ignores = docs/source/guide/examples/*:E402
+
+[isort]
+profile = black
+sections=FUTURE,STDLIB,THIRDPARTY,ENTHOUGHT,FIRSTPARTY,LOCALFOLDER
+known_third_party = wx
+known_enthought = chaco,enable,pyface,traits,traitsui
+line_length = 79
+order_by_type = False
+skip_glob = docs/source/guide/examples/*,examples/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,10 @@
 [flake8]
+max-line-length = 79
 per-file-ignores = docs/source/guide/examples/*:E402
 
 [isort]
 profile = black
-sections=FUTURE,STDLIB,THIRDPARTY,ENTHOUGHT,FIRSTPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,ENTHOUGHT,FIRSTPARTY,LOCALFOLDER
 known_third_party = wx
 known_enthought = chaco,enable,pyface,traits,traitsui
 line_length = 79

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,0 @@
-[flake8]
-
-import-order-style = appnexus
-application-package-names = chaco,enable,pyface,traits,traitsui
-application-import-names = ci,traits_futures
-
-per-file-ignores = docs/source/guide/examples/*:E402,I100,I201,I202


### PR DESCRIPTION
This PR enhances the build machinery in various ways:

- use the `isort` package instead of using `flake8-import-order` to check import order
- rename the `python -m ci flake8` command to `python -m ci style`, since it now covers more than just flake8 checks
- add a new `python -m ci format` command that automatically sorts and groups imports
- fix missing help for `python -m ci shell`
- remove `FLAKE8_TARGETS`:  the information about which files to skip is moved to `setup.cfg`, where it belongs (that way it applies to all the various ways of invoking `flake8`, not just `python -m ci flake8`)
- move configuration to `setup.cfg`, since we can use this file both for `isort` and `flake8` configuration
- add configuration for the `black` utility, though we're not enforcing black style through CI at the moment

I opted not to use the `flake8-isort` package, partly to avoid an unnecessary dependency on the `enthought/gpl` egg repository, and partly because it doesn't really add anything that isn't already provided directly by `isort`.


Closes #271 