### PR TITLE
Fix temporal coupling between Pingee and Pinger

### DIFF
--- a/traits_futures/asyncio/pingee.py
+++ b/traits_futures/asyncio/pingee.py
@@ -59,7 +59,7 @@ class Pingee:
 
     def disconnect(self):
         """
-        Undo any connections made in the connect method.
+        Disconnect from the on_ping callable.
         """
         del self._on_ping
 
@@ -71,7 +71,8 @@ class Pingee:
         a background thread, and this method used within that background thread
         to create a pinger.
 
-        This method should only be called on a connected pingee.
+        This method should only be called after the 'connect' method has
+        been called.
 
         Returns
         -------

--- a/traits_futures/i_pingee.py
+++ b/traits_futures/i_pingee.py
@@ -47,7 +47,9 @@ class IPingee(abc.ABC):
     @abc.abstractmethod
     def disconnect(self):
         """
-        Undo any connections made in the connect method.
+        Disconnect from the on_ping callable.
+
+        Pings that are received after this method is called will be ignored.
 
         Not thread-safe. This method should only be called in the main thread.
         """
@@ -61,7 +63,8 @@ class IPingee(abc.ABC):
         a background thread, and this method used within that background thread
         to create a pinger.
 
-        This method should only be called on a connected pingee.
+        This method should only be called after the 'connect' method has
+        been called.
 
         Returns
         -------

--- a/traits_futures/qt/pingee.py
+++ b/traits_futures/qt/pingee.py
@@ -65,7 +65,7 @@ class Pingee(QObject):
 
     def disconnect(self):
         """
-        Undo any connections made in the connect method.
+        Disconnect from the on_ping callable.
         """
         del self._on_ping
 
@@ -77,7 +77,8 @@ class Pingee(QObject):
         a background thread, and this method used within that background thread
         to create a pinger.
 
-        This method should only be called on a connected pingee.
+        This method should only be called after the 'connect' method has
+        been called.
 
         Returns
         -------

--- a/traits_futures/qt/pingee.py
+++ b/traits_futures/qt/pingee.py
@@ -53,7 +53,9 @@ class Pingee(QObject):
 
     @Slot()
     def _execute_ping_callback(self):
-        self._on_ping()
+        callback = getattr(self, "_on_ping", None)
+        if callback is not None:
+            callback()
 
     def connect(self):
         """
@@ -65,7 +67,7 @@ class Pingee(QObject):
         """
         Undo any connections made in the connect method.
         """
-        pass
+        del self._on_ping
 
     def pinger(self):
         """

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -183,7 +183,7 @@ class IPingeeTests:
             ready = threading.Event()
             pinger_thread = threading.Thread(
                 target=send_delayed_ping,
-                args=(pingee, ready)
+                args=(pingee, ready),
             )
             pinger_thread.start()
 

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -154,13 +154,12 @@ class IPingeeTests:
     def test_ping_after_pingee_closed(self):
         def send_delayed_ping(pingee, ready):
             """
-            Simulate delayed creation of Pinger.
+            Simulate delayed creation and use of Pinger.
             """
             ready.wait(timeout=SAFETY_TIMEOUT)
             pinger = pingee.pinger()
             pinger.connect()
             try:
-                ready.wait(timeout=SAFETY_TIMEOUT)
                 pinger.ping()
             finally:
                 pinger.disconnect()
@@ -174,6 +173,7 @@ class IPingeeTests:
             )
             pinger_thread.start()
 
+        # Unblock the Pinger creation.
         ready.set()
 
         # There shouldn't be any ping-related activity queued on the event

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -24,19 +24,6 @@ from traits.api import Bool, Event, HasStrictTraits, Int
 SAFETY_TIMEOUT = 5.0
 
 
-# XXX Lifetime issue:
-# - 1. Pingee created in main thread.
-# - 2. Pingee passed to background thread
-# - 3. Pingee disconnected in main thread
-# - 4. (sometime later) Pinger created in background thread
-
-# How is the background thread to know that the Pingee has been disconnected?
-# It can't. So it's not reasonable to say that "pinger" can only be called
-# for a connected pingee - it should be callable for _any_ pingee.
-
-# How to set this up for asyncio?
-
-
 class BackgroundPinger:
     """
     Object allowing pings to be sent from a background thread to a given

--- a/traits_futures/wx/pingee.py
+++ b/traits_futures/wx/pingee.py
@@ -64,6 +64,7 @@ class Pingee(wx.EvtHandler):
         Undo any connections made in the connect method.
         """
         self.Unbind(_PingEventBinder, handler=self._on_ping)
+        del self._on_ping
 
     def pinger(self):
         """

--- a/traits_futures/wx/pingee.py
+++ b/traits_futures/wx/pingee.py
@@ -61,7 +61,7 @@ class Pingee(wx.EvtHandler):
 
     def disconnect(self):
         """
-        Undo any connections made in the connect method.
+        Disconnect from the on_ping callable.
         """
         self.Unbind(_PingEventBinder, handler=self._on_ping)
         del self._on_ping
@@ -74,7 +74,8 @@ class Pingee(wx.EvtHandler):
         a background thread, and this method used within that background thread
         to create a pinger.
 
-        This method should only be called on a connected pingee.
+        This method should only be called after the 'connect' method has
+        been called.
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes an issue in communication between a Pingee and an associated Pinger: if a Pinger continues to send pings after the "disconnect" method of the Pingee has been called, then the behaviour was ill-defined and differed from toolkit to toolkit.

With this PR,

- a Pinger can still be created after the Pingee.disconnect method has been called, and
- the Pinger can still send a ping after the Pingee.disconnect method has been called, but
- that ping will have no effect

To explain why the first bullet point above is important: the usual workflow is that:

- a `Pingee` object is created in the main thread
- that `Pingee` object is passed to background worker threads
- the `Pinger` object is created via the pingee's `pinger` method in the worker thread

It's possible (albeit unlikely in normal use) that timing could be such that the `Pinger` creation occurs after the main thread decides we're done with the `Pingee`, and has called the `Pingee.disconnect` method.

We can either have the `Pinger` check whether the `Pingee` is still connected, which introduces a need for cross-thread synchronization, or we fix things up so that it's legal to create a `Pinger` after the `Pingee` is disconnected. This PR takes the second option.

Fixes #329

