### PR TITLE
Adding logging for message routers

### DIFF
--- a/examples/slow_squares.py
+++ b/examples/slow_squares.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+import logging
 import random
 import time
 
@@ -151,5 +152,11 @@ class SquaringHelper(Handler):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format=(
+            "%(asctime)s %(levelname)-8.8s [%(name)s:%(lineno)s] %(message)s"
+        ),
+    )
     view = SquaringHelper()
     view.configure_traits()

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -249,6 +249,7 @@ class MultiprocessingRouter(HasRequiredTraits):
         self._monitor_thread.start()
 
         self._running = True
+        logger.debug(f"{self} started")
 
     def stop(self):
         """
@@ -271,7 +272,7 @@ class MultiprocessingRouter(HasRequiredTraits):
             raise RuntimeError("Router is not running")
 
         if self._receivers:
-            logger.warning("there are unclosed pipes")
+            logger.warning(f"{self} has {len(self._receivers)} unclosed pipes")
 
         # Shut everything down in reverse order.
         # First the monitor thread.
@@ -291,6 +292,7 @@ class MultiprocessingRouter(HasRequiredTraits):
         self._local_message_queue = None
 
         self._running = False
+        logger.debug(f"{self} stopped")
 
     def pipe(self):
         """
@@ -324,6 +326,9 @@ class MultiprocessingRouter(HasRequiredTraits):
         )
         receiver = MultiprocessingReceiver(connection_id=connection_id)
         self._receivers[connection_id] = receiver
+        logger.debug(
+            f"{self} created pipe #{connection_id} with receiver {receiver}"
+        )
         return sender, receiver
 
     def close_pipe(self, receiver):
@@ -350,6 +355,9 @@ class MultiprocessingRouter(HasRequiredTraits):
 
         connection_id = receiver.connection_id
         self._receivers.pop(connection_id)
+        logger.debug(
+            f"{self} closed pipe #{connection_id} with receiver {receiver}"
+        )
 
     # Public traits ###########################################################
 
@@ -387,8 +395,7 @@ class MultiprocessingRouter(HasRequiredTraits):
             receiver = self._receivers[connection_id]
         except KeyError:
             logger.warning(
-                f"No receiver for message with connection_id {connection_id}. "
-                "Message discarded."
+                f"{self} discarding message from closed pipe #{connection_id}."
             )
         else:
             receiver.message = message

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -203,6 +203,7 @@ class MultithreadingRouter(HasStrictTraits):
         self._pingee.connect()
 
         self._running = True
+        logger.debug(f"{self} started")
 
     def stop(self):
         """
@@ -225,7 +226,7 @@ class MultithreadingRouter(HasStrictTraits):
             raise RuntimeError("router is not running")
 
         if self._receivers:
-            logger.warning("there are unclosed pipes")
+            logger.warning(f"{self} has {len(self._receivers)} unclosed pipes")
 
         self._pingee.disconnect()
         self._pingee = None
@@ -233,6 +234,7 @@ class MultithreadingRouter(HasStrictTraits):
         self._message_queue = None
 
         self._running = False
+        logger.debug(f"{self} stopped")
 
     def pipe(self):
         """
@@ -266,6 +268,9 @@ class MultithreadingRouter(HasStrictTraits):
         )
         receiver = MultithreadingReceiver(connection_id=connection_id)
         self._receivers[connection_id] = receiver
+        logger.debug(
+            f"{self} created pipe #{connection_id} with receiver {receiver}"
+        )
         return sender, receiver
 
     def close_pipe(self, receiver):
@@ -292,6 +297,9 @@ class MultithreadingRouter(HasStrictTraits):
 
         connection_id = receiver.connection_id
         self._receivers.pop(connection_id)
+        logger.debug(
+            f"{self} closed pipe #{connection_id} with receiver {receiver}"
+        )
 
     # Private traits ##########################################################
 
@@ -318,8 +326,8 @@ class MultithreadingRouter(HasStrictTraits):
             receiver = self._receivers[connection_id]
         except KeyError:
             logger.warning(
-                f"No receiver for message with connection_id {connection_id}. "
-                "Message discarded."
+                f"{self} has no receiver for connection_id {connection_id}. "
+                "Discarding message."
             )
         else:
             receiver.message = message

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -326,8 +326,7 @@ class MultithreadingRouter(HasStrictTraits):
             receiver = self._receivers[connection_id]
         except KeyError:
             logger.warning(
-                f"{self} has no receiver for connection_id {connection_id}. "
-                "Discarding message."
+                f"{self} discarding message from closed pipe #{connection_id}."
             )
         else:
             receiver.message = message

--- a/traits_futures/tests/i_message_router_tests.py
+++ b/traits_futures/tests/i_message_router_tests.py
@@ -224,13 +224,8 @@ class IMessageRouterTests:
             with self.started_router() as router:
                 router.pipe()
 
-        self.assertTrue(
-            any(
-                "there are unclosed pipes" in log_message
-                for log_message in cm.output
-            ),
-            msg="Expected log message not found",
-        )
+        all_log_messages = "\n".join(cm.output)
+        self.assertIn("unclosed pipes", all_log_messages)
 
     def test_threads_cleaned_up(self):
         threads_before = threading.enumerate()
@@ -254,12 +249,9 @@ class IMessageRouterTests:
                 sender.send("some message")
                 sender.stop()
 
-            self.assertTrue(
-                any(
-                    "No receiver for message" in log_message
-                    for log_message in cm.output
-                ),
-                msg="Expected log message not found",
+            all_log_messages = "\n".join(cm.output)
+            self.assertIn(
+                "discarding message from closed pipe", all_log_messages
             )
 
     def test_sender_send_without_start(self):


### PR DESCRIPTION
This PR adds basic logging for message routers, and modifies one of the example scripts to make it easy to see the effect of that logging.

I'm deliberately not logging for every message sent / received; that would likely be too noisy. (For some applications, we could potentially have tens of such messages per second.)

Contributes to #24