### PR TITLE
Fix potential race condition in long_running_task

### DIFF
--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -65,6 +65,8 @@ def test_progress(arg1, arg2, kwd1, kwd2, progress):
 def wait_for_event(started, event, timeout):
     """Wait for an event, and raise if it doesn't occur within a timeout.
 
+    Also signals via an event when it starts executing.
+
     Parameters
     ----------
     started : threading.Event


### PR DESCRIPTION
Follow-on to #338, change extracted from #334.

A test in the upcoming PR #334 encountered a race condition when using `long_running_task`. The test assumed that the task would already be executing by the time the associated with block was entered, but that's sensitive to timing.

This PR tightens the behaviour so that by the time the with block is entered it's safe to assume that the long-running task is already executing.