### PR TITLE
Fix missing 'f' prefix on what was supposed to be an f-string.

### DIFF
--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -370,7 +370,7 @@ class TraitsExecutor(HasStrictTraits):
         """
         Cancel all currently running tasks.
         """
-        logger.debug("{self} cancelling incomplete tasks")
+        logger.debug(f"{self} cancelling incomplete tasks")
         cancel_count = 0
         for wrapper in self._wrappers:
             future = wrapper.future


### PR DESCRIPTION
Fix idiotic typo introduced in #346.