### PR TITLE
Fix appearance of copyright in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,17 +65,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Traits Futures"
-copyright = """\
-(C) Copyright 2018-2021 Enthought, Inc., Austin, TX
-All rights reserved.
-
-This software is provided without warranty under the terms of the BSD
-license included in LICENSE.txt and may be redistributed only under
-the conditions described in the aforementioned license. The license
-is also available online at http://www.enthought.com/licenses/BSD.txt
-
-Thanks for using Enthought open source!
-"""
+copyright = "2018-2021 Enthought, Inc., Austin, TX"
 author = "Enthought"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This PR fixes the appearance of the copyright statement at the bottom of each page of the rendered HTML documentation. The [Sphinx docs](https://www.sphinx-doc.org/en/master/usage/configuration.html) say that this should be "A copyright statement in the style '2008, Author Name'.", so we use that format.

Fixes #216 
