### PR TITLE
Replace dynamic use of "on_trait_change" handlers with "observe"

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -34,6 +34,7 @@ of Traits Futures.
 Other Changes
 ~~~~~~~~~~~~~
 
+* Traits Futures now requires Traits 6.2.0 or later.
 * Python 3.5 is no longer supported. Traits Futures requires Python 3.6
   or later.
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_long_description():
 
 install_requires = [
     "pyface",
-    "traits",
+    "traits>=6.2.0",
 ]
 
 

--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -96,11 +96,11 @@ class EventLoopHelper:
             timed_out.append(True)
             event_loop.stop()
 
-        def stop_if_condition():
+        def stop_if_condition(event):
             if condition(object):
                 event_loop.stop()
 
-        object.on_trait_change(stop_if_condition, trait)
+        object.observe(stop_if_condition, trait)
         try:
             # The condition may have become True before we
             # started listening to changes. So start with a check.
@@ -111,7 +111,7 @@ class EventLoopHelper:
                 finally:
                     timer_handle.cancel()
         finally:
-            object.on_trait_change(stop_if_condition, trait, remove=True)
+            object.observe(stop_if_condition, trait, remove=True)
 
         if timed_out:
             raise RuntimeError(

--- a/traits_futures/qt/event_loop_helper.py
+++ b/traits_futures/qt/event_loop_helper.py
@@ -124,11 +124,11 @@ class EventLoopHelper:
         def stop_on_timeout():
             qt_app.exit(1)
 
-        def stop_if_condition():
+        def stop_if_condition(event):
             if condition(object):
                 qt_app.exit(0)
 
-        object.on_trait_change(stop_if_condition, trait)
+        object.observe(stop_if_condition, trait)
         try:
             # The condition may have become True before we
             # started listening to changes. So start with a check.
@@ -143,7 +143,7 @@ class EventLoopHelper:
                     timeout_timer.stop()
                     timeout_timer.timeout.disconnect(stop_on_timeout)
         finally:
-            object.on_trait_change(stop_if_condition, trait, remove=True)
+            object.observe(stop_if_condition, trait, remove=True)
 
         if timed_out:
             raise RuntimeError(

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -57,7 +57,7 @@ class CommonFutureTests:
         # Triples (state, cancellable, done)
         states = []
 
-        def record_states():
+        def record_states(event=None):
             """Record the future's state and derived traits."""
             states.append((future.state, future.cancellable, future.done))
 
@@ -65,9 +65,9 @@ class CommonFutureTests:
         future = self.future_class()
         future._executor_initialized(dummy_cancel_callback)
 
-        future.on_trait_change(record_states, "cancellable")
-        future.on_trait_change(record_states, "done")
-        future.on_trait_change(record_states, "state")
+        future.observe(record_states, "cancellable")
+        future.observe(record_states, "done")
+        future.observe(record_states, "state")
 
         # Record initial, synthesize some state changes, then record final.
         record_states()

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -250,8 +250,8 @@ class TraitsExecutorTests:
             )
 
         results = []
-        future.on_trait_change(
-            lambda result: results.append(result), "result_event"
+        future.observe(
+            lambda event: results.append(event.new), "result_event"
         )
 
         self.wait_until_done(future)
@@ -295,7 +295,7 @@ class TraitsExecutorTests:
         # Triples (state, running, stopped).
         states = []
 
-        def record_states():
+        def record_states(event=None):
             states.append(
                 (
                     self.executor.state,
@@ -304,9 +304,9 @@ class TraitsExecutorTests:
                 )
             )
 
-        self.executor.on_trait_change(record_states, "running")
-        self.executor.on_trait_change(record_states, "stopped")
-        self.executor.on_trait_change(record_states, "state")
+        self.executor.observe(record_states, "running")
+        self.executor.observe(record_states, "stopped")
+        self.executor.observe(record_states, "state")
         submit_call(self.executor, int)
 
         # Record states before, during, and after stopping.

--- a/traits_futures/wx/event_loop_helper.py
+++ b/traits_futures/wx/event_loop_helper.py
@@ -212,11 +212,11 @@ class EventLoopHelper:
 
         timeout_timer = TimeoutTimer(timeout, lambda: wx_app.exit(1))
 
-        def stop_if_condition():
+        def stop_if_condition(event):
             if condition(object):
                 wx_app.exit(0)
 
-        object.on_trait_change(stop_if_condition, trait)
+        object.observe(stop_if_condition, trait)
         try:
             # The condition may have become True before we
             # started listening to changes. So start with a check.
@@ -230,7 +230,7 @@ class EventLoopHelper:
                     timed_out = wx_app.exit_code
                     timeout_timer.stop()
         finally:
-            object.on_trait_change(stop_if_condition, trait, remove=True)
+            object.observe(stop_if_condition, trait, remove=True)
 
         if timed_out:
             raise RuntimeError(


### PR DESCRIPTION
This PR replaces the dynamic use of `on_trait_change` e.g. `object.on_trait_change(...)` with `observe` i.e. `object.observe(...)`.

Along with #370 , #371 , #372, this PR fixes #356 .

Note that these changes make Traits Futures depend on Traits >= 6.2.0, which is explicitly listed in the setup script. A small note has been added to the changelog as well.