### PR TITLE
Use the asyncio context by default for testing

### DIFF
--- a/traits_futures/testing/gui_test_assistant.py
+++ b/traits_futures/testing/gui_test_assistant.py
@@ -13,7 +13,7 @@ Test support, providing the ability to run the event loop from within tests.
 """
 
 
-from traits_futures.ets_context import ETSContext
+from traits_futures.asyncio.context import AsyncioContext
 
 #: Maximum timeout for blocking calls, in seconds. A successful test should
 #: never hit this timeout - it's there to prevent a failing test from hanging
@@ -34,7 +34,7 @@ class GuiTestAssistant:
     #: Factory for the GUI context. This should be a zero-argument callable
     #: that provides an IGuiContext instance. Override in subclasses to
     #: run tests with a particular toolkit.
-    gui_context_factory = ETSContext
+    gui_context_factory = AsyncioContext
 
     def setUp(self):
         self._gui_context = self.gui_context_factory()

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -16,7 +16,12 @@ import unittest
 
 from traits.api import Event, HasStrictTraits
 
-from traits_futures.api import CANCELLED, submit_call, TraitsExecutor
+from traits_futures.api import (
+    CANCELLED,
+    MultithreadingContext,
+    submit_call,
+    TraitsExecutor,
+)
 from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 
 
@@ -60,7 +65,9 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
 
     def test_run_until_timeout_trait_fired(self):
         # Trait fired, but condition still never true.
-        executor = TraitsExecutor()
+        executor = TraitsExecutor(
+            context=MultithreadingContext(gui_context=self._gui_context)
+        )
         future = submit_call(executor, int, "111")
         start_time = time.monotonic()
         with self.assertRaises(RuntimeError):
@@ -97,7 +104,9 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
 
     def test_run_until_success(self):
         # Trait fired, condition starts false but becomes true.
-        executor = TraitsExecutor()
+        executor = TraitsExecutor(
+            context=MultithreadingContext(gui_context=self._gui_context)
+        )
 
         # Case 1: condition true on second trait change event.
         future = submit_call(executor, slow_return)


### PR DESCRIPTION
This PR changes the default context for the `GuiTestAssistant` to the one backed by `asyncio`; previously, it depended on `ETSContext`, whose behaviour in turn depended on the system context (particularly, the value of the `ETS_TOOLKIT` environment variable).

With this PR, the test run is no longer affected by the `ETS_TOOLKIT` environment variable. Instead, the Qt and Wx tests are run if and only if the corresponding toolkits are available. (And yes, in theory, this means that we could try to run both the Qt and Wx tests in the same test run. In practice, this went badly when I tried it: there was a hanging test, and I haven't yet figured out what went wrong.)