### PR TITLE
Rename GuiTestAssistant to TestAssistant

### DIFF
--- a/traits_futures/asyncio/tests/test_pingee.py
+++ b/traits_futures/asyncio/tests/test_pingee.py
@@ -15,10 +15,10 @@ Tests for the asyncio implementations of IPingee and IPinger.
 import unittest
 
 from traits_futures.asyncio.event_loop import AsyncioEventLoop
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.i_pingee_tests import IPingeeTests
 
 
-class TestPingee(GuiTestAssistant, IPingeeTests, unittest.TestCase):
+class TestPingee(TestAssistant, IPingeeTests, unittest.TestCase):
 
     event_loop_factory = AsyncioEventLoop

--- a/traits_futures/qt/tests/test_pingee.py
+++ b/traits_futures/qt/tests/test_pingee.py
@@ -14,13 +14,13 @@ Tests for the Qt implementations of IPingee and IPinger.
 
 import unittest
 
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.testing.optional_dependencies import requires_qt
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.i_pingee_tests import IPingeeTests
 
 
 @requires_qt
-class TestPingee(GuiTestAssistant, IPingeeTests, unittest.TestCase):
+class TestPingee(TestAssistant, IPingeeTests, unittest.TestCase):
     def event_loop_factory(self):
         from traits_futures.qt.event_loop import QtEventLoop
 

--- a/traits_futures/testing/test_assistant.py
+++ b/traits_futures/testing/test_assistant.py
@@ -34,7 +34,7 @@ class _HasBool(HasStrictTraits):
     flag = Bool(False)
 
 
-class GuiTestAssistant:
+class TestAssistant:
     """
     Convenience mixin class for tests that need the event loop.
 

--- a/traits_futures/tests/i_event_loop_helper_tests.py
+++ b/traits_futures/tests/i_event_loop_helper_tests.py
@@ -39,8 +39,8 @@ class IEventLoopHelperTests:
     Mixin for testing IEventLoopHelper implementations.
 
     Unlike other similar event-loop-specific test helpers, this mixin
-    should *not* be used alongside the GuiTestAssistant: it's testing
-    the foundations that the GuiTestAssistant is built on.
+    should *not* be used alongside the TestAssistant: it's testing
+    the foundations that the TestAssistant is built on.
     """
 
     #: Factory for the event loop. This should be a zero-argument callable

--- a/traits_futures/tests/i_message_router_tests.py
+++ b/traits_futures/tests/i_message_router_tests.py
@@ -103,7 +103,7 @@ class IMessageRouterTests:
     """
     Test mix-in for testing implementations of the IMessageRouter interface.
 
-    Should be used in conjunction with the GuiTestAssistant.
+    Should be used in conjunction with the TestAssistant.
     """
 
     #: Factory providing the parallelism context.

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -105,7 +105,7 @@ class IPingeeTests:
     """
     Mixin class for testing IPingee and IPinger implementations.
 
-    Should be used in combination with the GuiTestAssistant.
+    Should be used in combination with the TestAssistant.
     """
 
     def test_single_background_ping(self):

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -13,7 +13,7 @@ import contextlib
 import unittest
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.background_call_tests import BackgroundCallTests
 
 #: Timeout for blocking operations, in seconds.
