### PR TITLE
Simplify messages, ensure cleanup ordering

### DIFF
--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -227,15 +227,22 @@ class BaseFuture(HasStrictTraits):
         message : tuple(str, object)
             Message from the background task, in the form (message_type,
             message_args).
+
+        Returns
+        -------
+        done : bool
+            True if this will be the last message received from the background
+            task, else False. For this method, it's always False.
         """
 
         if self._internal_state == _CANCELLING_AFTER_STARTED:
             # Ignore messages that arrive after a cancellation request.
-            return
+            return False
         elif self._internal_state == EXECUTING:
             message_type, message_arg = message
             method_name = "_process_{}".format(message_type)
             getattr(self, method_name)(message_arg)
+            return False
         else:
             raise _StateTransitionError(
                 "Unexpected custom message in internal state {!r}".format(
@@ -251,11 +258,19 @@ class BaseFuture(HasStrictTraits):
         ----------
         none : NoneType
             This parameter is unused.
+
+        Returns
+        -------
+        done : bool
+            True if this will be the last message received from the background
+            task, else False. For this method, it's always False.
         """
         if self._internal_state == _INITIALIZED:
             self._internal_state = EXECUTING
+            return False
         elif self._internal_state == _CANCELLING_BEFORE_STARTED:
             self._internal_state = _CANCELLING_AFTER_STARTED
