### PR TITLE
Add Pingee.pinger method

### DIFF
--- a/traits_futures/asyncio/pinger.py
+++ b/traits_futures/asyncio/pinger.py
@@ -54,6 +54,23 @@ class Pingee:
         """
         del self._event_loop
 
+    def pinger(self):
+        """
+        Create and return a new pinger linked to this pingee.
+
+        This method is thread-safe. Typically the pingee will be passed to
+        a background thread, and this method used within that background thread
+        to create a pinger.
+
+        This method should only be called on a connected pingee.
+
+        Returns
+        -------
+        pinger : Pinger
+            New pinger, linked to this pingee.
+        """
+        return Pinger(pingee=self)
+
 
 @IPinger.register
 class Pinger:

--- a/traits_futures/i_pingee.py
+++ b/traits_futures/i_pingee.py
@@ -52,6 +52,23 @@ class IPingee(abc.ABC):
         Not thread-safe. This method should only be called in the main thread.
         """
 
+    @abc.abstractmethod
+    def pinger(self):
+        """
+        Create and return a new pinger linked to this pingee.
+
+        This method is thread-safe. Typically the pingee will be passed to
+        a background thread, and this method used within that background thread
+        to create a pinger.
+
+        This method should only be called on a connected pingee.
+
+        Returns
+        -------
+        pinger : IPinger
+            New pinger, linked to this pingee.
+        """
+
 
 class IPinger(abc.ABC):
     """

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -79,7 +79,6 @@ from traits_futures.toolkit_support import toolkit
 logger = logging.getLogger(__name__)
 
 Pingee = toolkit("pinger:Pingee")
-Pinger = toolkit("pinger:Pinger")
 
 
 #: Internal states for the sender. The sender starts in the _INITIAL state,
@@ -427,7 +426,7 @@ def monitor_queue(process_queue, local_queue, pingee):
         a message pending.
 
     """
-    pinger = Pinger(pingee=pingee)
+    pinger = pingee.pinger()
     pinger.connect()
     try:
         while True:

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -40,7 +40,6 @@ from traits_futures.toolkit_support import toolkit
 logger = logging.getLogger(__name__)
 
 Pingee = toolkit("pinger:Pingee")
-Pinger = toolkit("pinger:Pinger")
 
 
 #: Internal states for the sender. The sender starts in the _INITIAL state,
@@ -74,7 +73,7 @@ class MultithreadingSender:
 
     def __init__(self, connection_id, pingee, message_queue):
         self.connection_id = connection_id
-        self.pinger = Pinger(pingee=pingee)
+        self.pinger = pingee.pinger()
         self.message_queue = message_queue
         self._state = _INITIAL
 

--- a/traits_futures/qt/pinger.py
+++ b/traits_futures/qt/pinger.py
@@ -67,6 +67,23 @@ class Pingee(QObject):
         """
         pass
 
+    def pinger(self):
+        """
+        Create and return a new pinger linked to this pingee.
+
+        This method is thread-safe. Typically the pingee will be passed to
+        a background thread, and this method used within that background thread
+        to create a pinger.
+
+        This method should only be called on a connected pingee.
+
+        Returns
+        -------
+        pinger : Pinger
+            New pinger, linked to this pingee.
+        """
+        return Pinger(pingee=self)
+
 
 @IPinger.register
 class Pinger:

--- a/traits_futures/tests/test_pinger.py
+++ b/traits_futures/tests/test_pinger.py
@@ -27,7 +27,6 @@ from traits_futures.toolkit_support import toolkit
 
 GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 Pingee = toolkit("pinger:Pingee")
-Pinger = toolkit("pinger:Pinger")
 
 #: Safety timeout, in seconds, for blocking operations, to prevent
 #: the test suite from blocking indefinitely if something goes wrong.
@@ -75,7 +74,7 @@ class BackgroundPinger:
         """
         request_queue = self.ping_request_queue
 
