### PR TITLE
Add tests for each of the IEventLoopHelper implementations

### DIFF
--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -35,6 +35,29 @@ class EventLoopHelper:
         """
         asyncio.get_event_loop().close()
 
+    def setattr_soon(self, obj, name, value):
+        """
+        Arrange for an attribute to be set once the event loop is running.
+
+        In typical usage, *obj* will be a ``HasTraits`` instance and
+        *name* will be the name of a trait on *obj*.
+
+        This method is not thread-safe. It's designed to be called
+        from the main thread.
+
+        Parameters
+        ----------
+        obj : object
+            Object to set the given attribute on.
+        name : str
+            Name of the attribute to set; typically this is
+            a traited attribute.
+        value : object
+            Value to set the attribute to.
+        """
+        event_loop = asyncio.get_event_loop()
+        event_loop.call_soon(setattr, obj, name, value)
+
     def run_until(self, object, trait, condition, timeout):
         """
         Run event loop until a given condition occurs, or timeout.

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -1,0 +1,26 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the asyncio implementation of IEventLoopHelper.
+"""
+
+import unittest
+
+from traits_futures.asyncio.event_loop_helper import EventLoopHelper
+from traits_futures.tests.i_event_loop_helper_tests import (
+    IEventLoopHelperTests,
+)
+
+
+class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
+
+    #: Zero-parameter callable that creates an instance of the EventLoopHelper.
+    event_loop_helper_factory = EventLoopHelper

--- a/traits_futures/i_event_loop_helper.py
+++ b/traits_futures/i_event_loop_helper.py
@@ -24,6 +24,7 @@ class IEventLoopHelper(abc.ABC):
     is in testing.
     """
 
+    @abc.abstractmethod
     def init(self):
         """
         Prepare the event loop for use.
@@ -32,6 +33,7 @@ class IEventLoopHelper(abc.ABC):
         main GUI thread.
         """
 
+    @abc.abstractmethod
     def dispose(self):
         """
         Dispose of any resources used by this object.
@@ -40,6 +42,29 @@ class IEventLoopHelper(abc.ABC):
         main GUI thread.
         """
 
+    @abc.abstractmethod
+    def setattr_soon(self, obj, name, value):
+        """
+        Arrange for an attribute to be set once the event loop is running.
+
+        In typical usage, *obj* will be a ``HasTraits`` instance and
+        *name* will be the name of a trait on *obj*.
+
+        This method is not thread-safe. It's designed to be called
+        from the main thread.
+
+        Parameters
+        ----------
+        obj : object
+            Object to set the given attribute on.
+        name : str
+            Name of the attribute to set; typically this is
+            a traited attribute.
+        value : object
+            Value to set the attribute to.
+        """
+
+    @abc.abstractmethod
     def run_until(self, object, trait, condition, timeout):
         """
         Run event loop until a given condition occurs, or timeout.

--- a/traits_futures/qt/event_loop_helper.py
+++ b/traits_futures/qt/event_loop_helper.py
@@ -20,8 +20,8 @@ from traits_futures.i_event_loop_helper import IEventLoopHelper
 
 class AttributeSetter(QObject):
     """
-    Simple QObject
-
+    Simple QObject that allows us to set object attributes from with
+    a running event loop.
     """
 
     @Slot(object, str, object)
@@ -31,7 +31,7 @@ class AttributeSetter(QObject):
         """
         setattr(obj, name, value)
 
-    #: Signal used to trigger attribute sets.
+    #: Signal used to trigger setattr operations.
     setattr = Signal(object, str, object)
 
 