@@ -21,10 +21,10 @@ TIMEOUT = 10.0
 
 
 class TestBackgroundCall(
-    GuiTestAssistant, BackgroundCallTests, unittest.TestCase
+    TestAssistant, BackgroundCallTests, unittest.TestCase
 ):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultithreadingContext()
         self.executor = TraitsExecutor(
             context=self._context,
@@ -34,7 +34,7 @@ class TestBackgroundCall(
     def tearDown(self):
         self.halt_executor()
         self._context.close()
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
     @contextlib.contextmanager
     def block_worker_pool(self):

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -16,7 +16,7 @@ import contextlib
 import unittest
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.background_iteration_tests import (
     BackgroundIterationTests,
 )
@@ -26,10 +26,10 @@ TIMEOUT = 10.0
 
 
 class TestBackgroundIteration(
-    GuiTestAssistant, BackgroundIterationTests, unittest.TestCase
+    TestAssistant, BackgroundIterationTests, unittest.TestCase
 ):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultithreadingContext()
         self.executor = TraitsExecutor(
             context=self._context,
@@ -39,7 +39,7 @@ class TestBackgroundIteration(
     def tearDown(self):
         self.halt_executor()
         self._context.close()
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
     @contextlib.contextmanager
     def block_worker_pool(self):

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -16,7 +16,7 @@ import contextlib
 import unittest
 
 from traits_futures.api import MultithreadingContext, TraitsExecutor
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.background_progress_tests import (
     BackgroundProgressTests,
 )
@@ -26,10 +26,10 @@ TIMEOUT = 10.0
 
 
 class TestBackgroundProgress(
-    GuiTestAssistant, BackgroundProgressTests, unittest.TestCase
+    TestAssistant, BackgroundProgressTests, unittest.TestCase
 ):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultithreadingContext()
         self.executor = TraitsExecutor(
             context=self._context,
@@ -39,7 +39,7 @@ class TestBackgroundProgress(
     def tearDown(self):
         self.halt_executor()
         self._context.close()
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
     @contextlib.contextmanager
     def block_worker_pool(self):

--- a/traits_futures/tests/test_multiprocessing_router.py
+++ b/traits_futures/tests/test_multiprocessing_router.py
@@ -15,12 +15,12 @@ Tests for the MultiprocessingRouter class.
 import unittest
 
 from traits_futures.multiprocessing_context import MultiprocessingContext
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
 
 
 class TestMultiprocessingRouter(
-    GuiTestAssistant, IMessageRouterTests, unittest.TestCase
+    TestAssistant, IMessageRouterTests, unittest.TestCase
 ):
     """
     Test that MultiprocessingRouter implements the IMessageRouter interface.
@@ -31,9 +31,9 @@ class TestMultiprocessingRouter(
         return MultiprocessingContext()
 
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         IMessageRouterTests.setUp(self)
 
     def tearDown(self):
         IMessageRouterTests.tearDown(self)
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)

--- a/traits_futures/tests/test_multithreading_router.py
+++ b/traits_futures/tests/test_multithreading_router.py
@@ -15,12 +15,12 @@ Tests for the MultithreadingRouter class.
 import unittest
 
 from traits_futures.multithreading_context import MultithreadingContext
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.i_message_router_tests import IMessageRouterTests
 
 
 class TestMultithreadingRouter(
-    GuiTestAssistant, IMessageRouterTests, unittest.TestCase
+    TestAssistant, IMessageRouterTests, unittest.TestCase
 ):
     """
     Test that MultithreadingRouter implements the IMessageRouter interface.
@@ -31,9 +31,9 @@ class TestMultithreadingRouter(
         return MultithreadingContext()
 
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         IMessageRouterTests.setUp(self)
 
     def tearDown(self):
         IMessageRouterTests.tearDown(self)
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)

--- a/traits_futures/tests/test_test_assistant.py
+++ b/traits_futures/tests/test_test_assistant.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 """
-Tests for the GuiTestAssistant.
+Tests for the TestAssistant.
 """
 import time
 import unittest.mock
@@ -22,7 +22,7 @@ from traits_futures.api import (
     submit_call,
     TraitsExecutor,
 )
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 
 #: Maximum timeout for blocking calls, in seconds. A successful test should
 #: never hit this timeout - it's there to prevent a failing test from hanging
@@ -42,12 +42,12 @@ def slow_return():
     return 1729
 
 
-class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
+class TestTestAssistant(TestAssistant, unittest.TestCase):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
 
     def tearDown(self):
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
     def test_run_until_timeout(self):
         # Trait never fired, condition never true.

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -21,7 +21,7 @@ from traits_futures.api import (
     MultithreadingContext,
     TraitsExecutor,
 )
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.traits_executor_tests import (
     ExecutorListener,
     TraitsExecutorTests,
@@ -54,14 +54,14 @@ class TrackingTraitsExecutor(TraitsExecutor):
         return TraitsExecutor._TraitsExecutor__context_default(self)
 
 
-class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
+class TestTraitsExecutorCreation(TestAssistant, unittest.TestCase):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultithreadingContext()
 
     def tearDown(self):
         self._context.close()
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
     def test_max_workers(self):
         executor = TraitsExecutor(
@@ -228,10 +228,10 @@ class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
 
 
 class TestTraitsExecutor(
-    GuiTestAssistant, TraitsExecutorTests, unittest.TestCase
+    TestAssistant, TraitsExecutorTests, unittest.TestCase
 ):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultithreadingContext()
         self.executor = TraitsExecutor(
             context=self._context,
@@ -245,14 +245,14 @@ class TestTraitsExecutor(
         del self.executor
         self._context.close()
         del self._context
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
 
 class TestTraitsExecutorWithExternalWorkerPool(
-    GuiTestAssistant, TraitsExecutorTests, unittest.TestCase
+    TestAssistant, TraitsExecutorTests, unittest.TestCase
 ):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultithreadingContext()
         self._worker_pool = self._context.worker_pool()
         self.executor = TraitsExecutor(
@@ -270,4 +270,4 @@ class TestTraitsExecutorWithExternalWorkerPool(
         del self._worker_pool
         self._context.close()
         del self._context
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)

--- a/traits_futures/tests/test_traits_process_executor.py
+++ b/traits_futures/tests/test_traits_process_executor.py
@@ -20,7 +20,7 @@ from traits_futures.api import (
     MultithreadingContext,
     TraitsExecutor,
 )
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.traits_executor_tests import (
     ExecutorListener,
     TraitsExecutorTests,
@@ -32,14 +32,14 @@ from traits_futures.tests.traits_executor_tests import (
 SAFETY_TIMEOUT = 5.0
 
 
-class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
+class TestTraitsExecutorCreation(TestAssistant, unittest.TestCase):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultiprocessingContext()
 
     def tearDown(self):
         self._context.close()
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)
 
     def test_max_workers(self):
         executor = TraitsExecutor(
@@ -155,10 +155,10 @@ class TestTraitsExecutorCreation(GuiTestAssistant, unittest.TestCase):
 
 
 class TestTraitsExecutor(
-    GuiTestAssistant, TraitsExecutorTests, unittest.TestCase
+    TestAssistant, TraitsExecutorTests, unittest.TestCase
 ):
     def setUp(self):
-        GuiTestAssistant.setUp(self)
+        TestAssistant.setUp(self)
         self._context = MultiprocessingContext()
         self.executor = TraitsExecutor(
             context=self._context,
@@ -172,4 +172,4 @@ class TestTraitsExecutor(
         del self.executor
         self._context.close()
         del self._context
-        GuiTestAssistant.tearDown(self)
+        TestAssistant.tearDown(self)

--- a/traits_futures/wx/tests/test_pingee.py
+++ b/traits_futures/wx/tests/test_pingee.py
@@ -14,13 +14,13 @@ Tests for the Wx implementations of IPingee and IPinger.
 
 import unittest
 
-from traits_futures.testing.gui_test_assistant import GuiTestAssistant
 from traits_futures.testing.optional_dependencies import requires_wx
+from traits_futures.testing.test_assistant import TestAssistant
 from traits_futures.tests.i_pingee_tests import IPingeeTests
 
 
 @requires_wx
-class TestPingee(GuiTestAssistant, IPingeeTests, unittest.TestCase):
+class TestPingee(TestAssistant, IPingeeTests, unittest.TestCase):
     def event_loop_factory(self):
         from traits_futures.wx.event_loop import WxEventLoop
 


### PR DESCRIPTION
Step towards #304: this PR renames the Traits Futures `GuiTestAssistant`, to avoid confusion with the existing Pyface `GuiTestAssistant`.

The only problem is figuring out what to name it *to*. My first thought was `TraitsFuturesTestAssistant`, but that's getting a bit long. Instead we simply use `TestAssistant` (thanks @itziakos for the suggestion); users can make use of the context to disambiguate if necessary.