### PR TITLE
Don't call stop on a STOPPING executor

### DIFF
--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -185,8 +185,9 @@ class TestTraitsExecutor(
 
     def tearDown(self):
         del self.listener
-        if not self.executor.stopped:
+        if self.executor.running:
             self.executor.stop()
+        if not self.executor.stopped:
             self.wait_until_stopped(self.executor)
         del self.executor
         self._context.close()

--- a/traits_futures/tests/test_traits_process_executor.py
+++ b/traits_futures/tests/test_traits_process_executor.py
@@ -153,8 +153,9 @@ class TestTraitsExecutor(
 
     def tearDown(self):
         del self.listener
-        if not self.executor.stopped:
+        if self.executor.running:
             self.executor.stop()
+        if not self.executor.stopped:
             self.wait_until_stopped(self.executor)
         del self.executor
         self._context.close()


### PR DESCRIPTION
This PR contains a simple drive-by fix to a couple of `tearDown` methods that aimed to shut down an executor in an unknown state: those methods attempted to call `stop` if the executor wasn't already stopped, but in the case that the executor is in `STOPPING` state that's an error. Instead, we need to call `stop` if the executor is running, and then wait for stop if the executor hasn't yet stopped.