### PR TITLE
Refactor to move 'progress' argument check in submit_progress

### DIFF
--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -79,7 +79,7 @@ class BackgroundCall(HasStrictTraits):
         return CallBackgroundTask(
             callable=self.callable,
             args=self.args,
-            kwargs=self.kwargs.copy(),
+            kwargs=self.kwargs,
         )
 
 

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -107,7 +107,7 @@ class BackgroundIteration(HasStrictTraits):
         return IterationBackgroundTask(
             callable=self.callable,
             args=self.args,
-            kwargs=self.kwargs.copy(),
+            kwargs=self.kwargs,
         )
 
 


### PR DESCRIPTION
This is a small refactor in `submit_progress` to move the detection of an invalid `progress` keyword earlier. This enables the removal of a [try/except in `TraitsExecutor.submit`](https://github.com/enthought/traits-futures/blob/077e8b9b6d871c2273fb9781063991fa86bcd688/traits_futures/traits_executor.py#L306-L312). I haven't included that removal in this PR, because it will conflict with other currently open PRs.

While we're here, we also remove unnecessary dict `copy` operations from all three background task types, and simplify the code that calls the background task.