### PR TITLE
Extract toolkit-specific EventLoopHelper from the GuiTestAssistant

### DIFF
--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -14,20 +14,30 @@ Test support, providing the ability to run the event loop from tests.
 
 import asyncio
 
-#: Default timeout, in seconds
-TIMEOUT = 10.0
+from traits_futures.i_event_loop_helper import IEventLoopHelper
 
 
-class GuiTestAssistant:
-    def setUp(self):
+@IEventLoopHelper.register
+class EventLoopHelper:
+    """
+    Support for running the asyncio event loop in unit tests.
+    """
+
+    def init(self):
+        """
+        Prepare the event loop for use.
+        """
         asyncio.set_event_loop(asyncio.new_event_loop())
 
-    def tearDown(self):
+    def dispose(self):
+        """
+        Dispose of any resources used by this object.
+        """
         asyncio.get_event_loop().close()
 
-    def run_until(self, object, trait, condition, timeout=TIMEOUT):
+    def run_until(self, object, trait, condition, timeout):
         """
-        Run event loop until the given condition holds true, or until timeout.
+        Run event loop until a given condition occurs, or timeout.
 
         The condition is re-evaluated, with the object as argument, every time
         the trait changes.
@@ -41,9 +51,8 @@ class GuiTestAssistant:
         condition : callable
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
-        timeout : float, optional
+        timeout : float
             Number of seconds to allow before timing out with an exception.
-            The (somewhat arbitrary) default is 10 seconds.
 
         Raises
         ------
@@ -51,7 +60,6 @@ class GuiTestAssistant:
             If timeout is reached, regardless of whether the condition is
             true or not at that point.
         """
-
         timed_out = []
 
         event_loop = asyncio.get_event_loop()

--- a/traits_futures/i_event_loop_helper.py
+++ b/traits_futures/i_event_loop_helper.py
@@ -1,0 +1,70 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Interface for toolkit-specific event loop helper class.
+"""
+
+import abc
+
+
+class IEventLoopHelper(abc.ABC):
+    """
+    Interface for toolkit-specific event loop helper class.
+
+    An IEventLoopHelper instance provides a way to run the event loop
+    programmatically until a given condition occurs. Its primary use
+    is in testing.
+    """
+
+    def init(self):
+        """
+        Prepare the event loop for use.
+
+        This method is not thread-safe. It should always be called on the
+        main GUI thread.
+        """
+
+    def dispose(self):
+        """
+        Dispose of any resources used by this object.
+
+        This method is not thread-safe. It should always be called on the
+        main GUI thread.
+        """
+
+    def run_until(self, object, trait, condition, timeout):
+        """
+        Run event loop until a given condition occurs, or timeout.
+
+        The condition is re-evaluated, with the object as argument, every time
+        the trait changes.
+
+        This method is not thread-safe. It should always be called on the
+        main GUI thread.
+
+        Parameters
+        ----------
+        object : traits.has_traits.HasTraits
+            Object whose trait we monitor.
+        trait : str
+            Name of the trait to monitor for changes.
+        condition : callable
+            Single-argument callable, returning a boolean. This will be
+            called with *object* as the only input.
+        timeout : float
+            Number of seconds to allow before timing out with an exception.
+
+        Raises
+        ------
+        RuntimeError
+            If timeout is reached, regardless of whether the condition is
+            true or not at that point.
+        """

--- a/traits_futures/qt/event_loop_helper.py
+++ b/traits_futures/qt/event_loop_helper.py
@@ -15,21 +15,31 @@ Test support, providing the ability to run the event loop from tests.
 from pyface.qt.QtCore import QTimer
 from pyface.qt.QtGui import QApplication
 
-#: Default timeout, in seconds
-TIMEOUT = 10.0
+from traits_futures.i_event_loop_helper import IEventLoopHelper
 
 
-class GuiTestAssistant:
-    def setUp(self):
+@IEventLoopHelper.register
+class EventLoopHelper:
+    """
+    Support for running the Qt event loop in unit tests.
+    """
+
+    def init(self):
+        """
+        Prepare the event loop for use.
+        """
         qt_app = QApplication.instance()
         if qt_app is None:
             qt_app = QApplication([])
         self.qt_app = qt_app
 
-    def tearDown(self):
+    def dispose(self):
+        """
+        Dispose of any resources used by this object.
+        """
         del self.qt_app
 
-    def run_until(self, object, trait, condition, timeout=TIMEOUT):
+    def run_until(self, object, trait, condition, timeout):
         """
         Run event loop until the given condition holds true, or until timeout.
 
