### PR TITLE
Re-blacken the source

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -424,7 +424,7 @@ def _get_devenv(edm, python_version, toolkit):
 
 
 def _remove_readonly(func, path, _):
-    """ Clear the readonly bit and reattempt the removal """
+    """Clear the readonly bit and reattempt the removal"""
     os.chmod(path, stat.S_IWRITE)
     func(path)
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -424,7 +424,7 @@ def _get_devenv(edm, python_version, toolkit):
 
 
 def _remove_readonly(func, path, _):
-    """Clear the readonly bit and reattempt the removal"""
+    """Clear the readonly bit and reattempt the removal."""
     os.chmod(path, stat.S_IWRITE)
     func(path)
 

--- a/ci/python_environment.py
+++ b/ci/python_environment.py
@@ -20,7 +20,7 @@ MINIMUM_EDM_VERSION = 1, 6, 0
 
 
 class PythonEnvironment:
-    """ A Python Environment provisioned by edm. """
+    """A Python Environment provisioned by edm."""
 
     def __init__(
         self,

--- a/docs/source/examples/quick_start.py
+++ b/docs/source/examples/quick_start.py
@@ -26,7 +26,7 @@ from traits_futures.api import CallFuture, submit_call, TraitsExecutor
 
 
 def slow_square(n):
-    """ Square the given input, slowly. """
+    """Square the given input, slowly."""
     time.sleep(5.0)
     return n * n
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import find_packages, setup
 
 
 def get_version_info():
-    """ Extract version information as a dictionary from version.py. """
+    """Extract version information as a dictionary from version.py."""
     version_info = {}
     version_filename = os.path.join("traits_futures", "version.py")
     with open(version_filename, "r", encoding="utf-8") as version_module:
@@ -24,7 +24,7 @@ def get_version_info():
 
 
 def get_long_description():
-    """ Read long description from README.rst. """
+    """Read long description from README.rst."""
     with open("README.rst", "r", encoding="utf-8") as readme:
         return readme.read()
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -366,19 +366,19 @@ class BaseFuture(HasStrictTraits):
     # Private methods #########################################################
 
     def _get_state(self):
-        """ Property getter for the "state" trait. """
+        """Property getter for the "state" trait."""
         return _INTERNAL_STATE_TO_STATE[self._internal_state]
 
     def _get_cancellable(self):
-        """ Property getter for the "cancellable" trait. """
+        """Property getter for the "cancellable" trait."""
         return self._internal_state in _CANCELLABLE_INTERNAL_STATES
 
     def _get_done(self):
-        """ Property getter for the "done" trait. """
+        """Property getter for the "done" trait."""
         return self._internal_state in _DONE_INTERNAL_STATES
 
     def __internal_state_changed(self, old_internal_state, new_internal_state):
-        """ Trait change handler for the "_internal_state" trait. """
+        """Trait change handler for the "_internal_state" trait."""
         old_state = _INTERNAL_STATE_TO_STATE[old_internal_state]
         new_state = _INTERNAL_STATE_TO_STATE[new_internal_state]
         if old_state != new_state:

--- a/traits_futures/qt/tests/test_context.py
+++ b/traits_futures/qt/tests/test_context.py
@@ -22,7 +22,7 @@ from traits_futures.tests.i_gui_context_tests import IGuiContextTests
 @requires_qt
 class TestQtContext(IGuiContextTests, unittest.TestCase):
     def context_factory(self):
-        """ Factory for instances of the context. """
+        """Factory for instances of the context."""
         from traits_futures.qt.context import QtContext
 
         return QtContext()

--- a/traits_futures/qt/tests/test_event_loop_helper.py
+++ b/traits_futures/qt/tests/test_event_loop_helper.py
@@ -23,7 +23,7 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 @requires_qt
 class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
     def event_loop_helper_factory(self):
-        """ Create an instance of the EventLoopHelper for testing. """
+        """Create an instance of the EventLoopHelper for testing."""
         from traits_futures.qt.event_loop_helper import EventLoopHelper
 
         return EventLoopHelper()

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -67,7 +67,7 @@ class CallFutureListener(HasStrictTraits):
 
 
 class BackgroundCallTests:
-    """ Mixin class containing tests for the background call. """
+    """Mixin class containing tests for the background call."""
 
     def test_successful_call(self):
         future = submit_call(self.executor, pow, 2, 3)

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -26,7 +26,7 @@ def dummy_cancel_callback():
 
 
 class FutureListener(HasStrictTraits):
-    """ Record state changes to a given future. """
+    """Record state changes to a given future."""
 
     #: The future that we're listening to.
     future = Any()
@@ -56,7 +56,7 @@ class CommonFutureTests:
         states = []
 
         def record_states():
-            """ Record the future's state and derived traits. """
+            """Record the future's state and derived traits."""
             states.append((future.state, future.cancellable, future.done))
 
         # Record state when any of the three traits changes.
@@ -181,7 +181,7 @@ class CommonFutureTests:
         self.assertIsInstance(future, IFuture)
 
     def send_message(self, future, message):
-        """ Send a particular message to a future. """
+        """Send a particular message to a future."""
         if message == "I":
             future._executor_initialized(dummy_cancel_callback)
         elif message == "S":
@@ -195,7 +195,7 @@ class CommonFutureTests:
             future._user_cancelled()
 
     def send_message_sequence(self, messages):
-        """ Create a new future, and send the given message sequence to it. """
+        """Create a new future, and send the given message sequence to it."""
         future = self.future_class()
         for message in messages:
             self.send_message(future, message)

--- a/traits_futures/tests/i_gui_context_tests.py
+++ b/traits_futures/tests/i_gui_context_tests.py
@@ -16,7 +16,7 @@ from traits_futures.i_pingee import IPingee
 
 
 class IGuiContextTests:
-    """ Mixin providing tests for implementations of IGuiContext. """
+    """Mixin providing tests for implementations of IGuiContext."""
 
     #: Override this in subclasses.
     context_factory = IGuiContext

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -47,23 +47,23 @@ SAFETY_TIMEOUT = 5.0
 
 
 def test_call(*args, **kwds):
-    """ Simple test target for submit_call. """
+    """Simple test target for submit_call."""
     return args, kwds
 
 
 def test_iteration(*args, **kwargs):
-    """ Simple test target for submit_iteration. """
+    """Simple test target for submit_iteration."""
     yield args
     yield kwargs
 
 
 def test_progress(arg1, arg2, kwd1, kwd2, progress):
-    """ Simple test target for submit_progress. """
+    """Simple test target for submit_progress."""
     return arg1, arg2, kwd1, kwd2
 
 
 class ExecutorListener(HasStrictTraits):
-    """ Listener for executor state changes. """
+    """Listener for executor state changes."""
 
     #: Executor that we're listening to.
     executor = Instance(TraitsExecutor)

--- a/traits_futures/wx/tests/test_context.py
+++ b/traits_futures/wx/tests/test_context.py
@@ -24,7 +24,7 @@ class TestWxContext(IGuiContextTests, unittest.TestCase):
 
     #: Factory for instances of the context
     def context_factory(self):
-        """ Factory for instances of the context. """
+        """Factory for instances of the context."""
         from traits_futures.wx.context import WxContext
 
         return WxContext()

--- a/traits_futures/wx/tests/test_event_loop_helper.py
+++ b/traits_futures/wx/tests/test_event_loop_helper.py
@@ -23,7 +23,7 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 @requires_wx
 class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
     def event_loop_helper_factory(self):
-        """ Create an instance of the EventLoopHelper for testing. """
+        """Create an instance of the EventLoopHelper for testing."""
         from traits_futures.wx.event_loop_helper import EventLoopHelper
 
         return EventLoopHelper()


### PR DESCRIPTION
This PR re-applies the latest version of `black` (version 21.5b1) to the codebase, which has the effect of modifying the spacing in one-line docstrings.

There's also a drive-by missing period fix.

I'm holding off on adding a `black --check` step to the GitHub Actions workflow until EDM's version of `black` has caught up: right now, the EDM version of `black` (19.10b0) makes significant changes to the codebase. Traits Futures developers need to be able to work with the version of `black` from EDM.