### PR TITLE
Enable faulthandler when running tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: ${{ runner.temp }}
-        run: python -m unittest discover -v traits_futures
+        run: python -X faulthandler -m unittest discover -v traits_futures
 
   tests-wx:
     strategy:
@@ -81,4 +81,4 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: ${{ runner.temp }}
-        run: python -m unittest discover -v traits_futures
+        run: python -X faulthandler -m unittest discover -v traits_futures

--- a/.github/workflows/test-bleeding-edge.yml
+++ b/.github/workflows/test-bleeding-edge.yml
@@ -42,4 +42,4 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: ${{ runner.temp }}
-        run: python -m unittest discover -v traits_futures
+        run: python -X faulthandler -m unittest discover -v traits_futures


### PR DESCRIPTION
One of the CI runs for #334 ran into a segfault. This PR enables faulthandler during test runs so that we get more information on the cause of the segfault next time this happens.