### PR TITLE
ITaskSpecification change: 'send' expects a single argument

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -15,11 +15,30 @@ Release 0.3.0
 
 Release date: XXXX-XX-XX
 
+
+Backwards-incompatible changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following backwards-incompatible changes may affect advanced users
+of Traits Futures.
+
+* The ``send`` callable passed to the background task now expects a single
+  Python object as an argument, rather than accepting a message type and
+  a message argument as separate arguments. Existing uses of the form
+  ``send(message_type, message_args)`` will need to be changed to
+  ``send((message_type, message_args))``. This affects those writing their
+  own background task types, but does not affect users of the existing
+  background task types.
+* The ``state`` trait of the ``~.TraitsExecutor`` is now read-only;
+  previously, it was writable.
+
+
 Changes
 ~~~~~~~
 
 * Python 3.5 is no longer supported. Traits Futures requires Python 3.6
   or later.
+
 
 
 Release 0.2.0

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -38,7 +38,6 @@ Other Changes
   or later.
 
 
-
 Release 0.2.0
 -------------
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -15,7 +15,6 @@ Release 0.3.0
 
 Release date: XXXX-XX-XX
 
-
 Backwards-incompatible changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -38,9 +38,9 @@ def fizz_buzz(send, cancelled):
     Parameters
     ----------
     send : callable(object) -> None
-        Callable accepting the message to be sent. The message argument should
-        be pickleable, and preferably immutable (or at least, not intended to
-        be mutated). It should return nothing.
+        Callable accepting the message to be sent, and returning nothing. The
+        message argument should be pickleable, and preferably immutable (or at
+        least, not intended to be mutated).
     cancelled : callable
         Callable accepting no arguments and returning a boolean result. It
         returns ``True`` if cancellation has been requested, and ``False``

--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -37,12 +37,10 @@ def fizz_buzz(send, cancelled):
 
     Parameters
     ----------
-    send : callable(message_type, message_argument) -> None
-        Callable accepting two arguments: a message type (a string) as the
-        first argument, and the message argument (if any) as the optional
-        second argument. The message argument should be pickleable, and
-        preferably immutable (or at least, not intended to be mutated). It
-        should return nothing.
+    send : callable(object) -> None
+        Callable accepting the message to be sent. The message argument should
+        be pickleable, and preferably immutable (or at least, not intended to
+        be mutated). It should return nothing.
     cancelled : callable
         Callable accepting no arguments and returning a boolean result. It
         returns ``True`` if cancellation has been requested, and ``False``
@@ -55,11 +53,11 @@ def fizz_buzz(send, cancelled):
         n_is_multiple_of_5 = n % 5 == 0
 
         if n_is_multiple_of_3 and n_is_multiple_of_5:
-            send(FIZZ_BUZZ, n)
+            send((FIZZ_BUZZ, n))
         elif n_is_multiple_of_3:
-            send(FIZZ, n)
+            send((FIZZ, n))
         elif n_is_multiple_of_5:
-            send(BUZZ, n)
+            send((BUZZ, n))
 
         time.sleep(1.0)
         n += 1

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -46,7 +46,7 @@ class IterationBackgroundTask:
                 # exception carries that value. Return it.
                 return e.value
 
-            send(GENERATED, result)
+            send((GENERATED, result))
             # Don't keep a reference around until the next iteration.
             del result
 

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -70,7 +70,7 @@ class ProgressReporter:
         """
         if self.cancelled():
             raise ProgressCancelled("Task was cancelled")
-        self.send(PROGRESS, progress_info)
+        self.send((PROGRESS, progress_info))
 
 
 class ProgressBackgroundTask:

--- a/traits_futures/i_task_specification.py
+++ b/traits_futures/i_task_specification.py
@@ -40,13 +40,10 @@ class ITaskSpecification(ABC):
         by the callable, will be recorded in the corresponding future.
 
         The ``send`` argument can be used by the background task to send
-        messages back to the main thread of execution. It's a callable that can
-        be used either in the form ``send(message_type)`` or in the form
-        ``send(message_type, message_args)``. Here ``message_type`` is a simple
-        constant (typically a string), and ``message_args`` is a single Python
-        object containing optional arguments for the message. The arguments to
-        ``send`` should typically be both immutable and pickleable. ``send``
-        returns no useful result.
+        messages back to the main thread of execution. It's a callable that
+        should be called as ``send(message)``, where ``message`` is an
+        arbitrary Python object. The argument to ``send`` should typically be
+        both immutable and pickleable. ``send`` returns no useful result.
 
         The ``cancelled`` argument may be used by the background task to check
         whether cancellation has been requested. When called with no arguments,

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -141,16 +141,13 @@ class BackgroundTaskWrapper:
         """
         self._sender.send((CONTROL, (message_type, message_args)))
 
-    def send_custom_message(self, message_type, message_args=None):
+    def send_custom_message(self, message):
         """
         Send a custom message from the background task to the future.
 
         Parameters
         ----------
-        message_type : str
-            The message type.
-        message_args : object, optional
-            Any arguments providing additional information for the message.
-            If not given, ``None`` is passed.
+        message : object
+            The message to be sent.
         """
-        self._sender.send((CUSTOM, (message_type, message_args)))
+        self._sender.send((CUSTOM, message))


### PR DESCRIPTION
This PR represents a backwards-incompatible change to the `ITaskSpecification` interface: the `send` callable that's passed to the background task now expects a single argument rather than a pair of arguments of the form `message_type, message_arg`.

The reason for the change is both to simplify the existing code and to remove an unnecessary constraint on custom future types. The general executor machinery should not know or care about the form of the messages passed from a user-defined background task to the corresponding user-defined future, but currently it _does_ need that knowledge, because the `send` callable that it passes to the background task needs to have the correct signature. I consider this a design mistake in the current code, and one that it's better to fix sooner rather than later.

As far as I know, no-one is yet using this interface, so I think a warning in the changelog (and in the release announcements) is sufficient here - I don't think it's worth adding machinery for issuing deprecating warnings.

For reviewers: the bulk of this PR is documentation changes. To see the functional changes (which are small), look at the three files `background_iteration.py`, `background_progress.py` and `wrappers.py`.