@@ -45,9 +55,8 @@ class GuiTestAssistant:
         condition : callable
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
-        timeout : float, optional
+        timeout : float
             Number of seconds to allow before timing out with an exception.
-            The (somewhat arbitrary) default is 10 seconds.
 
         Raises
         ------

--- a/traits_futures/testing/gui_test_assistant.py
+++ b/traits_futures/testing/gui_test_assistant.py
@@ -1,0 +1,70 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Test support, providing the ability to run the event loop from within tests.
+"""
+
+
+from traits_futures.toolkit_support import toolkit
+
+EventLoopHelper = toolkit("event_loop_helper:EventLoopHelper")
+
+#: Maximum timeout for blocking calls, in seconds. A successful test should
+#: never hit this timeout - it's there to prevent a failing test from hanging
+#: forever and blocking the rest of the test suite.
+SAFETY_TIMEOUT = 5.0
+
+
+class GuiTestAssistant:
+    """
+    Convenience mixin class for tests that need the event loop.
+
+    This class is designed to be used as a mixin alongside unittest.TestCase
+    for tests that need to run the event loop as part of the test.
+
+    Most of the logic is devolved to a toolkit-specific EventLoopHelper class.
+    """
+
+    def setUp(self):
+        self._event_loop_helper = EventLoopHelper()
+        self._event_loop_helper.init()
+
+    def tearDown(self):
+        self._event_loop_helper.dispose()
+        del self._event_loop_helper
+
+    def run_until(self, object, trait, condition, timeout=SAFETY_TIMEOUT):
+        """
+        Run event loop until the given condition holds true, or until timeout.
+
+        The condition is re-evaluated, with the object as argument, every time
+        the trait changes.
+
+        Parameters
+        ----------
+        object : traits.has_traits.HasTraits
+            Object whose trait we monitor.
+        trait : str
+            Name of the trait to monitor for changes.
+        condition : callable
+            Single-argument callable, returning a boolean. This will be
+            called with *object* as the only input.
+        timeout : float, optional
+            Number of seconds to allow before timing out with an exception.
+            The (somewhat arbitrary) default is 5 seconds.
+
+        Raises
+        ------
+        RuntimeError
+            If timeout is reached, regardless of whether the condition is
+            true or not at that point.
+        """
+        self._event_loop_helper.run_until(object, trait, condition, timeout)

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -13,11 +13,8 @@ import contextlib
 import unittest
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.background_call_tests import BackgroundCallTests
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
-
 
 #: Timeout for blocking operations, in seconds.
 TIMEOUT = 10.0

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -16,13 +16,10 @@ import contextlib
 import unittest
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.background_iteration_tests import (
     BackgroundIterationTests,
 )
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
-
 
 #: Timeout for blocking operations, in seconds.
 TIMEOUT = 10.0

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -16,13 +16,10 @@ import contextlib
 import unittest
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.background_progress_tests import (
     BackgroundProgressTests,
 )
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
-
 
 #: Timeout for blocking operations, in seconds.
 TIMEOUT = 10.0

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -17,9 +17,7 @@ import unittest
 from traits.api import Event, HasStrictTraits
 
 from traits_futures.api import CANCELLED, submit_call, TraitsExecutor
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 
 
 class Dummy(HasStrictTraits):

--- a/traits_futures/tests/test_multiprocessing_router.py
+++ b/traits_futures/tests/test_multiprocessing_router.py
@@ -15,10 +15,8 @@ Tests for the MultiprocessingRouter class.
 import unittest
 
 from traits_futures.multiprocessing_context import MultiprocessingContext
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 
 
 class TestMultiprocessingRouter(

--- a/traits_futures/tests/test_multithreading_router.py
+++ b/traits_futures/tests/test_multithreading_router.py
@@ -15,10 +15,8 @@ Tests for the MultithreadingRouter class.
 import unittest
 
 from traits_futures.multithreading_context import MultithreadingContext
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 
 
 class TestMultithreadingRouter(

--- a/traits_futures/tests/test_pinger.py
+++ b/traits_futures/tests/test_pinger.py
@@ -23,9 +23,9 @@ from traits.api import (
 )
 
 from traits_futures.i_pingee import IPingee
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.toolkit_support import toolkit
 
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 Pingee = toolkit("pinger:Pingee")
 
 #: Safety timeout, in seconds, for blocking operations, to prevent

--- a/traits_futures/tests/test_toolkit_support.py
+++ b/traits_futures/tests/test_toolkit_support.py
@@ -43,10 +43,10 @@ class TestToolkitSupport(unittest.TestCase):
         self.assertValidToolkitEntryPoint("qt")
         self.assertValidToolkitEntryPoint("qt4")
 
-    def test_gui_test_assistant(self):
-        GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
-        test_assistant = GuiTestAssistant()
-        self.assertTrue(hasattr(test_assistant, "run_until"))
+    def test_event_loop_helper(self):
+        EventLoopHelper = toolkit("event_loop_helper:EventLoopHelper")
+        event_loop_helper = EventLoopHelper()
+        self.assertTrue(hasattr(event_loop_helper, "run_until"))
 
     def test_pinger_class(self):
         Pingee = toolkit("pinger:Pingee")

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -17,13 +17,11 @@ import unittest
 from traits.api import Bool
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.traits_executor_tests import (
     ExecutorListener,
     TraitsExecutorTests,
 )
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 
 
 class TrackingTraitsExecutor(TraitsExecutor):

--- a/traits_futures/tests/test_traits_process_executor.py
+++ b/traits_futures/tests/test_traits_process_executor.py
@@ -19,13 +19,11 @@ from traits_futures.api import (
     MultithreadingContext,
     TraitsExecutor,
 )
+from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.tests.traits_executor_tests import (
     ExecutorListener,
     TraitsExecutorTests,
 )
-from traits_futures.toolkit_support import toolkit
-
-GuiTestAssistant = toolkit("gui_test_assistant:GuiTestAssistant")
 
 
 class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):

--- a/traits_futures/wx/event_loop_helper.py
+++ b/traits_futures/wx/event_loop_helper.py
@@ -14,14 +14,12 @@ Test support, providing the ability to run the event loop from tests.
 
 import wx
 
-#: Default timeout, in seconds
-TIMEOUT = 10.0
+from traits_futures.i_event_loop_helper import IEventLoopHelper
+
 
 # XXX We should be using Pyface's own CallbackTimer instead of creating
 # our own, but we were running into segfaults.
 # xref: enthought/pyface#815, enthought/traits-futures#251
-
-
 class TimeoutTimer(wx.Timer):
     """
     Single-shot timer that executes a given callback on completion.
