### PR TITLE
Refactor executor states and shutdown

### DIFF
--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -303,9 +303,9 @@ needed.
 .. |stop| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.stop`
 
 .. |ExecutorState| replace:: :meth:`~traits_futures.executor_states.ExecutorState`
-.. |RUNNING| replace:: :meth:`~traits_futures.traits_executor.RUNNING`
-.. |STOPPING| replace:: :meth:`~traits_futures.traits_executor.STOPPING`
-.. |STOPPED| replace:: :meth:`~traits_futures.traits_executor.STOPPED`
+.. |RUNNING| replace:: :data:`~traits_futures.executor_states.RUNNING`
+.. |STOPPING| replace:: :data:`~traits_futures.executor_states.STOPPING`
+.. |STOPPED| replace:: :data:`~traits_futures.executor_states.STOPPED`
 
 .. |cancel| replace:: :meth:`~traits_futures.base_future.BaseFuture.cancel`
 

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -302,7 +302,7 @@ needed.
 .. |TraitsExecutor| replace:: :class:`~traits_futures.traits_executor.TraitsExecutor`
 .. |stop| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.stop`
 
-.. |ExecutorState| replace:: :meth:`~traits_futures.traits_executor.ExecutorState`
+.. |ExecutorState| replace:: :meth:`~traits_futures.executor_states.ExecutorState`
 .. |RUNNING| replace:: :meth:`~traits_futures.traits_executor.RUNNING`
 .. |STOPPING| replace:: :meth:`~traits_futures.traits_executor.STOPPING`
 .. |STOPPED| replace:: :meth:`~traits_futures.traits_executor.STOPPED`

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -91,6 +91,12 @@ from traits_futures.background_progress import (
 )
 from traits_futures.base_future import BaseFuture
 from traits_futures.ets_context import ETSContext
