### PR TITLE
Doc: remove copyright headers from code literalincludes

### DIFF
--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -152,6 +152,8 @@ Putting everything together, here's an example GUI that makes use of the new
 background task type:
 
 .. literalinclude:: examples/fizz_buzz_ui.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 
 ..

--- a/docs/source/guide/cancel.rst
+++ b/docs/source/guide/cancel.rst
@@ -64,6 +64,8 @@ however, that the GUI will remain responsive and usable during those seconds.
 Here's a complete TraitsUI application that demonstrates this behaviour.
 
 .. literalinclude:: examples/non_interruptible_task.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 However, with two simple changes, we can allow the ``approximate_pi`` function
 to cancel mid-calculation. Those two changes are:
@@ -144,6 +146,8 @@ Here's a version of the approximation code that yields partial results at each
 Here's a complete TraitsUI example making use of the above.
 
 .. literalinclude:: examples/interruptible_task.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 ..
    substitutions

--- a/docs/source/guide/contexts.rst
+++ b/docs/source/guide/contexts.rst
@@ -46,6 +46,8 @@ a multiprocessing context::
 Here's a complete TraitsUI example that makes use of this.
 
 .. literalinclude:: examples/background_processes.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 
 ..

--- a/docs/source/guide/overview.rst
+++ b/docs/source/guide/overview.rst
@@ -50,6 +50,8 @@ wrapper for a slow calculation. In this case, the slowness is simulated via a
 call to :func:`time.sleep`.
 
 .. literalinclude:: examples/calculate_in_main_thread.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 When you run this code, you should see a dialog that looks something like
 this (modulo platform-specific styling differences):
@@ -95,6 +97,8 @@ dispatches squaring jobs to a background thread. Unlike the previous version,
 the GUI remains responsive and usable while a background job is executing.
 
 .. literalinclude:: examples/calculate_in_worker_thread.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 When you try this code, it may work perfectly for you, or it may crash with a
 segmentation fault. Or it may work perfectly during all your testing and only

--- a/docs/source/guide/testing.rst
+++ b/docs/source/guide/testing.rst
@@ -29,6 +29,8 @@ An example test
 Here's an example of testing a simple future.
 
 .. literalinclude:: examples/test_future.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 Some points of interest in the above example:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,6 +56,8 @@ a background computation when its "Calculate" button is pressed, and shows the
 result when it arrives.
 
 .. literalinclude:: examples/quick_start.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 
 User Guide


### PR DESCRIPTION
This PR skips the copyright headers in Python files included as documentation in the source.

For an example of how those headers currently appear, see the example in the "Quick Start" section of the main page of the documentation: https://docs.enthought.com/traits-futures/0.2/index.html#quick-start