### PR TITLE
Set PYTHONUNBUFFERED in all workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,7 +6,7 @@ on:
     - main
 
 env:
-  PYTHON_UNBUFFERED: 1
+  PYTHONUNBUFFERED: 1
 
 jobs:
   docs:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - main
 
+env:
+  PYTHON_UNBUFFERED: 1
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -3,6 +3,9 @@ name: Style check
 on:
   pull_request
 
+env:
+  PYTHON_UNBUFFERED: 1
+
 jobs:
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  PYTHON_UNBUFFERED: 1
+  PYTHONUNBUFFERED: 1
 
 jobs:
   style:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  PYTHON_UNBUFFERED: 1
+  PYTHONUNBUFFERED: 1
 
 jobs:
   tests-pyside2:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,6 +3,9 @@ name: Run test suite for PySide2 and wxPython
 on:
   pull_request
 
+env:
+  PYTHON_UNBUFFERED: 1
+
 jobs:
   tests-pyside2:
     strategy:

--- a/.github/workflows/test-bleeding-edge.yml
+++ b/.github/workflows/test-bleeding-edge.yml
@@ -5,6 +5,9 @@ on:
     # Run at 04:35 UTC every Sunday
     - cron: '35 4 * * 0'
 
+env:
+  PYTHON_UNBUFFERED: 1
+
 jobs:
   test-bleeding-edge:
     strategy:

--- a/.github/workflows/test-bleeding-edge.yml
+++ b/.github/workflows/test-bleeding-edge.yml
@@ -6,7 +6,7 @@ on:
     - cron: '35 4 * * 0'
 
 env:
-  PYTHON_UNBUFFERED: 1
+  PYTHONUNBUFFERED: 1
 
 jobs:
   test-bleeding-edge:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -3,6 +3,9 @@ name: Check that documentation builds cleanly
 on:
   pull_request
 
+env:
+  PYTHON_UNBUFFERED: 1
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  PYTHON_UNBUFFERED: 1
+  PYTHONUNBUFFERED: 1
 
 jobs:
   docs:


### PR DESCRIPTION
A recent CI run appeared to hang during the test run, but didn't output any useful information. That _may_ have  been due to Python output being buffered, or it may have been something else. This PR sets [PYTHONUNBUFFERED](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED) for all workflows, in the hope that we get more useful output next time this happens. (This is something we've had to do previously on Travis CI and Appveyor.)

(Test run: https://github.com/enthought/traits-futures/runs/2990762656?check_suite_focus=true)