### PR TITLE
Add Python 3.8 testing for cron job

### DIFF
--- a/.github/workflows/test-bleeding-edge.yml
+++ b/.github/workflows/test-bleeding-edge.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.9]
+        python-version: [3.6, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Our cron job currently tests on Python 3.6 and Python 3.9.  Internally we'll be running a lot of code on Python 3.8, so it makes sense to include that version, too, while keeping Python 3.9 so that we get alerted about possible issues with the bleeding edge version of Python. (At some point we'll likely replace the 3.9 run with a 3.10 run.)