### PR TITLE
Refactor: pull up ETSContext

### DIFF
--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -15,6 +15,7 @@ Context providing multiprocessing-friendly worker pools, events, and routers.
 import concurrent.futures
 import multiprocessing
 
+from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multiprocessing_router import MultiprocessingRouter
 
@@ -25,11 +26,15 @@ class MultiprocessingContext(IParallelContext):
 
     Parameters
     ----------
-    gui_context : IGuiContext
+    gui_context : IGuiContext, optional
         GUI context to use for interactions with the GUI event loop.
+        If not given, an :class:`ETSContext` instance is used.
     """
 
-    def __init__(self, gui_context):
+    def __init__(self, gui_context=None):
+        if gui_context is None:
+            gui_context = ETSContext()
+
         self._closed = False
         self._gui_context = gui_context
         self._manager = multiprocessing.Manager()

--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -15,6 +15,7 @@ Context providing multiprocessing-friendly worker pools, events, and routers.
 import concurrent.futures
 import multiprocessing
 
+from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multiprocessing_router import MultiprocessingRouter
 
@@ -26,6 +27,7 @@ class MultiprocessingContext(IParallelContext):
 
     def __init__(self):
         self._closed = False
+        self._gui_context = ETSContext()
         self._manager = multiprocessing.Manager()
 
     def worker_pool(self, *, max_workers=None):
@@ -63,7 +65,10 @@ class MultiprocessingContext(IParallelContext):
         -------
         message_router : MultiprocessingRouter
         """
-        return MultiprocessingRouter(manager=self._manager)
+        return MultiprocessingRouter(
+            gui_context=self._gui_context,
+            manager=self._manager,
+        )
 
     def close(self):
         """

--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -15,7 +15,6 @@ Context providing multiprocessing-friendly worker pools, events, and routers.
 import concurrent.futures
 import multiprocessing
 
-from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multiprocessing_router import MultiprocessingRouter
 
@@ -23,11 +22,16 @@ from traits_futures.multiprocessing_router import MultiprocessingRouter
 class MultiprocessingContext(IParallelContext):
     """
     Context for multiprocessing, suitable for use with the TraitsExecutor.
+
+    Parameters
+    ----------
+    gui_context : IGuiContext
+        GUI context to use for interactions with the GUI event loop.
     """
 
-    def __init__(self):
+    def __init__(self, gui_context):
         self._closed = False
-        self._gui_context = ETSContext()
+        self._gui_context = gui_context
         self._manager = multiprocessing.Manager()
 
     def worker_pool(self, *, max_workers=None):

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -68,7 +68,6 @@ from traits.api import (
     provides,
 )
 
-from traits_futures.ets_context import ETSContext
 from traits_futures.i_gui_context import IGuiContext
 from traits_futures.i_message_router import (
     IMessageReceiver,
@@ -210,8 +209,11 @@ class MultiprocessingRouter(HasRequiredTraits):
 
     Parameters
     ----------
+    gui_context : IGuiContext
+        GUI context to use for interactions with the GUI event loop.
     manager : multiprocessing.Manager
         Manager to be used for creating the shared-process queue.
+
     """
 
     def start(self):
@@ -234,9 +236,7 @@ class MultiprocessingRouter(HasRequiredTraits):
         self._local_message_queue = queue.Queue()
         self._process_message_queue = self.manager.Queue()
 
