### PR TITLE
Fix marshal_exception not to use global state

### DIFF
--- a/traits_futures/exception_handling.py
+++ b/traits_futures/exception_handling.py
@@ -14,12 +14,28 @@ Support for transferring exception information from a background task.
 import traceback
 
 
-def marshal_exception(e):
+def marshal_exception(exception):
     """
     Turn exception details into something that can be safely
     transmitted across thread / process boundaries.
+
+    Parameters
+    ----------
+    exception : BaseException
+        The exception instance to be marshalled
+
+    Returns
+    -------
+    exception_type, exception_value, exception_traceback : str
+        Strings representing the exception type, value and
+        formatted traceback.
     """
-    exc_type = str(type(e))
-    exc_value = str(e)
-    formatted_traceback = str(traceback.format_exc())
-    return exc_type, exc_value, formatted_traceback
+    return (
+        str(type(exception)),
+        str(exception),
+        "".join(
+            traceback.format_exception(
+                type(exception), exception, exception.__traceback__
+            )
+        ),
+    )

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -44,3 +44,21 @@ class TestExceptionHandling(unittest.TestCase):
         self.assertEqual(exc_type, str(ValueError))
         self.assertIn(message, exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)
+
+    def test_marshal_exception_works_outside_except(self):
+        try:
+            raise RuntimeError("something went wrong")
+        except BaseException as exception:
+            stored_exception = exception
+
+        exc_type, exc_value, exc_traceback = marshal_exception(
+            stored_exception
+        )
+
+        self.assertIsInstance(exc_type, str)
+        self.assertIsInstance(exc_value, str)
+        self.assertIsInstance(exc_traceback, str)
+
+        self.assertEqual(exc_type, str(RuntimeError))
+        self.assertIn("something went wrong", exc_value)
+        self.assertIn("test_marshal_exception", exc_traceback)


### PR DESCRIPTION
The `marshal_exception` function used `formatted_traceback = str(traceback.format_exc())` to format the traceback, which implicitly picked up the exception details from `sys.exc_info()`. This meant that it only worked correctly from within an "except" block (which is the only way that we're currently using it). This indirection may have been necessary in Python 2, but for Python 3 we can access the traceback directly from the exception object.

This PR fixes `marshal_exception` to use the actual exception traceback.

While we're here, we also improve the `marshal_exception` docstring and tidy up the implementation.