### PR TITLE
Flesh out last section of the overview

### DIFF
--- a/docs/source/guide/overview.rst
+++ b/docs/source/guide/overview.rst
@@ -143,6 +143,20 @@ differences are:
   updated on the main thread, so that listeners attached to those traits do
   not need to be thread safe.
 
+The effect is that, with a little bit of care, the GUI code can monitor the
+"future" object for changes as with any other traited object, and can avoid
+concerning itself with thread-safety and other threading-related issues. This
+helps to avoid a class of concurrency-related pitfalls when developing the GUI.
+
+Note however that there is a price to be paid for this safety and convenience:
+the relevant traits on the future object can only be updated when the GUI event
+loop is running, so Traits Futures fundamentally relies on the existence of a
+running event loop. For a running GUI application, this is of course not a
+problem, but unit tests will need to find a way to run the event loop in order
+to receive expected updates from background tasks, and some care can be needed
+during application shutdown.
+
+
 .. rubric:: Footnotes
 
 .. [#f1]

--- a/docs/source/guide/overview.rst
+++ b/docs/source/guide/overview.rst
@@ -154,7 +154,7 @@ loop is running, so Traits Futures fundamentally relies on the existence of a
 running event loop. For a running GUI application, this is of course not a
 problem, but unit tests will need to find a way to run the event loop in order
 to receive expected updates from background tasks, and some care can be needed
-during application shutdown. See the :ref:`testing` section for some hints on
+during application shutdown. See the :ref:`guide_testing` section for some hints on
 writing unit tests for code that uses Traits Futures.
 
 

--- a/docs/source/guide/overview.rst
+++ b/docs/source/guide/overview.rst
@@ -154,7 +154,8 @@ loop is running, so Traits Futures fundamentally relies on the existence of a
 running event loop. For a running GUI application, this is of course not a
 problem, but unit tests will need to find a way to run the event loop in order
 to receive expected updates from background tasks, and some care can be needed
-during application shutdown.
+during application shutdown. See the :ref:`testing` section for some hints on
+writing unit tests for code that uses Traits Futures.
 
 
 .. rubric:: Footnotes

--- a/docs/source/guide/testing.rst
+++ b/docs/source/guide/testing.rst
@@ -10,6 +10,8 @@
    Thanks for using Enthought open source!
 
 
+.. _testing:
+
 Testing Traits Futures code
 ===========================
 

--- a/docs/source/guide/testing.rst
+++ b/docs/source/guide/testing.rst
@@ -10,7 +10,7 @@
    Thanks for using Enthought open source!
 
 
-.. _testing:
+.. _guide_testing:
 
 Testing Traits Futures code
 ===========================


### PR DESCRIPTION
The new overview section of the documentation introduced in #325 ended rather abruptly, mostly because I wanted to get a PR in. This PR fleshes out that last section slightly.