### PR TITLE
Only exclude one troublesome example, not all of them

### DIFF
--- a/docs/source/guide/examples/headless.py
+++ b/docs/source/guide/examples/headless.py
@@ -22,7 +22,7 @@ from traits_futures.api import (
 )
 
 
-def approximate_pi(sample_count=10**8, report_interval=10 ** 6):
+def approximate_pi(sample_count=10 ** 8, report_interval=10 ** 6):
     """
     Yield successive approximations to π via Monte Carlo methods.
     """
@@ -42,6 +42,7 @@ async def future_wrapper(traits_future):
     """
     Wrap a Traits Futures future as a schedulable coroutine.
     """
+
     def set_result(event):
         traits_future = event.object
         asyncio_future.set_result(traits_future.result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [tool.black]
 line-length = 79
 target-version = ['py36']
-exclude = "/docs/source/guide/examples"
+# black introduces extra blank lines that we don't want in the Sphinx
+# rendering. xref: https://github.com/sphinx-doc/sphinx/issues/9407
+exclude = "/docs/source/guide/examples/fizz_buzz_task.py"


### PR DESCRIPTION
Update the black list of excluded files to exclude just the one troublesome file, and to explain why it's being excluded.

Also fix some non-black code that slipped by as the result of the more general exclusion.

Upstream issue: https://github.com/sphinx-doc/sphinx/issues/9407