### PR TITLE
Move event loop to AsyncioContext

### DIFF
--- a/traits_futures/asyncio/context.py
+++ b/traits_futures/asyncio/context.py
@@ -52,4 +52,4 @@ class AsyncioContext:
         -------
         event_loop_helper : IEventLoopHelper
         """
-        return EventLoopHelper()
+        return EventLoopHelper(event_loop=self._event_loop)

--- a/traits_futures/asyncio/context.py
+++ b/traits_futures/asyncio/context.py
@@ -11,6 +11,8 @@
 """
 IGuiContext implementation for the main-thread asyncio event loop.
 """
+import asyncio
+
 from traits_futures.asyncio.event_loop_helper import EventLoopHelper
 from traits_futures.asyncio.pingee import Pingee
 from traits_futures.i_gui_context import IGuiContext
@@ -21,6 +23,9 @@ class AsyncioContext:
     """
     IGuiContext implementation for the main-thread asyncio event loop.
     """
+
+    def __init__(self):
+        self._event_loop = asyncio.get_event_loop()
 
     def pingee(self, on_ping):
         """
@@ -37,7 +42,7 @@ class AsyncioContext:
         -------
         pingee : IPingee
         """
-        return Pingee(on_ping=on_ping)
+        return Pingee(on_ping=on_ping, event_loop=self._event_loop)
 
     def event_loop_helper(self):
         """

--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -12,8 +12,6 @@
 Test support, providing the ability to run the event loop from tests.
 """
 
-import asyncio
-
 from traits_futures.i_event_loop_helper import IEventLoopHelper
 
 
@@ -21,13 +19,21 @@ from traits_futures.i_event_loop_helper import IEventLoopHelper
 class EventLoopHelper:
     """
     Support for running the asyncio event loop in unit tests.
+
+    Parameters
+    ----------
+    event_loop : asyncio.events.AbstractEventLoop
+        The asyncio event loop that this object wraps.
     """
+
+    def __init__(self, event_loop):
+        self._event_loop = event_loop
 
     def init(self):
         """
         Prepare the event loop for use.
         """
-        self._event_loop = asyncio.get_event_loop()
+        pass
 
     def dispose(self):
         """

--- a/traits_futures/asyncio/pingee.py
+++ b/traits_futures/asyncio/pingee.py
@@ -15,8 +15,6 @@ This module provides a way for a background thread to request that
 the main thread execute a (fixed, parameterless) callback.
 """
 
-import asyncio
-
 from traits_futures.i_pingee import IPingee, IPinger
 
 
@@ -37,16 +35,20 @@ class Pingee:
     on_ping : callable
         Zero-argument callable that's called on the main thread
         every time a ping is received.
+    event_loop : asyncio.events.AbstractEventLoop
+        The asyncio event loop that pings will be sent to.
+
     """
 
-    def __init__(self, on_ping):
+    def __init__(self, on_ping, event_loop):
         self._on_ping = on_ping
+        self._event_loop = event_loop
 
     def connect(self):
         """
         Prepare Pingee to receive pings.
         """
-        self._event_loop = asyncio.get_event_loop()
+        pass
 
     def disconnect(self):
         """

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -12,15 +12,17 @@
 Tests for the asyncio implementation of IEventLoopHelper.
 """
 
+import asyncio
 import unittest
 
+from traits_futures.asyncio.context import AsyncioContext
 from traits_futures.asyncio.event_loop_helper import EventLoopHelper
 from traits_futures.tests.i_event_loop_helper_tests import (
     IEventLoopHelperTests,
 )
 
 
-class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
+class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
 