-        pinger = Pinger(self.pingee)
+        pinger = self.pingee.pinger()
         pinger.connect()
         try:
             while True:

--- a/traits_futures/tests/test_toolkit_support.py
+++ b/traits_futures/tests/test_toolkit_support.py
@@ -49,11 +49,10 @@ class TestToolkitSupport(unittest.TestCase):
         self.assertTrue(hasattr(test_assistant, "run_until"))
 
     def test_pinger_class(self):
-        Pinger = toolkit("pinger:Pinger")
         Pingee = toolkit("pinger:Pingee")
 
         pingee = Pingee(on_ping=lambda: None)
-        pinger = Pinger(pingee=pingee)
+        pinger = pingee.pinger()
         self.assertTrue(hasattr(pinger, "ping"))
 
     # Helper functions

--- a/traits_futures/wx/pinger.py
+++ b/traits_futures/wx/pinger.py
@@ -30,42 +30,6 @@ _PingEvent = _PingEventPair[0]
 _PingEventBinder = _PingEventPair[1]
 
 
-@IPinger.register
-class Pinger:
-    """
-    Ping emitter, which can send pings to a receiver in a thread-safe manner.
-
-    Parameters
-    ----------
-    pingee : Pingee
-        The target receiver for the pings. The receiver must already be
-        connected.
-    """
-
-    def __init__(self, pingee):
-        self.pingee = pingee
-
-    def connect(self):
-        """
-        Connect to the ping receiver. No pings should be sent until
-        this function is called.
-        """
-        pass
-
-    def disconnect(self):
-        """
-        Disconnect from the ping receiver. No pings should be sent
-        after calling this function.
-        """
-        pass
-
-    def ping(self):
-        """
-        Send a ping to the ping receiver.
-        """
-        wx.PostEvent(self.pingee, _PingEvent())
-
-
 @IPingee.register
 class Pingee(wx.EvtHandler):
     """
@@ -100,3 +64,56 @@ class Pingee(wx.EvtHandler):
         Undo any connections made in the connect method.
         """
         self.Unbind(_PingEventBinder, handler=self._on_ping)
+
+    def pinger(self):
+        """
+        Create and return a new pinger linked to this pingee.
+
+        This method is thread-safe. Typically the pingee will be passed to
+        a background thread, and this method used within that background thread
+        to create a pinger.
+
+        This method should only be called on a connected pingee.
+
+        Returns
+        -------
+        pinger : Pinger
+            New pinger, linked to this pingee.
+        """
+        return Pinger(pingee=self)
+
+
+@IPinger.register
+class Pinger:
+    """
+    Ping emitter, which can send pings to a receiver in a thread-safe manner.
+
+    Parameters
+    ----------
+    pingee : Pingee
+        The target receiver for the pings. The receiver must already be
+        connected.
+    """
+
+    def __init__(self, pingee):
+        self.pingee = pingee
+
+    def connect(self):
+        """
+        Connect to the ping receiver. No pings should be sent until
+        this function is called.
+        """
+        pass
+
+    def disconnect(self):
+        """
+        Disconnect from the ping receiver. No pings should be sent
+        after calling this function.
+        """
+        pass
+
+    def ping(self):
+        """
+        Send a ping to the ping receiver.
+        """
+        wx.PostEvent(self.pingee, _PingEvent())


### PR DESCRIPTION
This PR is a minor refactor of the pingee / pinger infrastructure: it adds a `pinger` method to the `Pingee` class.

The advantage of this is that previously, instantiating a `Pinger` required both knowledge of the toolkit and of the associated `Pingee`. With this PR, knowledge of the toolkit is no longer required. This is a step towards the changes in #299 that aim to remove the toolkit magic from the majority of the codebase.

The PR also contains a minor inconsistency fix: in the `wx` implementation, the `Pinger` class came before the `Pingee` class, while in all other implementations the order was reversed. This PR fixes the order in the `wx` implementation to match that elsewhere.

[Extracted from #299]