-        self._gui_context = ETSContext()
-
-        self._pingee = self._gui_context.pingee(on_ping=self._route_message)
+        self._pingee = self.gui_context.pingee(on_ping=self._route_message)
         self._pingee.connect()
 
         self._monitor_thread = threading.Thread(
@@ -362,14 +362,13 @@ class MultiprocessingRouter(HasRequiredTraits):
 
     # Public traits ###########################################################
 
+    #: GUI context to use for interactions with the GUI event loop.
+    gui_context = Instance(IGuiContext)
+
     #: Manager, used to create message queues.
     manager = Instance(multiprocessing.managers.BaseManager, required=True)
 
     # Private traits ##########################################################
-
-    #: GUI context, providing the appropriate ping mechanism for the GUI
-    #: event loop.
-    _gui_context = Instance(IGuiContext)
 
     #: Queue receiving messages from child processes.
     _process_message_queue = Any()

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -69,6 +69,7 @@ from traits.api import (
 )
 
 from traits_futures.ets_context import ETSContext
+from traits_futures.i_gui_context import IGuiContext
 from traits_futures.i_message_router import (
     IMessageReceiver,
     IMessageRouter,
@@ -77,8 +78,6 @@ from traits_futures.i_message_router import (
 from traits_futures.i_pingee import IPingee
 
 logger = logging.getLogger(__name__)
-
-gui_context = ETSContext()
 
 
 #: Internal states for the sender. The sender starts in the _INITIAL state,
@@ -235,7 +234,9 @@ class MultiprocessingRouter(HasRequiredTraits):
         self._local_message_queue = queue.Queue()
         self._process_message_queue = self.manager.Queue()
 
-        self._pingee = gui_context.pingee(on_ping=self._route_message)
+        self._gui_context = ETSContext()
+
+        self._pingee = self._gui_context.pingee(on_ping=self._route_message)
         self._pingee.connect()
 
         self._monitor_thread = threading.Thread(
@@ -365,6 +366,10 @@ class MultiprocessingRouter(HasRequiredTraits):
     manager = Instance(multiprocessing.managers.BaseManager, required=True)
 
     # Private traits ##########################################################
+
+    #: GUI context, providing the appropriate ping mechanism for the GUI
+    #: event loop.
+    _gui_context = Instance(IGuiContext)
 
     #: Queue receiving messages from child processes.
     _process_message_queue = Any()

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -213,7 +213,6 @@ class MultiprocessingRouter(HasRequiredTraits):
         GUI context to use for interactions with the GUI event loop.
     manager : multiprocessing.Manager
         Manager to be used for creating the shared-process queue.
-
     """
 
     def start(self):
@@ -363,7 +362,7 @@ class MultiprocessingRouter(HasRequiredTraits):
     # Public traits ###########################################################
 
     #: GUI context to use for interactions with the GUI event loop.
-    gui_context = Instance(IGuiContext)
+    gui_context = Instance(IGuiContext, required=True)
 
     #: Manager, used to create message queues.
     manager = Instance(multiprocessing.managers.BaseManager, required=True)

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -15,7 +15,6 @@ Context providing multithreading-friendly worker pools, events, and routers.
 import concurrent.futures
 import threading
 
-from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multithreading_router import MultithreadingRouter
 
@@ -23,11 +22,16 @@ from traits_futures.multithreading_router import MultithreadingRouter
 class MultithreadingContext(IParallelContext):
     """
     Context for multithreading, suitable for use with the TraitsExecutor.
+
+    Parameters
+    ----------
+    gui_context : IGuiContext
+        GUI context to use for interactions with the GUI event loop.
     """
 
-    def __init__(self):
+    def __init__(self, gui_context):
         self._closed = False
-        self._gui_context = ETSContext()
+        self._gui_context = gui_context
 
     def worker_pool(self, *, max_workers=None):
         """

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -15,6 +15,7 @@ Context providing multithreading-friendly worker pools, events, and routers.
 import concurrent.futures
 import threading
 
+from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multithreading_router import MultithreadingRouter
 
@@ -25,11 +26,15 @@ class MultithreadingContext(IParallelContext):
 
     Parameters
     ----------
-    gui_context : IGuiContext
+    gui_context : IGuiContext, optional
         GUI context to use for interactions with the GUI event loop.
+        If not given, an :class:`ETSContext` instance is used.
     """
 
-    def __init__(self, gui_context):
+    def __init__(self, gui_context=None):
+        if gui_context is None:
+            gui_context = ETSContext()
+
         self._closed = False
         self._gui_context = gui_context
 

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -15,6 +15,7 @@ Context providing multithreading-friendly worker pools, events, and routers.
 import concurrent.futures
 import threading
 
+from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multithreading_router import MultithreadingRouter
 
@@ -26,6 +27,7 @@ class MultithreadingContext(IParallelContext):
 
     def __init__(self):
         self._closed = False
+        self._gui_context = ETSContext()
 
     def worker_pool(self, *, max_workers=None):
         """
@@ -62,7 +64,7 @@ class MultithreadingContext(IParallelContext):
         -------
         message_router : MultithreadingRouter
         """
-        return MultithreadingRouter()
+        return MultithreadingRouter(gui_context=self._gui_context)
 
     def close(self):
         """

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -23,13 +23,13 @@ from traits.api import (
     Bool,
     Dict,
     Event,
+    HasRequiredTraits,
     HasStrictTraits,
     Instance,
     Int,
     provides,
 )
 
-from traits_futures.ets_context import ETSContext
 from traits_futures.i_gui_context import IGuiContext
 from traits_futures.i_message_router import (
     IMessageReceiver,
@@ -176,10 +176,16 @@ class MultithreadingReceiver(HasStrictTraits):
 
 
 @provides(IMessageRouter)
-class MultithreadingRouter(HasStrictTraits):
+class MultithreadingRouter(HasRequiredTraits):
     """
     Implementation of the IMessageRouter interface for the case where the
     sender will be in a background thread.
+
+    Parameters
+    ----------
+    gui_context : IGuiContext
+        GUI context to use for interactions with the GUI event loop.
+
     """
 
     def start(self):
@@ -201,9 +207,7 @@ class MultithreadingRouter(HasStrictTraits):
 
         self._message_queue = queue.Queue()
 
-        self._gui_context = ETSContext()
-
-        self._pingee = self._gui_context.pingee(on_ping=self._route_message)
+        self._pingee = self.gui_context.pingee(on_ping=self._route_message)
         self._pingee.connect()
 
         self._running = True
@@ -305,11 +309,12 @@ class MultithreadingRouter(HasStrictTraits):
             f"{self} closed pipe #{connection_id} with receiver {receiver}"
         )
 
-    # Private traits ##########################################################
+    # Public traits ###########################################################
 
-    #: GUI context, providing the appropriate ping mechanism for the GUI
-    #: event loop.
-    _gui_context = Instance(IGuiContext)
+    #: GUI context to use for interactions with the GUI event loop.
+    gui_context = Instance(IGuiContext)
+
+    # Private traits ##########################################################
 
     #: Internal queue for messages from all senders.
     _message_queue = Instance(queue.Queue)

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -312,7 +312,7 @@ class MultithreadingRouter(HasRequiredTraits):
     # Public traits ###########################################################
 
     #: GUI context to use for interactions with the GUI event loop.
-    gui_context = Instance(IGuiContext)
+    gui_context = Instance(IGuiContext, required=True)
 
     # Private traits ##########################################################
 

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -30,6 +30,7 @@ from traits.api import (
 )
 
 from traits_futures.ets_context import ETSContext
+from traits_futures.i_gui_context import IGuiContext
 from traits_futures.i_message_router import (
     IMessageReceiver,
     IMessageRouter,
@@ -38,8 +39,6 @@ from traits_futures.i_message_router import (
 from traits_futures.i_pingee import IPingee
 
 logger = logging.getLogger(__name__)
-
-gui_context = ETSContext()
 
 
 #: Internal states for the sender. The sender starts in the _INITIAL state,
@@ -202,7 +201,9 @@ class MultithreadingRouter(HasStrictTraits):
 
         self._message_queue = queue.Queue()
 
-        self._pingee = gui_context.pingee(on_ping=self._route_message)
+        self._gui_context = ETSContext()
+
+        self._pingee = self._gui_context.pingee(on_ping=self._route_message)
         self._pingee.connect()
 
         self._running = True
@@ -305,6 +306,10 @@ class MultithreadingRouter(HasStrictTraits):
         )
 
     # Private traits ##########################################################
+
+    #: GUI context, providing the appropriate ping mechanism for the GUI
+    #: event loop.
+    _gui_context = Instance(IGuiContext)
 
     #: Internal queue for messages from all senders.
     _message_queue = Instance(queue.Queue)

--- a/traits_futures/testing/gui_test_assistant.py
+++ b/traits_futures/testing/gui_test_assistant.py
@@ -15,8 +15,6 @@ Test support, providing the ability to run the event loop from within tests.
 
 from traits_futures.ets_context import ETSContext
 
-gui_context = ETSContext()
-
 #: Maximum timeout for blocking calls, in seconds. A successful test should
 #: never hit this timeout - it's there to prevent a failing test from hanging
 #: forever and blocking the rest of the test suite.
@@ -34,12 +32,14 @@ class GuiTestAssistant:
     """
 
     def setUp(self):
-        self._event_loop_helper = gui_context.event_loop_helper()
+        self._gui_context = ETSContext()
+        self._event_loop_helper = self._gui_context.event_loop_helper()
         self._event_loop_helper.init()
 
     def tearDown(self):
         self._event_loop_helper.dispose()
         del self._event_loop_helper
+        del self._gui_context
 
     def run_until(self, object, trait, condition, timeout=SAFETY_TIMEOUT):
         """

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -25,7 +25,7 @@ class TestBackgroundCall(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultithreadingContext()
+        self._context = MultithreadingContext(gui_context=self._gui_context)
         self.executor = TraitsExecutor(context=self._context)
 
     def tearDown(self):

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -30,7 +30,7 @@ class TestBackgroundIteration(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultithreadingContext()
+        self._context = MultithreadingContext(gui_context=self._gui_context)
         self.executor = TraitsExecutor(context=self._context)
 
     def tearDown(self):

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -30,7 +30,7 @@ class TestBackgroundProgress(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultithreadingContext()
+        self._context = MultithreadingContext(gui_context=self._gui_context)
         self.executor = TraitsExecutor(context=self._context)
 
     def tearDown(self):

--- a/traits_futures/tests/test_multiprocessing_router.py
+++ b/traits_futures/tests/test_multiprocessing_router.py
@@ -27,7 +27,8 @@ class TestMultiprocessingRouter(
     """
 
     #: Factory providing the parallelism context
-    context_factory = MultiprocessingContext
+    def context_factory(self):
+        return MultiprocessingContext(gui_context=self._gui_context)
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/traits_futures/tests/test_multithreading_router.py
+++ b/traits_futures/tests/test_multithreading_router.py
@@ -27,7 +27,8 @@ class TestMultithreadingRouter(
     """
 
     #: Factory providing the parallelism context
-    context_factory = MultithreadingContext
+    def context_factory(self):
+        return MultithreadingContext(gui_context=self._gui_context)
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -48,7 +48,7 @@ class TrackingTraitsExecutor(TraitsExecutor):
 class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultithreadingContext()
+        self._context = MultithreadingContext(gui_context=self._gui_context)
 
     def tearDown(self):
         self._context.close()
@@ -74,7 +74,7 @@ class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
             self.assertIsInstance(executor._context, MultithreadingContext)
 
     def test_externally_supplied_context(self):
-        context = MultithreadingContext()
+        context = MultithreadingContext(gui_context=self._gui_context)
         try:
             with self.temporary_executor(context=context) as executor:
                 self.assertIs(executor._context, context)
@@ -176,7 +176,7 @@ class TestTraitsExecutor(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultithreadingContext()
+        self._context = MultithreadingContext(gui_context=self._gui_context)
         self.executor = TraitsExecutor(context=self._context)
         self.listener = ExecutorListener(executor=self.executor)
 

--- a/traits_futures/tests/test_traits_process_executor.py
+++ b/traits_futures/tests/test_traits_process_executor.py
@@ -29,7 +29,7 @@ from traits_futures.tests.traits_executor_tests import (
 class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultiprocessingContext()
+        self._context = MultiprocessingContext(gui_context=self._gui_context)
 
     def tearDown(self):
         if hasattr(self, "executor"):
@@ -59,7 +59,7 @@ class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
             self.assertIsInstance(executor._context, MultithreadingContext)
 
     def test_externally_supplied_context(self):
-        context = MultiprocessingContext()
+        context = MultiprocessingContext(gui_context=self._gui_context)
         try:
             with self.temporary_executor(context=context) as executor:
                 self.assertIs(executor._context, context)
@@ -144,7 +144,7 @@ class TestTraitsExecutor(
 ):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self._context = MultiprocessingContext()
+        self._context = MultiprocessingContext(gui_context=self._gui_context)
         self.executor = TraitsExecutor(context=self._context)
         self.listener = ExecutorListener(executor=self.executor)
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -31,7 +31,6 @@ from traits.api import (
 from traits_futures.background_call import submit_call
 from traits_futures.background_iteration import submit_iteration
 from traits_futures.background_progress import submit_progress
-from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.wrappers import BackgroundTaskWrapper, FutureWrapper
 
@@ -359,7 +358,7 @@ class TraitsExecutor(HasStrictTraits):
         # By default, we use multithreading
         from traits_futures.multithreading_context import MultithreadingContext
 
-        context = MultithreadingContext(gui_context=ETSContext())
+        context = MultithreadingContext()
         self._own_context = True
         return context
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -31,6 +31,7 @@ from traits.api import (
 from traits_futures.background_call import submit_call
 from traits_futures.background_iteration import submit_iteration
 from traits_futures.background_progress import submit_progress
+from traits_futures.ets_context import ETSContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.wrappers import BackgroundTaskWrapper, FutureWrapper
 
@@ -358,7 +359,7 @@ class TraitsExecutor(HasStrictTraits):
         # By default, we use multithreading
         from traits_futures.multithreading_context import MultithreadingContext
 
-        context = MultithreadingContext()
+        context = MultithreadingContext(gui_context=ETSContext())
         self._own_context = True
         return context
 


### PR DESCRIPTION
This PR refactors to remove most module-level uses of `ETSContext`, and to allow multiple `TraitsExecutor`s using different GUI toolkits to co-exist in the same process.

In detail:
- The `MultithreadingRouter` and `MultiprocessingRouter` classes now require an instance of `IGuiContext` to be supplied at creation time.
- The `MultithreadingContext` and `MultiprocessingContext` classes now take an optional `gui_context` argument; if that argument is not given, then they use the lazy `ETSContext`
- The GUI context in the `MultithreadingContext` is passed down to the `MultithreadingRouter` on creation; similarly for the multiprocessing variants
- The `GuiTestAssistant` creates an `ETSContext` instance in its `setUp`, and uses it for tests. A future PR will extend this so that different contexts can be used when using the `GuiTestAssistant`

There's a remaining module-level use of `ETSContext` in the tests for the `Pinger` and `Pingee` classes; that will be fixed in a separate PR.