### PR TITLE
Fix a test that created a thread but failed to join in

### DIFF
--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -175,6 +175,7 @@ class IPingeeTests:
 
         # Unblock the Pinger creation.
         ready.set()
+        pinger_thread.join()
 
         # There shouldn't be any ping-related activity queued on the event
         # loop at this point. We exercise the event loop, in the hope


### PR DESCRIPTION
This PR fixes a recently-introduced test that failed to call `join` on its background thread.

I'm hopeful that this will fix #340.