-    #: Zero-parameter callable that creates an instance of the EventLoopHelper.
-    event_loop_helper_factory = EventLoopHelper
+    #: Zero-parameter callable that creates a suitable IGuiContext instance.
+    gui_context_factory = AsyncioContext

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -12,11 +12,9 @@
 Tests for the asyncio implementation of IEventLoopHelper.
 """
 
-import asyncio
 import unittest
 
 from traits_futures.asyncio.context import AsyncioContext
-from traits_futures.asyncio.event_loop_helper import EventLoopHelper
 from traits_futures.tests.i_event_loop_helper_tests import (
     IEventLoopHelperTests,
 )

--- a/traits_futures/qt/tests/test_event_loop_helper.py
+++ b/traits_futures/qt/tests/test_event_loop_helper.py
@@ -21,9 +21,10 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 
 
 @requires_qt
-class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
-    def event_loop_helper_factory(self):
-        """Create an instance of the EventLoopHelper for testing."""
-        from traits_futures.qt.event_loop_helper import EventLoopHelper
+class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
 
-        return EventLoopHelper()
+    def gui_context_factory(self):
+        """ Create a suitable IGuiContext instance. """
+        from traits_futures.qt.context import QtContext
+
+        return QtContext()

--- a/traits_futures/qt/tests/test_event_loop_helper.py
+++ b/traits_futures/qt/tests/test_event_loop_helper.py
@@ -22,9 +22,8 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 
 @requires_qt
 class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
-
     def gui_context_factory(self):
-        """ Create a suitable IGuiContext instance. """
+        """Create a suitable IGuiContext instance."""
         from traits_futures.qt.context import QtContext
 
         return QtContext()

--- a/traits_futures/tests/i_event_loop_helper_tests.py
+++ b/traits_futures/tests/i_event_loop_helper_tests.py
@@ -37,10 +37,25 @@ class HasFlag(HasStrictTraits):
 class IEventLoopHelperTests:
     """
     Mixin for testing IEventLoopHelper implementations.
+
+    Unlike other similar gui-context-specific test helpers, this mixin
+    should *not* be used alongside the GuiTestAssistant: it's testing
+    the foundations that the GuiTestAssistant is built on.
     """
 
+    #: Factory for the GUI context. This should be a zero-argument callable
+    #: that provides an IGuiContext instance. Must be overridden in subclasses
+    #: to run these tests with a particular toolkit.
+    gui_context_factory = None
+
+    def setUp(self):
+        self._gui_context = self.gui_context_factory()
+
+    def tearDown(self):
+        del self._gui_context
+
     def test_instance_of_i_event_loop_helper(self):
-        event_loop_helper = self.event_loop_helper_factory()
+        event_loop_helper = self._gui_context.event_loop_helper()
         self.assertIsInstance(event_loop_helper, IEventLoopHelper)
 
     def test_run_until_when_condition_becomes_true(self):
@@ -111,7 +126,7 @@ class IEventLoopHelperTests:
         The event loop helper is properly shut down on exit of the
         corresponding with block.
         """
-        event_loop_helper = self.event_loop_helper_factory()
+        event_loop_helper = self._gui_context.event_loop_helper()
         event_loop_helper.init()
         try:
             yield event_loop_helper

--- a/traits_futures/wx/tests/test_event_loop_helper.py
+++ b/traits_futures/wx/tests/test_event_loop_helper.py
@@ -21,9 +21,10 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 
 
 @requires_wx
-class TestEventLoopHelper(unittest.TestCase, IEventLoopHelperTests):
-    def event_loop_helper_factory(self):
-        """Create an instance of the EventLoopHelper for testing."""
-        from traits_futures.wx.event_loop_helper import EventLoopHelper
+class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
 
-        return EventLoopHelper()
+    def gui_context_factory(self):
+        """ Create a suitable IGuiContext instance. """
+        from traits_futures.wx.context import WxContext
+
+        return WxContext()

--- a/traits_futures/wx/tests/test_event_loop_helper.py
+++ b/traits_futures/wx/tests/test_event_loop_helper.py
@@ -22,9 +22,8 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 
 @requires_wx
 class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
-
     def gui_context_factory(self):
-        """ Create a suitable IGuiContext instance. """
+        """Create a suitable IGuiContext instance."""
         from traits_futures.wx.context import WxContext
 
         return WxContext()


### PR DESCRIPTION
For asyncio, the event loop used by the Pingee and by the EventLoopHelper need to be the same event loop; the event loop really belongs to the context.

This PR:
- pushes the event loop up to the `AsyncioContext`, and passes it from there to the `Pingee` and `EventLoopHelper`; this way we're only using `asyncio.get_event_loop` in a single place.
- reworks the tests for the `EventLoopHelper` to use a factory for the GUI context rather than a factory for the event loop helper. This way the tests are creating the `EventLoopHelper` in the same way that the `EventLoopHelper` is created elsewhere.