+from traits_futures.executor_states import (
+    ExecutorState,
+    RUNNING,
+    STOPPED,
+    STOPPING,
+)
 from traits_futures.future_states import (
     CANCELLED,
     CANCELLING,
@@ -106,13 +112,7 @@ from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.i_task_specification import ITaskSpecification
 from traits_futures.multiprocessing_context import MultiprocessingContext
 from traits_futures.multithreading_context import MultithreadingContext
-from traits_futures.traits_executor import (
-    ExecutorState,
-    RUNNING,
-    STOPPED,
-    STOPPING,
-    TraitsExecutor,
-)
+from traits_futures.traits_executor import TraitsExecutor
 
 __all__ = [
     # Different types of Future

--- a/traits_futures/executor_states.py
+++ b/traits_futures/executor_states.py
@@ -1,0 +1,27 @@
+# (C) Copyright 2018-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+User-facing states for the TraitsExecutor.
+"""
+from traits.api import Enum
+
+#: Executor is currently running (this is the initial state).
+RUNNING = "running"
+
+#: Executor has been requested to stop. In this state, no new
+#: jobs can be submitted, and we're waiting for old ones to complete.
+STOPPING = "stopping"
+
+#: Executor is stopped.
+STOPPED = "stopped"
+
+#: Trait type representing the executor state.
+ExecutorState = Enum(RUNNING, STOPPING, STOPPED)

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -341,7 +341,7 @@ class TraitsExecutor(HasStrictTraits):
             self._message_router.stop()
             self._message_router = None
             self._have_message_router = False
-            logger.debug(f"{self} stopping message router")
+            logger.debug(f"{self} message router stopped")
 
     def _close_context(self):
         """

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -475,8 +475,8 @@ class TraitsExecutor(HasStrictTraits):
         if old_running != new_running:
             self.trait_property_changed("running", old_running, new_running)
 
-        old_stopped = old_state in _STOPPED_INTERNAL_STATES
-        new_stopped = new_state in _STOPPED_INTERNAL_STATES
+        old_stopped = old_internal_state in _STOPPED_INTERNAL_STATES
+        new_stopped = new_internal_state in _STOPPED_INTERNAL_STATES
         if old_stopped != new_stopped:
             self.trait_property_changed("stopped", old_stopped, new_stopped)
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -32,6 +32,12 @@ from traits_futures.background_call import submit_call
 from traits_futures.background_iteration import submit_iteration
 from traits_futures.background_progress import submit_progress
 from traits_futures.ets_context import ETSContext
+from traits_futures.executor_states import (
+    ExecutorState,
+    RUNNING,
+    STOPPED,
+    STOPPING,
+)
 from traits_futures.i_gui_context import IGuiContext
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multithreading_context import MultithreadingContext
@@ -40,20 +46,44 @@ from traits_futures.wrappers import BackgroundTaskWrapper, FutureWrapper
 logger = logging.getLogger(__name__)
 
 
-# Executor states.
+# The TraitsExecutor class maintains an internal state that maps to the
+# publicly visible state. The internal state keeps track of some extra
+# details about the shutdown.
 
-#: Executor is currently running (this is the initial state).
-RUNNING = "running"
+#: Internal state: 'shutdown' has been requested, but not all
+#: background tasks have been completed.
+_TERMINATING = "terminating"
 
-#: Executor has been requested to stop. In this state, no new
-#: jobs can be submitted, and we're waiting for old ones to complete.
-STOPPING = "stopping"
+#: Mapping from each internal state to the corresponding user-visible state.
+_INTERNAL_STATE_TO_EXECUTOR_STATE = {
+    RUNNING: RUNNING,
+    STOPPING: STOPPING,
+    STOPPED: STOPPED,
+    _TERMINATING: STOPPING,
+}
 
-#: Executor is stopped.
-STOPPED = "stopped"
+#: Set of internal states that are considered to be "running" states.
+_RUNNING_INTERNAL_STATES = {
+    internal_state
+    for internal_state, state in _INTERNAL_STATE_TO_EXECUTOR_STATE.items()
+    if state == RUNNING
+}
 
-#: Trait type representing the executor state.
-ExecutorState = Enum(RUNNING, STOPPING, STOPPED)
+#: Set of internal states that are considered to be "stopped" states.
+_STOPPED_INTERNAL_STATES = {
+    internal_state
+    for internal_state, state in _INTERNAL_STATE_TO_EXECUTOR_STATE.items()
+    if state == STOPPED
+}
+
+
+class _StateTransitionError(Exception):
+    """
+    Exception used to indicate a bad state transition.
+
+    Users should never see this exception. It always indicates an error in the
+    executor logic.
+    """
 
 
 class TraitsExecutor(HasStrictTraits):
@@ -92,7 +122,7 @@ class TraitsExecutor(HasStrictTraits):
     """
 
     #: Current state of this executor.
-    state = ExecutorState
+    state = Property(ExecutorState)
 
     #: Derived state: true if this executor is running; False if it's
     #: stopped or stopping.
@@ -278,13 +308,17 @@ class TraitsExecutor(HasStrictTraits):
             self._message_router.close_pipe(receiver)
             raise
 
-        future_wrapper = FutureWrapper(future=future, receiver=receiver)
-        self._wrappers.add(future_wrapper)
-
         background_task_wrapper = BackgroundTaskWrapper(
             runner, sender, cancel_event
         )
-        self._worker_pool.submit(background_task_wrapper)
+        cf_future = self._worker_pool.submit(background_task_wrapper)
+
+        future_wrapper = FutureWrapper(
+            future=future,
+            cf_future=cf_future,
+            receiver=receiver,
+        )
+        self._wrappers.add(future_wrapper)
 
         logger.debug(f"{self} created future {future}")
         return future
@@ -296,25 +330,194 @@ class TraitsExecutor(HasStrictTraits):
         if not self.running:
             raise RuntimeError("Executor is not currently running.")
 
-        # Cancel any futures that aren't already cancelled.
-        if self._wrappers:
-            logger.debug(
-                f"{self} cancelling {len(self._wrappers)} unfinished futures"
-            )
-            for wrapper in self._wrappers:
-                future = wrapper.future
-                if future.cancellable:
-                    future.cancel()
-
-        # For consistency, we always go through the STOPPING state,
-        # even if there are no jobs.
-        self.state = STOPPING
-        logger.debug(f"{self} stopping")
-
+        self._initiate_stop()
         if not self._wrappers:
-            self._stop()
+            self._complete_stop()
+
+    def shutdown(self, timeout=None):
+        """
+        Shut this executor down, abandoning all currently executing futures.
+
+        All currently executing futures that are cancellable will be cancelled.
+
+        This method is blocking: it waits for associated background tasks
+        to complete, and if this executor owns its worker pool, it waits
+        for the worker pool to be shut down.
+
+        No further updates to a future's state will occur after this method
+        is called. In particular, any future that's cancelled by calling this
+        method will remain in CANCELLING state, and its state will never be
+        updated to CANCELLED.
+
+        This method may be called at any time. If called on an executor
+        that's already stopped, this method does nothing.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Maximum time to wait for background tasks to complete, in seconds.
+            If not given, this method will wait indefinitely.
+
+        Raises
+        ------
+        RuntimeError
+            If a timeout is given, and the background tasks fail to complete
+            within the given timeout. In this case the executor will remain
+            in STOPPING state.
+        """
+        if self.stopped:
+            return
+
+        if self.running:
+            self._initiate_stop()
+        if self._internal_state == STOPPING:
+            self._abandon_tasks()
+        if self._wait_for_futures(timeout):
+            self._terminate()
+        else:
+            raise RuntimeError(
+                "Shutdown timed out; "
+                "f{len(self._wrappers)} tasks still running"
+            )
+
+    # State transitions #######################################################
+
+    def _wait_for_futures(self, timeout):
+        """
+        Wait for concurrent.futures futures associated to pending tasks.
+
+        Returns True on success, False on timeout.
+        """
+        cf_futures = [wrapper.cf_future for wrapper in self._wrappers]
+        logger.debug(f"Waiting for {len(cf_futures)} background tasks")
+        done, not_done = concurrent.futures.wait(cf_futures, timeout=timeout)
+        logger.debug(
+            f"{len(done)} tasks completed, {len(not_done)} tasks still running"
+        )
+
+        # Remove wrappers for completed futures.
+        done_wrappers = [
+            wrapper for wrapper in self._wrappers if wrapper.cf_future in done
+        ]
+        for wrapper in done_wrappers:
+            self._wrappers.remove(wrapper)
+
+        return not not_done
+
+    def _stop_router(self):
+        """
+        Stop the message router.
+        """
+        if self._have_message_router:
+            for wrapper in self._wrappers:
+                self._message_router.close_pipe(wrapper.receiver)
+            self._message_router.stop()
+            self._message_router = None
+            self._have_message_router = False
+
+    def _do_cleanup(self):
+        """
+        Close the context, shut down the worker pool if we own it.
+        """
+        if self._own_worker_pool:
+            logger.debug(f"{self} shutting down owned worker pool")
+            self._worker_pool.shutdown()
+            logger.debug(f"{self} worker pool is now shut down")
+        self._worker_pool = None
+
+        if self._own_context:
+            self._context.close()
+        self._context = None
+
+    def _cancel_tasks(self):
+        """
+        Cancel all currently running tasks.
+        """
+        logger.debug("Cancelling incomplete tasks")
+        cancel_count = 0
+        for wrapper in self._wrappers:
+            future = wrapper.future
+            if future.cancellable:
+                future.cancel()
+                cancel_count += 1
+        logger.debug(f"{cancel_count} tasks cancelled")
+
+    def _initiate_stop(self):
+        """
+        Prevent new tasks from being submitted and cancel existing tasks.
+
+        State: RUNNING -> STOPPING
+        """
+        if self._internal_state == RUNNING:
+            self._cancel_tasks()
+            self._internal_state = STOPPING
+        else:
+            raise _StateTransitionError(
+                "Unexpected state transition in internal state {!r}".format(
+                    self._internal_state
+                )
+            )
+
+    def _complete_stop(self):
+        """
+        Move to stopped state when all remaining futures have completed.
+
+        State: STOPPING -> STOPPED
+        """
+        if self._internal_state == STOPPING:
+            self._stop_router()
+            self._do_cleanup()
+            self._internal_state = STOPPED
+        else:
+            raise _StateTransitionError(
+                "Unexpected state transition in internal state {!r}".format(
+                    self._internal_state
+                )
+            )
+
+    def _abandon_tasks(self):
+        """
+        Stop routing messages from background tasks to the foreground futures.
+
+        This doesn't stop the background tasks from executing, but after this
+        method is called, the corresponding futures will no longer receive any
+        state updates in response to messages sent by the background task.
+
+        State: STOPPING -> _TERMINATING
+        """
+        if self._internal_state == STOPPING:
+            self._stop_router()
+            self._internal_state = _TERMINATING
+        else:
+            raise _StateTransitionError(
+                "Unexpected state transition in internal state {!r}".format(
+                    self._internal_state
+                )
+            )
+
+    def _terminate(self):
+        """
+        Complete executor shutdown.
+
+        State: _TERMINATING -> STOPPED
+        """
+        if self._internal_state == _TERMINATING:
+            self._do_cleanup()
+            self._internal_state = STOPPED
+        else:
+            raise _StateTransitionError(
+                "Unexpected state transition in internal state {!r}".format(
+                    self._internal_state
+                )
+            )
 
     # Private traits ##########################################################
+
+    #: Internal state of the executor.
+    _internal_state = Enum(RUNNING, list(_INTERNAL_STATE_TO_EXECUTOR_STATE))
+
+    #: Wrappers for currently-executing futures.
+    _wrappers = Set(Instance(FutureWrapper))
 
     #: Parallelization context
     _context = Instance(IParallelContext)
@@ -339,25 +542,39 @@ class TraitsExecutor(HasStrictTraits):
     #: True if we've created a message router, and need to shut it down.
     _have_message_router = Bool(False)
 
-    #: Wrappers for currently-executing futures.
-    _wrappers = Set(Instance(FutureWrapper))
-
     # Private methods #########################################################
 
+    def _get_state(self):
+        """Property getter for the "state" trait."""
+        return _INTERNAL_STATE_TO_EXECUTOR_STATE[self._internal_state]
+
     def _get_running(self):
-        return self.state == RUNNING
+        """Property getter for the "running" trait."""
+        return self._internal_state in _RUNNING_INTERNAL_STATES
 
     def _get_stopped(self):
-        return self.state == STOPPED
+        """Property getter for the "stopped" trait."""
+        return self._internal_state in _STOPPED_INTERNAL_STATES
 
-    def _state_changed(self, old_state, new_state):
-        old_running = old_state == RUNNING
-        new_running = new_state == RUNNING
+    def __internal_state_changed(self, old_internal_state, new_internal_state):
+        """Trait change handler for the "_internal_state" trait."""
+        logger.debug(
+            "Executor internal state changed "
+            f"from {old_internal_state} to {new_internal_state}"
+        )
+
+        old_state = _INTERNAL_STATE_TO_EXECUTOR_STATE[old_internal_state]
+        new_state = _INTERNAL_STATE_TO_EXECUTOR_STATE[new_internal_state]
+        if old_state != new_state:
+            self.trait_property_changed("state", old_state, new_state)
+
+        old_running = old_internal_state in _RUNNING_INTERNAL_STATES
+        new_running = new_internal_state in _RUNNING_INTERNAL_STATES
         if old_running != new_running:
             self.trait_property_changed("running", old_running, new_running)
 
-        old_stopped = old_state == STOPPED
-        new_stopped = new_state == STOPPED
+        old_stopped = old_state in _STOPPED_INTERNAL_STATES
+        new_stopped = new_state in _STOPPED_INTERNAL_STATES
         if old_stopped != new_stopped:
             self.trait_property_changed("stopped", old_stopped, new_stopped)
 
@@ -389,27 +606,5 @@ class TraitsExecutor(HasStrictTraits):
         )
         # If we're in STOPPING state and the last future has just exited,
         # go to STOPPED state.
-        if self.state == STOPPING and not self._wrappers:
-            self._stop()
-
-    def _stop(self):
-        """
-        Go to STOPPED state, and shut down the worker pool if we own it.
-        """
-        assert self.state == STOPPING
-
-        if self._have_message_router:
-            self._message_router.stop()
-            self._message_router = None
-
-        if self._own_worker_pool:
-            logger.debug(f"{self} shutting down owned worker pool")
-            self._worker_pool.shutdown()
-        self._worker_pool = None
-
-        if self._own_context:
-            self._context.close()
-        self._context = None
-
-        self.state = STOPPED
-        logger.debug(f"{self} stopped")
+        if self._internal_state == STOPPING and not self._wrappers:
+            self._complete_stop()


### PR DESCRIPTION
[Extracted from #334]

This PR extracts the refactoring and cleanup component of #334. The main aim is to remove the refactoring noise from #334 so that the functional changes in #334 are clearer and easier to review.

In detail:

- the executor states have been moved into their own top-level module, similar to the existing module for the future states
- machinery to support an internal state for the `TraitsExecutor` has been added. Right now the internal state exactly matches the actual state, but that will change with #334, which adds a new internal state that maps to the external `STOPPING` state.
- the order of wrapper creation in the `submit` method has been switched. This should have no visible effect, but is needed for #334 so that we can record the concurrent.futures `future` in the `FutureWrapper`. (We need access to the concurrent.futures `future` so that we can wait on it.)
- the shutdown code has been broken up into various helper methods; we'll need to call those same helper methods, but potentially in different orders, in the new `shutdown` method introduced in #334 