### PR TITLE
Update examples to use 'shutdown'

### DIFF
--- a/docs/source/guide/contexts.rst
+++ b/docs/source/guide/contexts.rst
@@ -40,7 +40,7 @@ a multiprocessing context::
             view = SquaringHelper(traits_executor=traits_executor)
             view.configure_traits()
         finally:
-            traits_executor.stop()
+            traits_executor.shutdown()
             context.close()
 
 Here's a :download:`complete TraitsUI example

--- a/docs/source/guide/examples/background_processes.py
+++ b/docs/source/guide/examples/background_processes.py
@@ -23,7 +23,16 @@ dependencies.
 import random
 import time
 
-from traits.api import Button, Dict, Instance, List, Property, Range, Str
+from traits.api import (
+    Button,
+    Dict,
+    HasStrictTraits,
+    Instance,
+    List,
+    Property,
+    Range,
+    Str,
+)
 from traits_futures.api import (
     CallFuture,
     CANCELLED,
@@ -37,7 +46,6 @@ from traits_futures.api import (
     WAITING,
 )
 from traitsui.api import (
-    Handler,
     HGroup,
     Item,
     TabularAdapter,
@@ -100,7 +108,7 @@ class JobTabularAdapter(TabularAdapter):
         return state_text
 
 
-class SquaringHelper(Handler):
+class SquaringHelper(HasStrictTraits):
     #: The Traits executor for the background jobs.
     traits_executor = Instance(TraitsExecutor)
 
@@ -168,7 +176,7 @@ def main():
         view = SquaringHelper(traits_executor=traits_executor)
         view.configure_traits()
     finally:
-        traits_executor.stop()
+        traits_executor.shutdown()
         context.close()
 
 

--- a/docs/source/guide/examples/fizz_buzz_ui.py
+++ b/docs/source/guide/examples/fizz_buzz_ui.py
@@ -29,7 +29,7 @@ from fizz_buzz_task import FizzBuzzFuture, submit_fizz_buzz
 
 class FizzBuzzUI(HasStrictTraits):
     #: The executor to submit tasks to.
-    executor = Instance(TraitsExecutor, ())
+    traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
     future = Instance(FizzBuzzFuture)
@@ -48,7 +48,7 @@ class FizzBuzzUI(HasStrictTraits):
     @observe("calculate")
     def _submit_calculation(self, event):
         self.message = "Running"
-        self.future = submit_fizz_buzz(self.executor)
+        self.future = submit_fizz_buzz(self.traits_executor)
 
     @observe("cancel")
     def _cancel_running_task(self, event):
@@ -89,4 +89,8 @@ class FizzBuzzUI(HasStrictTraits):
 
 
 if __name__ == "__main__":
-    FizzBuzzUI().configure_traits()
+    traits_executor = TraitsExecutor()
+    try:
+        FizzBuzzUI(traits_executor=traits_executor).configure_traits()
+    finally:
+        traits_executor.shutdown()

--- a/docs/source/guide/examples/interruptible_task.py
+++ b/docs/source/guide/examples/interruptible_task.py
@@ -56,7 +56,7 @@ def approximate_pi(sample_count=10 ** 8):
 
 class InterruptibleTaskExample(HasStrictTraits):
     #: The executor to submit tasks to.
-    executor = Instance(TraitsExecutor, ())
+    traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
     future = Instance(IFuture)
@@ -79,7 +79,7 @@ class InterruptibleTaskExample(HasStrictTraits):
     def _submit_calculation(self, event):
         self.message = "Calculating π"
         self.future = submit_iteration(
-            self.executor, approximate_pi, self.sample_count
+            self.traits_executor, approximate_pi, self.sample_count
         )
 
     @observe("cancel")
@@ -123,4 +123,10 @@ class InterruptibleTaskExample(HasStrictTraits):
 
 
 if __name__ == "__main__":
-    InterruptibleTaskExample().configure_traits()
+    traits_executor = TraitsExecutor()
+    try:
+        InterruptibleTaskExample(
+            traits_executor=traits_executor
+        ).configure_traits()
+    finally:
+        traits_executor.shutdown()

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -54,7 +54,7 @@ def approximate_pi(sample_count=10 ** 8):
 
 class NonInterruptibleTaskExample(HasStrictTraits):
     #: The executor to submit tasks to.
-    executor = Instance(TraitsExecutor, ())
+    traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
     future = Instance(IFuture)
@@ -77,7 +77,7 @@ class NonInterruptibleTaskExample(HasStrictTraits):
     def _submit_calculation(self, event):
         self.message = "Calculating π"
         self.future = submit_call(
-            self.executor, approximate_pi, self.sample_count
+            self.traits_executor, approximate_pi, self.sample_count
         )
 
     @observe("cancel")
@@ -117,4 +117,10 @@ class NonInterruptibleTaskExample(HasStrictTraits):
 
 
 if __name__ == "__main__":
-    NonInterruptibleTaskExample().configure_traits()
+    traits_executor = TraitsExecutor()
+    try:
+        NonInterruptibleTaskExample(
+            traits_executor=traits_executor
+        ).configure_traits()
+    finally:
+        traits_executor.shutdown()

--- a/docs/source/guide/examples/pi_iterations.py
+++ b/docs/source/guide/examples/pi_iterations.py
@@ -24,6 +24,7 @@ from traits.api import (
     Bool,
     Button,
     Float,
+    HasStrictTraits,
     Instance,
     Int,
     List,
@@ -36,7 +37,7 @@ from traits_futures.api import (
     submit_iteration,
     TraitsExecutor,
 )
-from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
+from traitsui.api import HGroup, Item, UItem, VGroup, View
 
 
 def pi_iterations(chunk_size):
@@ -79,13 +80,13 @@ def pi_iterations(chunk_size):
         yield nsamples, approximation, error
 
 
-class PiIterator(Handler):
+class PiIterator(HasStrictTraits):
     """
     View and plot of pi approximation running in the background.
     """
 
     #: The Traits executor for the background jobs.
-    traits_executor = Instance(TraitsExecutor, ())
+    traits_executor = Instance(TraitsExecutor)
 
     #: Chunk size to use for the approximations.
     chunk_size = Int(1000000)
@@ -116,11 +117,6 @@ class PiIterator(Handler):
 
     #: The plot.
     plot = Instance(Plot)
-
-    def closed(self, info, is_ok):
-        # Stopping the executor cancels any running future.
-        self.traits_executor.stop()
-        super().closed(info, is_ok)
 
     def _approximate_fired(self):
         self.future = submit_iteration(
@@ -197,5 +193,9 @@ class PiIterator(Handler):
 
 
 if __name__ == "__main__":
-    view = PiIterator()
-    view.configure_traits()
+    traits_executor = TraitsExecutor()
+    try:
+        view = PiIterator(traits_executor=traits_executor)
+        view.configure_traits()
+    finally:
+        traits_executor.shutdown()

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -32,7 +32,7 @@ from traits_futures.api import (
     submit_progress,
     TraitsExecutor,
 )
-from traitsui.api import Handler, HGroup, Item, UItem, VGroup, View
+from traitsui.api import HGroup, Item, UItem, VGroup, View
 
 
 class ProgressDialog(Dialog, HasStrictTraits):
@@ -175,13 +175,13 @@ def count_primes_less_than(n, chunk_size, progress=None):
     return prime_count
 
 
-class PrimeCounter(Handler):
+class PrimeCounter(HasStrictTraits):
     """
     UI to compute primes less than a given number.
     """
 
     #: The Traits executor for the background jobs.
-    traits_executor = Instance(TraitsExecutor, ())
+    traits_executor = Instance(TraitsExecutor)
 
     #: Calculation future.
     future = Instance(ProgressFuture)
@@ -203,11 +203,6 @@ class PrimeCounter(Handler):
 
     #: Limit used for most recent run.
     _last_limit = Int()
-
-    def closed(self, info, is_ok):
-        # Stopping the executor cancels any running future.
-        self.traits_executor.stop()
-        super().closed(info, is_ok)
 
     def _count_fired(self):
         self._last_limit = self.limit
@@ -256,5 +251,9 @@ class PrimeCounter(Handler):
 
 
 if __name__ == "__main__":
-    view = PrimeCounter()
-    view.configure_traits()
+    traits_executor = TraitsExecutor()
+    try:
+        view = PrimeCounter(traits_executor=traits_executor)
+        view.configure_traits()
+    finally:
+        traits_executor.shutdown()

--- a/docs/source/guide/examples/quick_start.py
+++ b/docs/source/guide/examples/quick_start.py
@@ -32,7 +32,7 @@ def slow_square(n):
 
 class QuickStartExample(HasStrictTraits):
     #: The executor to submit tasks to.
-    executor = Instance(TraitsExecutor, ())
+    traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
     future = Instance(CallFuture)
@@ -58,7 +58,7 @@ class QuickStartExample(HasStrictTraits):
         input = self.input
         self.input_for_calculation = self.input
         self.message = "Calculating square of {} ...".format(input)
-        self.future = submit_call(self.executor, slow_square, input)
+        self.future = submit_call(self.traits_executor, slow_square, input)
         # Keep a record so that we can present messages accurately.
         self.input_for_calculation = input
 
@@ -80,4 +80,9 @@ class QuickStartExample(HasStrictTraits):
     )
 
 
-QuickStartExample().configure_traits()
+if __name__ == "__main__":
+    traits_executor = TraitsExecutor()
+    try:
+        QuickStartExample(traits_executor=traits_executor).configure_traits()
+    finally:
+        traits_executor.shutdown()

--- a/docs/source/guide/examples/test_future.py
+++ b/docs/source/guide/examples/test_future.py
@@ -31,21 +31,15 @@ GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
 class TestMyFuture(GuiTestAssistant, unittest.TestCase):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self.executor = TraitsExecutor()
+        self.traits_executor = TraitsExecutor()
 
     def tearDown(self):
         # Request the executor to stop, and wait for that stop to complete.
-        self.executor.stop()
-        self.assertEventuallyTrueInGui(
-            lambda: self.executor.stopped, timeout=SAFETY_TIMEOUT
-        )
-
+        self.traits_executor.shutdown(timeout=SAFETY_TIMEOUT)
         GuiTestAssistant.tearDown(self)
 
     def test_my_future(self):
-        executor = self.executor
-
-        future = submit_call(executor, pow, 3, 5)
+        future = submit_call(self.traits_executor, pow, 3, 5)
 
         # Wait for the future to complete.
         self.assertEventuallyTrueInGui(
@@ -53,3 +47,7 @@ class TestMyFuture(GuiTestAssistant, unittest.TestCase):
         )
 
         self.assertEqual(future.result, 243)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/guide/testing.rst
+++ b/docs/source/guide/testing.rst
@@ -46,23 +46,22 @@ Some points of interest in the above example:
   communications from the background task have completed. We do that by using
   the |assertEventuallyTrueInGui| method. At that point, we can check that the
   result of the future is the expected one.
-- We also need to shut down the executor itself at the end of the test. Note
-  that the |stop| method is not blocking and does not actually stop the
-  executor - instead, it requests cancellation of all running futures and
-  prevents new jobs from being scheduled. For the executor to eventually reach
-  the |STOPPED| state, the GUI event loop must again be running, so we make a
-  second use of |assertEventuallyTrueInGui| in the ``tearDown`` method in the
-  example.
+- We also need to shut down the executor itself at the end of the test; we
+  use the |shutdown| method for this.
+- In all potentially blocking calls, we provide a timeout. This should help
+  prevent a failing test from blocking the entire test run if something goes
+  wrong. However, note that if the timeout on the |shutdown| method fails then
+  in addition to the test failing you may see segmentation faults or other
+  peculiar side-effects, especially at process termination time, as a result of
+  pieces of cleanup occurring out of order.
 
 If you don't need the result of the future (for example because you're using
 the future for its side-effect rather than to perform a computation) then it's
-safe to remove the wait for ``future.done``, so long as you keep the |stop|
-call and then wait for the executor to stop: the executor won't reach |STOPPED|
-state until all futures have completed.
+safe to remove the wait for ``future.done``, so long as you keep the |shutdown|
+call.
 
 
 .. |assertEventuallyTrueInGui| replace:: :meth:`pyface.ui.qt4.util.gui_test_assistant.GuiTestAssistant.assertEventuallyTrueInGui`
 .. |GuiTestAssistant| replace:: :class:`pyface.ui.qt4.util.gui_test_assistant.GuiTestAssistant`
 
-.. |stop| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.stop`
-.. |STOPPED| replace:: :meth:`~traits_futures.traits_executor.STOPPED`
+.. |shutdown| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.shutdown`


### PR DESCRIPTION
This PR updates the examples to better show best practices with respect to executor creation and shutdown:

- Always use 'shutdown' to shut the executor down.
- Remove examples of the `Instance(TraitsExecutor, ())` antipattern, with its implicit executor creation

There's also some drive-by cleanup:

- Be consistent about the executor attribute: before we had a mixture of `self.executor` and `self.traits_executor`; now we have only `self.traits_executor`
- Now that we're doing executor shutdown externally to the running UI, we no longer need to use `Handler` from TraitsUI, and we no longer need to implement the `closing` method in our UIs

Finally, we also update the advice in `testing.rst` about executor cleanup: it now mentions `shutdown` as the preferred way to shut down an executor.

Closes #345