### PR TITLE
Extend 'ci format' and 'ci style' checks to example directories

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -22,3 +22,5 @@ jobs:
       run: |
         python -m flake8
         python -m isort . --check --diff
+        python -m isort examples --check --diff
+        python -m isort docs/source/guide/examples --check --diff

--- a/ci/config.py
+++ b/ci/config.py
@@ -45,6 +45,14 @@ ROOT_DIR = os.path.abspath(".")
 PACKAGE_DIR = os.path.join(ROOT_DIR, PACKAGE_NAME)
 COVERAGE_DIR = os.path.join(ROOT_DIR, "coverage")
 
+# Directories containing isort configurations. We need to run isort
+# separately from each such directory.
+ISORT_ROOTS = [
+    ROOT_DIR,
+    os.path.join(ROOT_DIR, "examples"),
+    os.path.join(ROOT_DIR, "docs", "source", "guide", "examples"),
+]
+
 # Locations of data directories for the ci package.
 DATA = pkg_resources.resource_filename("ci", "data")
 

--- a/docs/source/guide/examples/.isort.cfg
+++ b/docs/source/guide/examples/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+profile = black
+sections = FUTURE,STDLIB,THIRDPARTY,ENTHOUGHT,FIRSTPARTY,LOCALFOLDER
+known_third_party = wx
+known_enthought = chaco,enable,pyface,traits,traits_futures,traitsui
+line_length = 79
+order_by_type = False

--- a/examples/.isort.cfg
+++ b/examples/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+profile = black
+sections = FUTURE,STDLIB,THIRDPARTY,ENTHOUGHT,FIRSTPARTY,LOCALFOLDER
+known_third_party = wx
+known_enthought = chaco,enable,pyface,traits,traits_futures,traitsui
+line_length = 79
+order_by_type = False


### PR DESCRIPTION
[Followup to #285]

The Python files in the example directories have different import-order needs from the main codebase: in the examples, `traits_futures` is just another ETS package, so `traits_futures.api` imports should be placed into the same sections as `traits` and `traitsui` imports. In the main codebase, `traits_futures` is the local package, so its imports come after `traits` and friends.

This PR adds local `isort` configuration files for the two example directories, and extends the `ci format` and `ci style` commands to use those configurations.