### PR TITLE
Fix import grouping and ordering throughout the codebase

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -23,11 +23,7 @@ import tempfile
 import click
 
 import ci.config as cfg
-from ci.python_environment import (
-    current_platform,
-    PythonEnvironment,
-)
-
+from ci.python_environment import current_platform, PythonEnvironment
 
 # Ensure that "-h" is supported for getting help.
 CONTEXT_SETTINGS = dict(

--- a/docs/source/guide/examples/interruptible_task.py
+++ b/docs/source/guide/examples/interruptible_task.py
@@ -30,8 +30,6 @@ from traits.api import (
     Property,
     Str,
 )
-from traitsui.api import HGroup, Item, UItem, View
-
 from traits_futures.api import (
     CANCELLED,
     COMPLETED,
@@ -40,6 +38,7 @@ from traits_futures.api import (
     submit_iteration,
     TraitsExecutor,
 )
+from traitsui.api import HGroup, Item, UItem, View
 
 
 def approximate_pi(sample_count=10 ** 8):

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -30,8 +30,6 @@ from traits.api import (
     Property,
     Str,
 )
-from traitsui.api import HGroup, Item, UItem, View
-
 from traits_futures.api import (
     CANCELLED,
     COMPLETED,
@@ -40,6 +38,7 @@ from traits_futures.api import (
     submit_call,
     TraitsExecutor,
 )
+from traitsui.api import HGroup, Item, UItem, View
 
 
 def approximate_pi(sample_count=10 ** 8):

--- a/docs/source/guide/examples/test_future.py
+++ b/docs/source/guide/examples/test_future.py
@@ -17,7 +17,6 @@ import unittest
 from pyface.toolkit import toolkit_object
 from traits_futures.api import submit_call, TraitsExecutor
 
-
 #: Maximum timeout for blocking calls, in seconds. A successful test should
 #: never hit this timeout - it's there to prevent a failing test from hanging
 #: forever and blocking the rest of the test suite.

--- a/examples/pi_iterations.py
+++ b/examples/pi_iterations.py
@@ -31,13 +31,12 @@ from traits.api import (
     Property,
     Tuple,
 )
-from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
-
 from traits_futures.api import (
     IterationFuture,
     submit_iteration,
     TraitsExecutor,
 )
+from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
 
 
 def pi_iterations(chunk_size):

--- a/examples/prime_counting.py
+++ b/examples/prime_counting.py
@@ -25,8 +25,6 @@ from traits.api import (
     Property,
     Str,
 )
-from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
-
 from traits_futures.api import (
     CANCELLED,
     COMPLETED,
@@ -34,6 +32,7 @@ from traits_futures.api import (
     submit_progress,
     TraitsExecutor,
 )
+from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
 
 
 class ProgressDialog(Dialog, HasStrictTraits):

--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -12,17 +12,6 @@ import random
 import time
 
 from traits.api import Button, Instance, List, Property, Range
-from traitsui.api import (
-    Handler,
-    HGroup,
-    Item,
-    TabularEditor,
-    UItem,
-    VGroup,
-    View,
-)
-from traitsui.tabular_adapter import TabularAdapter
-
 from traits_futures.api import (
     CallFuture,
     CANCELLED,
@@ -34,6 +23,16 @@ from traits_futures.api import (
     TraitsExecutor,
     WAITING,
 )
+from traitsui.api import (
+    Handler,
+    HGroup,
+    Item,
+    TabularEditor,
+    UItem,
+    VGroup,
+    View,
+)
+from traitsui.tabular_adapter import TabularAdapter
 
 
 def slow_square(n, timeout=5.0):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
+
 [flake8]
 
 import-order-style = appnexus
 application-package-names = chaco,enable,pyface,traits,traitsui
 application-import-names = ci,traits_futures
 
-per-file-ignores = docs/source/guide/examples/*:E402,I100,I201,I202
+per-file-ignores = docs/source/guide/examples/*:E402,I100,I201,I202,examples/*:I100,I201,I202

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,3 @@
-
 [flake8]
 
 import-order-style = appnexus

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -69,18 +69,12 @@ Parallelism contexts
 - :class:`~.MultithreadingContext`
 
 """
-from traits_futures.background_call import (
-    CallFuture,
-    submit_call,
-)
+from traits_futures.background_call import CallFuture, submit_call
 from traits_futures.background_iteration import (
     IterationFuture,
     submit_iteration,
 )
-from traits_futures.background_progress import (
-    ProgressFuture,
-    submit_progress,
-)
+from traits_futures.background_progress import ProgressFuture, submit_progress
 from traits_futures.base_future import BaseFuture
 from traits_futures.future_states import (
     CANCELLED,

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -12,18 +12,10 @@
 Background task that sends results from an iteration.
 """
 
-from traits.api import (
-    Callable,
-    Dict,
-    Event,
-    HasStrictTraits,
-    Str,
-    Tuple,
-)
+from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
 from traits_futures.base_future import BaseFuture
 from traits_futures.i_task_specification import ITaskSpecification
-
 
 #: Message sent whenever the iteration yields a result.
 #: The message argument is the result generated.

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -19,18 +19,10 @@ Every progress submission also marks a point where the callable can
 be cancelled.
 """
 
-from traits.api import (
-    Callable,
-    Dict,
-    Event,
-    HasStrictTraits,
-    Str,
-    Tuple,
-)
+from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
 from traits_futures.base_future import BaseFuture
 from traits_futures.i_task_specification import ITaskSpecification
-
 
 # Message types for messages from ProgressBackgroundTask
 # to ProgressFuture.

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -37,7 +37,6 @@ from traits_futures.future_states import (
 )
 from traits_futures.i_future import IFuture
 
-
 # The BaseFuture class maintains an internal state. That internal state maps to
 # the user-facing state, but is more fine-grained, allowing the class to keep
 # track of the internal consistency and invariants. For example, the

--- a/traits_futures/i_message_router.py
+++ b/traits_futures/i_message_router.py
@@ -62,7 +62,6 @@ import contextlib
 
 from traits.api import Any, Event, Interface
 
-
 # Note: implementations of IMessageRouter and IMessageReceiver are expected to
 # be HasTraits classes, so we inherit from the Traits Interface class.
 # IMessageSender implementations are not expected to be HasTraits classes:

--- a/traits_futures/null/gui_test_assistant.py
+++ b/traits_futures/null/gui_test_assistant.py
@@ -14,7 +14,6 @@ Test support, providing the ability to run the event loop from tests.
 
 import asyncio
 
-
 #: Default timeout, in seconds
 TIMEOUT = 10.0
 

--- a/traits_futures/qt/gui_test_assistant.py
+++ b/traits_futures/qt/gui_test_assistant.py
@@ -15,7 +15,6 @@ Test support, providing the ability to run the event loop from tests.
 from pyface.qt.QtCore import QTimer
 from pyface.qt.QtGui import QApplication
 
-
 #: Default timeout, in seconds
 TIMEOUT = 10.0
 

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -22,7 +22,6 @@ from traits_futures.api import (
     WAITING,
 )
 
-
 #: Timeout for blocking operations, in seconds.
 TIMEOUT = 10.0
 

--- a/traits_futures/tests/i_message_router_tests.py
+++ b/traits_futures/tests/i_message_router_tests.py
@@ -28,7 +28,6 @@ from traits.api import (
 from traits_futures.i_message_router import IMessageReceiver
 from traits_futures.i_parallel_context import IParallelContext
 
-
 #: Safety timeout, in seconds, for blocking operations, to prevent
 #: the test suite from blocking indefinitely if something goes wrong.
 SAFETY_TIMEOUT = 10.0

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -19,7 +19,6 @@ from traits.api import Event, HasStrictTraits
 from traits_futures.api import CANCELLED, submit_call, TraitsExecutor
 from traits_futures.toolkit_support import toolkit
 
-
 GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -32,7 +32,6 @@ from traits_futures.background_progress import submit_progress
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.wrappers import BackgroundTaskWrapper, FutureWrapper
 
-
 # Executor states.
 
 #: Executor is currently running (this is the initial state).

--- a/traits_futures/wx/gui_test_assistant.py
+++ b/traits_futures/wx/gui_test_assistant.py
@@ -14,7 +14,6 @@ Test support, providing the ability to run the event loop from tests.
 
 import wx
 
-
 #: Default timeout, in seconds
 TIMEOUT = 10.0
 

--- a/traits_futures/wx/pinger.py
+++ b/traits_futures/wx/pinger.py
@@ -17,7 +17,6 @@ the main thread execute a (fixed, parameterless) callback.
 
 import wx.lib.newevent
 
-
 # Note: we're not using the more obvious spelling
 #   _PingEvent, _PingEventBinder = wx.lib.newevent.NewEvent()
 # here because that confuses Sphinx's autodoc mocking.


### PR DESCRIPTION
This PR fixes import orders and groups. The fixes should be enough to make the style check pass in #285.

Note: most of this PR came from simply applying `isort` to the codebase. The changes in the example scripts were made manually.