### PR TITLE
Ensure that Pingees are always collected on the main thread

### DIFF
--- a/traits_futures/asyncio/pingee.py
+++ b/traits_futures/asyncio/pingee.py
@@ -113,7 +113,7 @@ class Pinger:
         Disconnect from the ping receiver. No pings should be sent
         after calling this function.
         """
-        pass
+        del self.pingee
 
     def ping(self):
         """

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -207,9 +207,7 @@ class MultithreadingRouter(HasRequiredTraits):
             raise RuntimeError("router is already running")
 
         self._message_queue = queue.Queue()
-
-        self._pingee = self.event_loop.pingee(on_ping=self._route_message)
-        self._pingee.connect()
+        self._link_to_event_loop()
 
         self._running = True
         logger.debug(f"{self} started")
@@ -374,21 +372,45 @@ class MultithreadingRouter(HasRequiredTraits):
     #: Receiver for the "message_sent" signal.
     _pingee = Instance(IPingee)
 
+    #: Bool keeping track of whether we're linked to the event loop
+    #: or not.
+    _linked = Bool(False)
+
     #: Router status: True if running, False if stopped.
     _running = Bool(False)
 
     # Private methods #########################################################
 
+    def _link_to_event_loop(self):
+        """
+        Link this router to the event loop.
+        """
+        if self._linked:
+            # Raise, because lifetime management of self._pingee is delicate,
+            # so if we ever get here then something likely needs fixing.
+            raise RuntimeError("Already linked to the event loop")
+
+        self._pingee = self.event_loop.pingee(on_ping=self._route_message)
+        self._pingee.connect()
+        self._linked = True
+
     def _unlink_from_event_loop(self):
         """
-        Unlink this router from the event loop.
+        Unlink this router from the event loop, if it's linked.
 
         After this call, the router will no longer react to any pending
         tasks on the event loop.
         """
-        if self._pingee is not None:
+        if self._linked:
+            # Note: it might be tempting to set self._pingee to None at this
+            # point, and to use the None-ness (or not) of self._pingee to avoid
+            # needing self._linked. But it's important not to do so: we need to
+            # be sure that the main thread reference to the Pingee outlives any
+            # reference on background threads. Otherwise we end up collection a
+            # Qt object (the Pingee) on a thread other than the one it was
+            # created on, and that's unsafe in general.
             self._pingee.disconnect()
-            self._pingee = None
+            self._linked = False
 
     def _route_message(self, timeout=None):
         connection_id, message = self._message_queue.get(timeout=timeout)

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -183,6 +183,19 @@ class IPingeeTests:
         self.exercise_event_loop()
         self.assertEqual(listener.ping_count, 0)
 
+    def test_pinger_disconnect_removes_pingee_reference(self):
+
+        with self.connected_pingee(on_ping=lambda: None) as pingee:
+            pinger = pingee.pinger()
+            pinger.connect()
+
+        finalizer = weakref.finalize(pingee, lambda: None)
+        self.assertTrue(finalizer.alive)
+        del pingee
+        # This should remove any remaining reference to the pingee.
+        pinger.disconnect()
+        self.assertFalse(finalizer.alive)
+
     def test_disconnect_removes_callback_reference(self):
         # Implementation detail: after disconnection, the pingee should
         # no longer hold a reference to its callback.

--- a/traits_futures/wx/pingee.py
+++ b/traits_futures/wx/pingee.py
@@ -112,7 +112,7 @@ class Pinger:
         Disconnect from the ping receiver. No pings should be sent
         after calling this function.
         """
-        pass
+        del self.pingee
 
     def ping(self):
         """


### PR DESCRIPTION
For safety, Qt requires that objects that are owned by the main thread should be collected on the main thread. Quoting from https://doc.qt.io/qt-5/threads-qobject.html#per-thread-event-loop:

> Calling delete on a QObject from a thread other than the one that owns the object [...] is unsafe

We've seen segfaults previously that likely arise from violating this constraint (xref: #340), so it doesn't seem like a purely theoretical concern.

But when combined with Python's refcount and cycle-based garbage collection model, this is problematic for the Qt `Pingee` class in Traits Futures. Each `Pingee` object is owned by the main thread, but we have both main-thread and worker-thread references to a `Pingee` object. In order to ensure that the `Pingee` is collected on the main thread, we need to make sure that (a) there are no cycles involving, or eventually referring to, a `Pingee` (including the case where a cycle not directly involving a `Pingee` nevertheless includes an object that _does_ refer to a `Pingee`), and (b) that all worker-thread references to a `Pingee` are outlasted by at least one main-thread reference.

So for (b), we essentially need to make sure that worker-thread references to a `Pingee` are disposed of as early as possible, while main-thread references are kept around for as long as possible.

This PR implements a solution to part (b): we remove the worker-thread references to a `Pingee` on disconnect, and make sure that the message router's reference is held onto until the router itself is deleted, which should only happen after all background tasks have completed, and so after all `Pinger`s have disconnected themselves from their associated `Pingee`.

Part (a) should not be much of an issue in practice *provided that executors are always shut down carefully*: the message routers aren't public and aren't made available to user code at any point, so the only reference to a router is in the executor, and that reference is explicitly removed at executor shutdown time. So even if the executor is part of a reference cycle, the message router won't be reachable from that cycle after the executor is shut down.