### PR TITLE
Route messages during executor shutdown

### DIFF
--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -292,8 +292,6 @@ method performs the following tasks, in order:
 
 * Moves the executor to |STOPPING| state.
 * Requests cancellation of all waiting or executing background tasks.
-* Unlinks all background tasks from their associated futures: the
-  futures will receive no further updates after |shutdown| returns.
 * Waits for all background tasks to complete.
 * Shuts down the worker pool (if that worker pool is owned by the executor).
 * Moves the executor to |STOPPED| state.

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -302,10 +302,6 @@ If called on an executor in |STOPPED| state, |shutdown| simply returns
 without taking any action. If called on an executor in |STOPPING| state,
 any of the above actions that have not already been taken will be taken.
 
-Note that because of the unlinking of the background tasks and their
-associated futures, background tasks that have been cancelled will leave their
-associated futures in |CANCELLING| state. Those futures will never reach
-|CANCELLED| state, even under a running event loop.
 
 Shutdown with a timeout
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -203,15 +203,15 @@ class TraitsExecutorTests:
     def test_shutdown_cancels_running_futures(self):
         future = submit_call(self.executor, pow, 3, 5)
         self.executor.shutdown(timeout=SAFETY_TIMEOUT)
-        self.assertEqual(future.state, CANCELLING)
+        self.assertEqual(future.state, CANCELLED)
         self.assertTrue(self.executor.stopped)
 
     def test_no_future_updates_after_shutdown(self):
         future = submit_call(self.executor, pow, 3, 5)
         self.executor.shutdown(timeout=SAFETY_TIMEOUT)
-        self.assertEqual(future.state, CANCELLING)
+        self.assertEqual(future.state, CANCELLED)
         self.exercise_event_loop()
-        self.assertEqual(future.state, CANCELLING)
+        self.assertEqual(future.state, CANCELLED)
 
     def test_shutdown_goes_through_stopping_state(self):
         self.executor.shutdown(timeout=SAFETY_TIMEOUT)

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -14,7 +14,6 @@ Wrappers for the background task callable and the foreground future.
 These are used by the TraitsExecutor machinery.
 """
 
-import concurrent.futures
 import logging
 
 from traits.api import Bool, HasStrictTraits, HasTraits, Instance, observe
@@ -56,9 +55,6 @@ class FutureWrapper(HasStrictTraits):
 
     #: The Traits Futures future being wrapped
     future = Instance(IFuture)
-
-    #: The concurrent.futures future associated to the background task.
-    cf_future = Instance(concurrent.futures.Future)
 
     #: Object that receives messages from the background task.
     receiver = Instance(HasTraits)


### PR DESCRIPTION
This PR updates the executor shutdown so that it routes messages as usual during the blocking shutdown. It also removes some now-unused machinery introduced in #334 and #344: there's no longer any need to wait for the concurrent.futures futures, so we don't need to keep them around in the wrapper class.

At behaviour level: a future that's cancelled due to shutdown _will_ now reach the `CANCELLED` state as usual.
At implementation level: we make use of the new `IMessageRouter.route_until` method introduced in #378.

This PR exposes some opportunities for refactoring (beyond simple removal of unused pieces), but those can be pursued in a separate PR that doesn't change behaviour.