--- a/traits_futures/qt/tests/test_event_loop_helper.py
+++ b/traits_futures/qt/tests/test_event_loop_helper.py
@@ -1,0 +1,29 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the Qt implementation of IEventLoopHelper.
+"""
+
+import unittest
+
+from traits_futures.testing.optional_dependencies import requires_qt
+from traits_futures.tests.i_event_loop_helper_tests import (
+    IEventLoopHelperTests,
+)
+
+
+@requires_qt
+class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
+    def event_loop_helper_factory(self):
+        """ Create an instance of the EventLoopHelper for testing. """
+        from traits_futures.qt.event_loop_helper import EventLoopHelper
+
+        return EventLoopHelper()

--- a/traits_futures/tests/i_event_loop_helper_tests.py
+++ b/traits_futures/tests/i_event_loop_helper_tests.py
@@ -1,0 +1,119 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Test mixin for testing IEventLoopHelper implementations.
+"""
+
+import contextlib
+
+from traits.api import Bool, Event, HasStrictTraits, Int, on_trait_change
+
+from traits_futures.i_event_loop_helper import IEventLoopHelper
+
+
+class HasFlag(HasStrictTraits):
+    #: Simple true/false flag
+    flag = Bool()
+
+    #: Simple event, with no payload
+    ping = Event()
+
+    #: Counter for number of pings received.
+    ping_count = Int()
+
+    @on_trait_change("ping")
+    def increment_ping_count(self):
+        self.ping_count += 1
+
+
+class IEventLoopHelperTests:
+    """
+    Mixin for testing IEventLoopHelper implementations.
+    """
+
+    def test_instance_of_i_event_loop_helper(self):
+        event_loop_helper = self.event_loop_helper_factory()
+        self.assertIsInstance(event_loop_helper, IEventLoopHelper)
+
+    def test_run_until_when_condition_becomes_true(self):
+        with self.initialised_event_loop_helper() as event_loop:
+
+            # Given
+            obj = HasFlag(flag=False)
+
+            # When
+            event_loop.setattr_soon(obj, "flag", True)
+
+            # Then
+            self.assertFalse(obj.flag)
+            event_loop.run_until(
+                obj, "flag", lambda obj: obj.flag, timeout=5.0
+            )
+            self.assertTrue(obj.flag)
+
+    def test_run_until_when_condition_never_true(self):
+        with self.initialised_event_loop_helper() as event_loop:
+
+            # Given
+            obj = HasFlag(flag=False)
+
+            # Then
+            self.assertFalse(obj.flag)
+            with self.assertRaises(RuntimeError):
+                event_loop.run_until(
+                    obj, "flag", lambda obj: obj.flag, timeout=0.1
+                )
+            self.assertFalse(obj.flag)
+
+    def test_run_until_when_condition_already_true(self):
+        with self.initialised_event_loop_helper() as event_loop:
+
+            # Given
+            obj = HasFlag(flag=True)
+
+            # Then
+            event_loop.run_until(
+                obj, "flag", lambda obj: obj.flag, timeout=5.0
+            )
+            self.assertTrue(obj.flag)
+
+    def test_run_until_with_nontrivial_condition(self):
+        with self.initialised_event_loop_helper() as event_loop:
+
+            # Given
+            obj = HasFlag(flag=False)
+
+            # When
+            event_loop.setattr_soon(obj, "ping", True)
+            event_loop.setattr_soon(obj, "ping", True)
+            event_loop.setattr_soon(obj, "ping", True)
+
+            # Then
+            self.assertFalse(obj.flag)
+            event_loop.run_until(
+                obj, "ping_count", lambda obj: obj.ping_count >= 3, timeout=5.0
+            )
+            self.assertEqual(obj.ping_count, 3)
+
+    @contextlib.contextmanager
+    def initialised_event_loop_helper(self):
+        """
+        Context manager that provides an initialised event loop helper.
+
+        The event loop helper is properly shut down on exit of the
+        corresponding with block.
+        """
+        event_loop_helper = self.event_loop_helper_factory()
+        event_loop_helper.init()
+        try:
+            yield event_loop_helper
+        finally:
+            event_loop_helper.dispose()

--- a/traits_futures/wx/event_loop_helper.py
+++ b/traits_futures/wx/event_loop_helper.py
@@ -16,6 +16,16 @@ import wx.lib.newevent
 
 from traits_futures.i_event_loop_helper import IEventLoopHelper
 
+# Note: we're not using the more obvious spelling
+#   _SetattrEvent, _SetattrEventBinder = wx.lib.newevent.NewEvent()
+# here because that confuses Sphinx's autodoc mocking.
+# Ref: enthought/traits-futures#263.
+
+#: New event type to be used for signalling attribute set operations.
+_SetattrEventPair = wx.lib.newevent.NewEvent()
+_SetattrEvent = _SetattrEventPair[0]
+_SetattrEventBinder = _SetattrEventPair[1]
+
 
 # XXX We should be using Pyface's own CallbackTimer instead of creating
 # our own, but we were running into segfaults.
@@ -101,18 +111,12 @@ class AppForTesting(wx.App):
         del self.frame
 
 
-# Note: we're not using the more obvious spelling
-#   _SetattrEvent, _SetattrEventBinder = wx.lib.newevent.NewEvent()
-# here because that confuses Sphinx's autodoc mocking.
-# Ref: enthought/traits-futures#263.
-
-#: New event type to be used for signalling attribute set operations.
-_SetattrEventPair = wx.lib.newevent.NewEvent()
-_SetattrEvent = _SetattrEventPair[0]
-_SetattrEventBinder = _SetattrEventPair[1]
-
-
 class AttributeSetter(wx.EvtHandler):
+    """
+    Event handler that allows us to set object attributes from with
+    a running event loop.
+    """
+
     def _on_setattr(self, event):
         setattr(event.obj, event.name, event.value)
 

--- a/traits_futures/wx/tests/test_event_loop_helper.py
+++ b/traits_futures/wx/tests/test_event_loop_helper.py
@@ -1,0 +1,29 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Tests for the wx implementation of IEventLoopHelper.
+"""
+
+import unittest
+
+from traits_futures.testing.optional_dependencies import requires_wx
+from traits_futures.tests.i_event_loop_helper_tests import (
+    IEventLoopHelperTests,
+)
+
+
+@requires_wx
+class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
+    def event_loop_helper_factory(self):
+        """ Create an instance of the EventLoopHelper for testing. """
+        from traits_futures.wx.event_loop_helper import EventLoopHelper
+
+        return EventLoopHelper()


### PR DESCRIPTION
The goal of this PR is to add tests for each of the `EventLoopHelper` implementations, so that all relevant implementations of `EventLoopHelper` are tested by the test run. Before this PR, only the `EventLoopHelper` for the "current" toolkit was tested, via `test_gui_test_assistant`.

To test the event loop helper effectively, we also need general machinery to set a trait from within a running event loop. I've added a new method `IEventLoopHelper.setattr_soon` for that, following the same naming convention that `asyncio` uses (`call_soon`).

We also fix an omission in the `IEventLoopHelper` interface, namely that the abstract methods weren't decorated with `abc.abstractmethod`.