### PR TITLE
Add section for backwards-incompatible changes to the changelog

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -15,8 +15,17 @@ Release 0.3.0
 
 Release date: XXXX-XX-XX
 
-Changes
-~~~~~~~
+Backwards-incompatible changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following backwards-incompatible changes may affect advanced users
+of Traits Futures.
+
+* The ``state`` trait of the ``~.TraitsExecutor`` is now read-only;
+  previously, it was writable.
+
+Other Changes
+~~~~~~~~~~~~~
 
 * Python 3.5 is no longer supported. Traits Futures requires Python 3.6
   or later.


### PR DESCRIPTION
This PR adds a section to the changelog, and adds a note about the backwards incompatible change introduced in #344.

Will self-merge when CI completes.