### PR TITLE
Update tests to use shutdown

### DIFF
--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -273,8 +273,7 @@ class BackgroundCallTests:
         Wait for the executor to stop.
         """
         executor = self.executor
-        executor.stop()
-        self.run_until(executor, "stopped", lambda executor: executor.stopped)
+        executor.shutdown(timeout=TIMEOUT)
         del self.executor
 
     def wait_until_done(self, future):

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -429,8 +429,7 @@ class BackgroundIterationTests:
         Wait for the executor to stop.
         """
         executor = self.executor
-        executor.stop()
-        self.run_until(executor, "stopped", lambda executor: executor.stopped)
+        executor.shutdown(timeout=TIMEOUT)
         del self.executor
 
     def wait_until_done(self, future):

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -309,8 +309,7 @@ class BackgroundProgressTests:
         Wait for the executor to stop.
         """
         executor = self.executor
-        executor.stop()
-        self.run_until(executor, "stopped", lambda executor: executor.stopped)
+        executor.shutdown(timeout=TIMEOUT)
         del self.executor
 
     def wait_until_done(self, future):

--- a/traits_futures/tests/test_gui_test_assistant.py
+++ b/traits_futures/tests/test_gui_test_assistant.py
@@ -24,6 +24,11 @@ from traits_futures.api import (
 )
 from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 
+#: Maximum timeout for blocking calls, in seconds. A successful test should
+#: never hit this timeout - it's there to prevent a failing test from hanging
+#: forever and blocking the rest of the test suite.
+SAFETY_TIMEOUT = 5.0
+
 
 class Dummy(HasStrictTraits):
     never_fired = Event()
@@ -80,12 +85,7 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
             )
         actual_timeout = time.monotonic() - start_time
 
-        executor.stop()
-        self.run_until(
-            executor,
-            "stopped",
-            condition=lambda executor: executor.stopped,
-        )
+        executor.shutdown(timeout=SAFETY_TIMEOUT)
         self.assertLess(actual_timeout, 1.0)
 
     def test_run_until_timeout_with_true_condition(self):


### PR DESCRIPTION
This PR updates tests in the test suite to use the executor's `shutdown` method in preference to the `stop` method, where that makes sense. The tests for `stop` itself still use the `stop` method, of course.