+            return False
         else:
             raise _StateTransitionError(
                 "Unexpected 'started' message in internal state {!r}".format(
@@ -271,13 +286,21 @@ class BaseFuture(HasStrictTraits):
         ----------
         result : any
             The object returned by the background task.
+
+        Returns
+        -------
+        done : bool
+            True if this will be the last message received from the background
+            task, else False. For this method, it's always True.
         """
         if self._internal_state == EXECUTING:
             self._cancel = None
             self._result = result
             self._internal_state = COMPLETED
+            return True
         elif self._internal_state == _CANCELLING_AFTER_STARTED:
             self._internal_state = CANCELLED
+            return True
         else:
             raise _StateTransitionError(
                 "Unexpected 'returned' message in internal state {!r}".format(
@@ -294,13 +317,21 @@ class BaseFuture(HasStrictTraits):
         exception_info : tuple(str, str, str)
             Tuple containing exception information in string form:
             (exception type, exception value, formatted traceback).
+
+        Returns
+        -------
+        done : bool
+            True if this will be the last message received from the background
+            task, else False. For this method, it's always True.
         """
         if self._internal_state == EXECUTING:
             self._cancel = None
             self._exception = exception_info
             self._internal_state = FAILED
+            return True
         elif self._internal_state == _CANCELLING_AFTER_STARTED:
             self._internal_state = CANCELLED
+            return True
         else:
             raise _StateTransitionError(
                 "Unexpected 'raised' message in internal state {!r}".format(

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -231,7 +231,7 @@ class BaseFuture(HasStrictTraits):
 
         if self._internal_state == _CANCELLING_AFTER_STARTED:
             # Ignore messages that arrive after a cancellation request.
-            pass
+            return
         elif self._internal_state == EXECUTING:
             message_type, message_arg = message
             method_name = "_process_{}".format(message_type)

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -71,7 +71,7 @@ class FutureWrapper(HasStrictTraits):
     done = Bool(False)
 
     @on_trait_change("receiver:message")
-    def _receive_message(self, message):
+    def _dispatch_to_future(self, message):
         """
         Pass on a message to the future.
         """

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -112,7 +112,7 @@ class BackgroundTaskWrapper:
                         result = None
                     else:
                         result = self._background_task(
-                            self.send_custom_message, self._cancelled
+                            self._send_custom_message, self._cancelled
                         )
                 except BaseException as e:
                     self._sender.send((RAISED, marshal_exception(e)))
@@ -125,7 +125,7 @@ class BackgroundTaskWrapper:
             logger.exception("Unexpected exception in background task.")
             raise
 
-    def send_custom_message(self, message_type, message_args=None):
+    def _send_custom_message(self, message_type, message_args=None):
         """
         Send a custom message from the background task to the future.
 

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -77,8 +77,8 @@ class FutureWrapper(HasStrictTraits):
         """
         message_type, message_arg = message
         method_name = "_task_{}".format(message_type)
-        done = getattr(self.future, method_name)(message_arg)
-        if done:
+        getattr(self.future, method_name)(message_arg)
+        if message_type in {RAISED, RETURNED}:
             self.done = True
 
 

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -30,13 +30,13 @@ from traits_futures.i_future import IFuture
 logger = logging.getLogger(__name__)
 
 
-#: Prefix used for custom messages.
-CUSTOM = "custom"
+# Messages sent by the BackgroundTaskWrapper, and interpreted by the
+# FutureWrapper.
 
-#: Prefix used for control messages.
-CONTROL = "control"
-
-# Control messages sent by the wrapper, and interpreted by the FutureWrapper.
+#: Custom message from the future. The argument is a pair
+#: (message_type, message_args); the message type and message args
+#: are interpreted by the future.
+SENT = "sent"
 
 #: Control message sent before we start to process the target callable.
 #: The argument is always ``None``.
@@ -65,27 +65,21 @@ class FutureWrapper(HasStrictTraits):
     #: Object that receives messages from the background task.
     receiver = Instance(HasTraits)
 
-    #: Bool recording whether the future has completed or not.
+    #: Bool recording whether the future has completed or not. The
+    #: executor listens to this trait to decide when it can clean up
+    #: its own internal state.
     done = Bool(False)
-
-    @on_trait_change("future:done")
-    def _update_done(self, new_done):
-        self.done = new_done
 
     @on_trait_change("receiver:message")
     def _receive_message(self, message):
         """
-        Pass on a message to the appropriate future.
+        Pass on a message to the future.
         """
-        message_kind, message = message
-
-        if message_kind == CUSTOM:
-            self.future._task_sent(message)
-        else:
-            assert message_kind == CONTROL
-            message_type, message_arg = message
-            method_name = "_task_{}".format(message_type)
-            getattr(self.future, method_name)(message_arg)
+        message_type, message_arg = message
+        method_name = "_task_{}".format(message_type)
+        done = getattr(self.future, method_name)(message_arg)
+        if done:
+            self.done = True
 
 
 class BackgroundTaskWrapper:
@@ -112,7 +106,7 @@ class BackgroundTaskWrapper:
     def __call__(self):
         try:
             with self._sender:
-                self.send_control_message(STARTED)
+                self._sender.send((STARTED, None))
                 try:
                     result = (
                         None
@@ -122,24 +116,15 @@ class BackgroundTaskWrapper:
                         )
                     )
                 except BaseException as e:
-                    self.send_control_message(RAISED, marshal_exception(e))
+                    self._sender.send((RAISED, marshal_exception(e)))
                 else:
-                    self.send_control_message(RETURNED, result)
+                    self._sender.send((RETURNED, result))
         except BaseException:
             # We'll only ever get here in the case of a coding error. But in
             # case that happens, it's useful to have the exception logged to
             # help the developer.
             logger.exception("Unexpected exception in background task.")
             raise
-
-    def send_control_message(self, message_type, message_args=None):
-        """
-        Send a control message from the background task to the future.
-
-        These messages apply to all futures, and are used to communicate
-        changes to the state of the future.
-        """
-        self._sender.send((CONTROL, (message_type, message_args)))
 
     def send_custom_message(self, message_type, message_args=None):
         """
@@ -153,4 +138,4 @@ class BackgroundTaskWrapper:
             Any arguments providing additional information for the message.
             If not given, ``None`` is passed.
         """
-        self._sender.send((CUSTOM, (message_type, message_args)))
+        self._sender.send((SENT, (message_type, message_args)))


### PR DESCRIPTION
Minor refactoring of the wrapper machinery:

- fix unnecessary nesting in the message structure - messages that were previously of the form `(CONTROL, (RETURNED, value))` now have the form `(RETURNED, value)` and similarly for `RAISED` and `STARTED`. Messages that were previously of the form `(CUSTOM, message)` now have the form `(SENT, message)`. This allows all of these messages to be treated uniformly in the `FutureWrapper`.
- ~the `BaseFuture` methods that receive messages from the wrapper now return a boolean that's `True` if this is expected to be the last message received~
- don't listen to the `Future`'s "done" trait; instead, use the message type to determine when to tell the executor to clean up. This means that all the effects of the future state change will happen strictly before the executor internal state cleanup, and avoids the possibility of the future state change being mixed with the executor cleanup.

This PR does not introduce user-visible behavioural changes.

Closes #359.