### PR TITLE
Prevent task submission off the main thread

### DIFF
--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -75,6 +75,10 @@ from ``traits_futures.api``:
   format in the |ProgressFuture|, and then your application can choose how to
   interpret them.
 
+In the current version of Traits Futures, tasks may only be submitted from the
+main thread. An attempt to submit a task from a background thread will raise
+|RuntimeError|. This restriction may be removed in the future.
+
 
 Working with future objects
 ---------------------------
@@ -319,3 +323,5 @@ needed.
 .. |FAILED| replace:: :data:`~traits_futures.future_states.FAILED`
 .. |CANCELLING| replace:: :data:`~traits_futures.future_states.CANCELLING`
 .. |CANCELLED| replace:: :data:`~traits_futures.future_states.CANCELLED`
+
+.. |RuntimeError| replace:: :exc:`RuntimeError`

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -267,12 +267,14 @@ class TraitsExecutor(HasStrictTraits):
             self._message_router.close_pipe(receiver)
             raise
 
+        future_wrapper = FutureWrapper(future=future, receiver=receiver)
+        self._wrappers.add(future_wrapper)
+
         background_task_wrapper = BackgroundTaskWrapper(
             runner, sender, cancel_event
         )
-        wrapper = FutureWrapper(future=future, receiver=receiver)
         self._worker_pool.submit(background_task_wrapper)
-        self._wrappers.add(wrapper)
+
         logger.debug(f"{self} created future {future}")
         return future
 


### PR DESCRIPTION
We recently encountered hard-to-debug failures on a project; it eventually emerged that tasks were being submitted off the main thread, and with the current code, that's not supported. There are various potential issues, including that the internal state of the `TraitsExecutor` is not currently protected by locks, and that if Traits default methods (like the current `_message_router_default`) are invoked on a background thread, there are interesting failure modes (the message router is currently only designed to be instantiated on the main thread).

This PR raises an immediate exception on at attempt to submit a task from a background thread, so that we get an early clear failure rather than a late-discovered hard-to-debug intermittent failure.

EDIT: I've also tweaked the order of execution slightly in `TraitsExecutor.submit`, to ensure that the executor state (in this case, the `_wrappers` set) is always updated strictly before the background task starts executing. (In the project that motivated this issue, the actual failure mode we encountered was related to the background task executing before the executor state changes took effect.)

See also #302: we could relax this restriction at some point in the future if use-cases emerge.

Closes #301.