@@ -103,19 +101,27 @@ class AppForTesting(wx.App):
         del self.frame
 
 
-class GuiTestAssistant:
+@IEventLoopHelper.register
+class EventLoopHelper:
     """
     Support for running the wx event loop in unit tests.
     """
 
-    def setUp(self):
+    def init(self):
+        """
+        Prepare the event loop for use.
+        """
+        # Running tests requires that there's a visible application.
         self.wx_app = AppForTesting()
 
-    def tearDown(self):
+    def dispose(self):
+        """
+        Dispose of any resources used by this object.
+        """
         self.wx_app.close()
         del self.wx_app
 
-    def run_until(self, object, trait, condition, timeout=TIMEOUT):
+    def run_until(self, object, trait, condition, timeout):
         """
         Run event loop until the given condition holds true, or until timeout.
 
@@ -131,9 +137,8 @@ class GuiTestAssistant:
         condition : callable
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
-        timeout : float, optional
+        timeout : float
             Number of seconds to allow before timing out with an exception.
-            The (somewhat arbitrary) default is 10 seconds.
 
         Raises
         ------


### PR DESCRIPTION
Context: This is another incremental step towards the changes in #299. There are many more steps to go, including renaming. I'm avoiding renaming in this PR in an effort to keep the individual PRs reviewable.

This PR extracts a toolkit-specific `EventLoopHelper` class from the `GuiTestAssistant`, and makes the `GuiTestAssistant` non-toolkit specific.

There are various rationales:

- The `EventLoopHelper` can potentially be used outside a test context, or in more refined ways within tests.
- This allows the toolkit resolution in the `GuiTestAssistant` to be moved (in a future PR) to runtime rather than import time, which will eventually allow us to run tests for both the asyncio and Qt backends in a single test run.