### PR TITLE
Run the executor tests with an external worker pool

### DIFF
--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -221,3 +221,31 @@ class TestTraitsExecutor(
         self._context.close()
         del self._context
         GuiTestAssistant.tearDown(self)
+
+
+class TestTraitsExecutorWithExternalWorkerPool(
+    GuiTestAssistant, TraitsExecutorTests, unittest.TestCase
+):
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+        self._context = MultithreadingContext()
+        self._worker_pool = self._context.worker_pool()
+        self.executor = TraitsExecutor(
+            context=self._context,
+            gui_context=self._gui_context,
+            worker_pool=self._worker_pool,
+        )
+        self.listener = ExecutorListener(executor=self.executor)
+
+    def tearDown(self):
+        del self.listener
+        if self.executor.running:
+            self.executor.stop()
+        if not self.executor.stopped:
+            self.wait_until_stopped(self.executor)
+        del self.executor
+        self._worker_pool.shutdown()
+        del self._worker_pool
+        self._context.close()
+        del self._context
+        GuiTestAssistant.tearDown(self)


### PR DESCRIPTION
[Extracted from #334]

The shutdown behaviour of the executor depends on whether we're using an external worker pool or one "owned" by the executor, but the behaviour in the former case wasn't very well tested. This PR adds a test class that runs the traits executor tests under an executor using an external worker pool.