### PR TITLE
Always instantiate Pinger on the thread it'll be used on

### DIFF
--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -73,9 +73,10 @@ class MultithreadingSender:
 
     def __init__(self, connection_id, pingee, message_queue):
         self.connection_id = connection_id
-        self.pinger = pingee.pinger()
+        self.pingee = pingee
         self.message_queue = message_queue
         self._state = _INITIAL
+        self.pinger = None
 
     def start(self):
         """
@@ -97,6 +98,7 @@ class MultithreadingSender:
                 f"Sender already started: state is {self._state}"
             )
 
+        self.pinger = self.pingee.pinger()
         self.pinger.connect()
 
         self._state = _OPEN
@@ -148,6 +150,7 @@ class MultithreadingSender:
             )
 
         self.pinger.disconnect()
+        self.pinger = None
 
         self._state = _CLOSED
 


### PR DESCRIPTION
This PR fixes an inconsistency with `Pinger` instantiation. For the multiprocessing context and the tests, the `Pinger` is always instantiated on the worker thread. For the multithreading context, it's instantiated in the main thread and then used in the worker thread. There are toolkits where the thread affinity could potentially matter, so this PR changes the code to always instantiate the `Pinger` on the worker thread on which it'll be used.