### PR TITLE
Refactor: fix wrapper asymmetry (and inaccurate docstring)

### DIFF
--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -102,7 +102,7 @@ class BackgroundCallTests:
         future = submit_call(self.executor, event.set)
         listener = CallFutureListener(future=future)
 
-        # Ensure the background task is past the cancel_event.is_set() check.
+        # Ensure the background task is past the cancellation check.
         self.assertTrue(event.wait(timeout=TIMEOUT))
 
         # And _now_ cancel before we process any messages.

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -304,7 +304,7 @@ class TraitsExecutor(HasStrictTraits):
             raise
 
         background_task_wrapper = BackgroundTaskWrapper(
-            runner, sender, cancel_event
+            runner, sender, cancel_event.is_set
         )
         self._worker_pool.submit(background_task_wrapper)
 

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -104,10 +104,10 @@ class BackgroundTaskWrapper:
         whether cancellation has been requested.
     """
 
-    def __init__(self, background_task, sender, cancel_event):
+    def __init__(self, background_task, sender, cancelled):
         self._background_task = background_task
         self._sender = sender
-        self._cancel_event = cancel_event
+        self._cancelled = cancelled
 
     def __call__(self):
         try:
@@ -116,9 +116,9 @@ class BackgroundTaskWrapper:
                 try:
                     result = (
                         None
-                        if self._cancel_event.is_set()
+                        if self._cancelled()
                         else self._background_task(
-                            self.send_custom_message, self._cancel_event.is_set
+                            self.send_custom_message, self._cancelled
                         )
                     )
                 except BaseException as e:

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -114,13 +114,12 @@ class BackgroundTaskWrapper:
             with self._sender:
                 self.send_control_message(STARTED)
                 try:
-                    result = (
-                        None
-                        if self._cancelled()
-                        else self._background_task(
+                    if self._cancelled():
+                        result = None
+                    else:
+                        result = self._background_task(
                             self.send_custom_message, self._cancelled
                         )
-                    )
                 except BaseException as e:
                     self.send_control_message(RAISED, marshal_exception(e))
                 else:


### PR DESCRIPTION
Minor refactor, that doesn't touch published interfaces: instead of passing the `cancel_event` event to the `BackgroundTaskWrapper`, pass the `cancel_event.is_set` bound method. This matches [what's done](https://github.com/enthought/traits-futures/blob/7d3ae40569f9313a819da726bbb823a1840e46b6/traits_futures/traits_executor.py#L301) with the `FutureWrapper` (passing `cancel_event.set` rather than `cancel_event`), and also matches the `BackgroundTaskWrapper` [docstring](https://github.com/enthought/traits-futures/blob/7d3ae40569f9313a819da726bbb823a1840e46b6/traits_futures/wrappers.py#L102-L104), which was previously incorrect.