### PR TITLE
Replace "depends_on" with "observe" for "Property" traits

### DIFF
--- a/docs/source/guide/examples/fizz_buzz_ui.py
+++ b/docs/source/guide/examples/fizz_buzz_ui.py
@@ -39,11 +39,11 @@ class FizzBuzzUI(HasStrictTraits):
 
     #: Button to calculate, plus its enabled state.
     calculate = Button()
-    can_calculate = Property(Bool(), depends_on="future")
+    can_calculate = Property(Bool(), observe="future")
 
     #: Button to cancel, plus its enabled state.
     cancel = Button()
-    can_cancel = Property(Bool(), depends_on="future.cancellable")
+    can_cancel = Property(Bool(), observe="future.cancellable")
 
     @observe("calculate")
     def _submit_calculation(self, event):

--- a/docs/source/guide/examples/interruptible_task.py
+++ b/docs/source/guide/examples/interruptible_task.py
@@ -69,11 +69,11 @@ class InterruptibleTaskExample(HasStrictTraits):
 
     #: Button to calculate, plus its enabled state.
     calculate = Button()
-    can_calculate = Property(Bool(), depends_on="future")
+    can_calculate = Property(Bool(), observe="future")
 
     #: Button to cancel, plus its enabled state.
     cancel = Button()
-    can_cancel = Property(Bool(), depends_on="future.cancellable")
+    can_cancel = Property(Bool(), observe="future.cancellable")
 
     @observe("calculate")
     def _submit_calculation(self, event):

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -67,11 +67,11 @@ class NonInterruptibleTaskExample(HasStrictTraits):
 
     #: Button to calculate, plus its enabled state.
     calculate = Button()
-    can_calculate = Property(Bool(), depends_on="future")
+    can_calculate = Property(Bool(), observe="future")
 
     #: Button to cancel, plus its enabled state.
     cancel = Button()
-    can_cancel = Property(Bool(), depends_on="future.cancellable")
+    can_cancel = Property(Bool(), observe="future.cancellable")
 
     @observe("calculate")
     def _submit_calculation(self, event):

--- a/docs/source/guide/examples/pi_iterations.py
+++ b/docs/source/guide/examples/pi_iterations.py
@@ -100,13 +100,13 @@ class PiIterator(Handler):
     approximate = Button()
 
     #: Is the approximate button enabled?
-    approximate_enabled = Property(Bool(), depends_on="future.state")
+    approximate_enabled = Property(Bool(), observe="future.state")
 
     #: Button to cancel the pi approximation.
     cancel = Button()
 
     #: Is the cancel button enabled?
-    cancel_enabled = Property(Bool(), depends_on="future.state")
+    cancel_enabled = Property(Bool(), observe="future.state")
 
     #: Maximum number of points to show in the plot.
     max_points = Int(100)

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -192,7 +192,7 @@ class PrimeCounter(Handler):
     count = Button()
 
     #: Bool indicating when the count should be enabled.
-    count_enabled = Property(Bool, depends_on="future.done")
+    count_enabled = Property(Bool, observe="future.done")
 
     #: Result from the previous run.
     result_message = Str("No previous result")

--- a/docs/source/guide/examples/quick_start.py
+++ b/docs/source/guide/examples/quick_start.py
@@ -50,7 +50,7 @@ class QuickStartExample(HasStrictTraits):
     calculate = Button()
 
     #: Boolean used to decide whether to enable the "calculate" button.
-    no_running_future = Property(Bool(), depends_on="future:done")
+    no_running_future = Property(Bool(), observe="future:done")
 
     @on_trait_change("calculate")
     def _submit_background_call(self):

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -127,7 +127,7 @@ class FuturesListener(HasStrictTraits):
     futures = List(Instance(CallFuture))
 
     #: True when all futures have completed.
-    all_done = Property(Bool(), depends_on="futures:done")
+    all_done = Property(Bool(), observe="futures:items:done")
 
     def _get_all_done(self):
         return all(future.done for future in self.futures)


### PR DESCRIPTION
This PR replaced `depends_on` with `observe` for `Property` traits using automated search-and-replace. After the search-and-replace, one of the change needed to be corrected from `x:done` to `x:items:done` because `x` was a container trait. All of the changes in example files have been checked.

This PR is one step towards #356.