### PR TITLE
Don't try to use a new event loop for every test

### DIFF
--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -27,13 +27,13 @@ class EventLoopHelper:
         """
         Prepare the event loop for use.
         """
-        asyncio.set_event_loop(asyncio.new_event_loop())
+        self._event_loop = asyncio.get_event_loop()
 
     def dispose(self):
         """
         Dispose of any resources used by this object.
         """
-        asyncio.get_event_loop().close()
+        self._event_loop = None
 
     def setattr_soon(self, obj, name, value):
         """
@@ -55,8 +55,7 @@ class EventLoopHelper:
         value : object
             Value to set the attribute to.
         """
-        event_loop = asyncio.get_event_loop()
-        event_loop.call_soon(setattr, obj, name, value)
+        self._event_loop.call_soon(setattr, obj, name, value)
 
     def run_until(self, object, trait, condition, timeout):
         """
@@ -85,7 +84,7 @@ class EventLoopHelper:
         """
         timed_out = []
 
-        event_loop = asyncio.get_event_loop()
+        event_loop = self._event_loop
 
         def stop_on_timeout():
             timed_out.append(True)


### PR DESCRIPTION
Currently when testing with asyncio we attempt to create a fresh event loop for each test. This was a piece of defensive programming, aimed at avoiding accidental interactions between different unit tests via the shared state of the current event loop.

However, in doing this we're fighting the way that asyncio is designed (with the event loop being implicitly and lazily created on first use, and having no way to tell whether an event loop has already been created or not), and we end up debugging spurious resource warnings from unclosed event loops. It seems to be simpler to accept the more natural asyncio workflow of having a single main-thread event loop that's active from the time it's first accessed until the end of the process.