### PR TITLE
Add GuiTestAssistant.exercise_event_loop

### DIFF
--- a/traits_futures/testing/gui_test_assistant.py
+++ b/traits_futures/testing/gui_test_assistant.py
@@ -13,12 +13,25 @@ Test support, providing the ability to run the event loop from within tests.
 """
 
 
+from traits.api import Bool, HasStrictTraits
+
 from traits_futures.asyncio.event_loop import AsyncioEventLoop
 
 #: Maximum timeout for blocking calls, in seconds. A successful test should
 #: never hit this timeout - it's there to prevent a failing test from hanging
 #: forever and blocking the rest of the test suite.
 SAFETY_TIMEOUT = 5.0
+
+
+class _HasBool(HasStrictTraits):
+    """
+    Simple HasTraits class with a single mutable trait.
+
+    Used in tests that need something mutable and observable.
+    """
+
+    #: Simple boolean flag.
+    flag = Bool(False)
 
 
 class GuiTestAssistant:
@@ -73,3 +86,26 @@ class GuiTestAssistant:
             true or not at that point.
         """
         self._event_loop_helper.run_until(object, trait, condition, timeout)
+
+    def exercise_event_loop(self):
+        """
+        Exercise the event loop.
+
+        Places a new task on the event loop and runs the event loop
+        until that task is complete. The goal is to flush out any other
+        tasks that might already be in event loop tasks queue.
+
+        Note that there's no guarantee that this will execute other pending
+        event loop tasks. So this method is useful for tests of the form
+        "check that nothing bad happens as a result of other pending event
+        loop tasks", but it's not safe to use it for tests that *require*
+        pending event loop tasks to be processed.
+        """
+        sentinel = _HasBool()
+        self._event_loop_helper.setattr_soon(sentinel, "flag", True)
+        self.run_until(
+            sentinel,
+            "flag",
+            lambda sentinel: sentinel.flag,
+            timeout=SAFETY_TIMEOUT,
+        )

--- a/traits_futures/testing/gui_test_assistant.py
+++ b/traits_futures/testing/gui_test_assistant.py
@@ -103,8 +103,4 @@ class GuiTestAssistant:
         """
         sentinel = _HasBool()
         self._event_loop_helper.setattr_soon(sentinel, "flag", True)
-        self.run_until(
-            sentinel,
-            "flag",
-            lambda sentinel: sentinel.flag,
-        )
+        self.run_until(sentinel, "flag", lambda sentinel: sentinel.flag)

--- a/traits_futures/testing/gui_test_assistant.py
+++ b/traits_futures/testing/gui_test_assistant.py
@@ -107,5 +107,4 @@ class GuiTestAssistant:
             sentinel,
             "flag",
             lambda sentinel: sentinel.flag,
-            timeout=SAFETY_TIMEOUT,
         )

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -17,7 +17,7 @@ import queue
 import threading
 import weakref
 
-from traits.api import Bool, Event, HasStrictTraits, Int
+from traits.api import Event, HasStrictTraits, Int
 
 #: Safety timeout, in seconds, for blocking operations, to prevent
 #: the test suite from blocking indefinitely if something goes wrong.
@@ -180,16 +180,7 @@ class IPingeeTests:
         # There shouldn't be any ping-related activity queued on the event
         # loop at this point. We exercise the event loop, in the hope
         # of flushing out any such activity.
-
-        class Sentinel(HasStrictTraits):
-            #: Simple boolean flag.
-            flag = Bool(False)
-
-        sentinel = Sentinel()
-
-        self._event_loop_helper.setattr_soon(sentinel, "flag", True)
-        self.run_until(sentinel, "flag", lambda sentinel: sentinel.flag)
-
+        self.exercise_event_loop()
         self.assertEqual(listener.ping_count, 0)
 
     def test_disconnect_removes_callback_reference(self):

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -24,11 +24,6 @@ from traits_futures.api import (
 )
 from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 
-#: Maximum timeout for blocking calls, in seconds. A successful test should
-#: never hit this timeout - it's there to prevent a failing test from hanging
-#: forever and blocking the rest of the test suite.
-SAFETY_TIMEOUT = 5.0
-
 
 class Dummy(HasStrictTraits):
     never_fired = Event()

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -465,24 +465,6 @@ class TraitsExecutorTests:
 
     # Helper methods and assertions ###########################################
 
-    def exercise_event_loop(self):
-        """
-        Exercise the event loop.
-
-        Places a new task on the event loop and runs the event loop
-        until that task is complete. The goal is to flush out any other
-        tasks that might already be in event loop tasks queue.
-        """
-
-        class Sentinel(HasStrictTraits):
-            #: Simple boolean flag.
-            flag = Bool(False)
-
-        sentinel = Sentinel()
-
-        self._event_loop_helper.setattr_soon(sentinel, "flag", True)
-        self.run_until(sentinel, "flag", lambda sentinel: sentinel.flag)
-
     def wait_until_stopped(self, executor):
         """
         Wait for the executor to reach STOPPED state.


### PR DESCRIPTION
This PR adds a new GuiTestAssistant.exercise_event_loop function and
refactors two existing test cases to make use of it.

exercise_event_loop simply runs the GUI event loop, in the hope of
flushing out any pending GUI events. It's useful for tests of the
form "nothing bad happens when the event loop is run". It's not
useful for tests that require pending events to be processed
by the event loop; that's a much harder problem to solve in general.
