### PR TITLE
Change string representation of marshalled exception type

### DIFF
--- a/traits_futures/exception_handling.py
+++ b/traits_futures/exception_handling.py
@@ -14,12 +14,28 @@ Support for transferring exception information from a background task.
 import traceback
 
 
-def marshal_exception(e):
+def marshal_exception(exception):
     """
     Turn exception details into something that can be safely
     transmitted across thread / process boundaries.
+
+    Parameters
+    ----------
+    exception : BaseException
+        The exception instance to be marshalled
+
+    Returns
+    -------
+    exception_type, exception_value, exception_traceback : str
+        Strings representing the exception type, value and
+        formatted traceback.
     """
-    exc_type = str(type(e))
-    exc_value = str(e)
-    formatted_traceback = str(traceback.format_exc())
-    return exc_type, exc_value, formatted_traceback
+    return (
+        str(type(exception)),
+        str(exception),
+        "".join(
+            traceback.format_exception(
+                type(exception), exception, exception.__traceback__
+            )
+        ),
+    )

--- a/traits_futures/exception_handling.py
+++ b/traits_futures/exception_handling.py
@@ -14,6 +14,34 @@ Support for transferring exception information from a background task.
 import traceback
 
 
+def _qualified_type_name(class_):
+    """
+    Compute a descriptive string representing a class, including
+    a module name where relevant.
+
+    Example outputs are "RuntimeError" for the built-in RuntimeError
+    exception, or "struct.error" for the struct module exception class.
+
+    Parameters
+    ----------
+    class_ : type
+
+    Returns
+    -------
+    class_name : str
+    """
+    # We're being extra conservative here and allowing for the possibility that
+    # the class doesn't have __module__ and/or __qualname__ attributes. This
+    # function is called during exception handling, so we want to minimise the
+    # possibility that it raises a new exception.
+    class_module = getattr(class_, "__module__", "<unknown>")
+    class_qualname = getattr(class_, "__qualname__", "<unknown>")
+    if class_module == "builtins":
+        return f"{class_qualname}"
+    else:
+        return f"{class_module}.{class_qualname}"
+
+
 def marshal_exception(exception):
     """
     Turn exception details into something that can be safely
@@ -31,7 +59,7 @@ def marshal_exception(exception):
         formatted traceback.
     """
     return (
-        str(type(exception)),
+        _qualified_type_name(type(exception)),
         str(exception),
         "".join(
             traceback.format_exception(

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -292,7 +292,7 @@ class BackgroundCallTests:
             future.result
 
     def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], str(exc_type))
+        self.assertIn(exc_type.__name__, future.exception[0])
 
     def assertNoException(self, future):
         with self.assertRaises(AttributeError):

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -448,7 +448,7 @@ class BackgroundIterationTests:
             future.result
 
     def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], str(exc_type))
+        self.assertIn(exc_type.__name__, future.exception[0])
 
     def assertNoException(self, future):
         with self.assertRaises(AttributeError):

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -332,4 +332,4 @@ class BackgroundProgressTests:
             future.exception
 
     def assertException(self, future, exc_type):
-        self.assertEqual(future.exception[0], str(exc_type))
+        self.assertIn(exc_type.__name__, future.exception[0])

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -13,6 +13,10 @@ import unittest
 from traits_futures.exception_handling import marshal_exception
 
 
+class CustomException(Exception):
+    """Custom exception for testing purposes."""
+
+
 class TestExceptionHandling(unittest.TestCase):
     def test_marshal_exception(self):
         try:
@@ -25,7 +29,7 @@ class TestExceptionHandling(unittest.TestCase):
         self.assertIsInstance(exc_value, str)
         self.assertIsInstance(exc_traceback, str)
 
-        self.assertEqual(exc_type, str(RuntimeError))
+        self.assertEqual(exc_type, "RuntimeError")
         self.assertIn("something went wrong", exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)
 
@@ -41,7 +45,7 @@ class TestExceptionHandling(unittest.TestCase):
         self.assertIsInstance(exc_value, str)
         self.assertIsInstance(exc_traceback, str)
 
-        self.assertEqual(exc_type, str(ValueError))
+        self.assertEqual(exc_type, "ValueError")
         self.assertIn(message, exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)
 
@@ -59,6 +63,41 @@ class TestExceptionHandling(unittest.TestCase):
         self.assertIsInstance(exc_value, str)
         self.assertIsInstance(exc_traceback, str)
 
-        self.assertEqual(exc_type, str(RuntimeError))
+        self.assertEqual(exc_type, "RuntimeError")
         self.assertIn("something went wrong", exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)
+
+    def test_marshal_exception_non_builtin(self):
+        message = "printer on fire"
+        try:
+            raise CustomException(message)
+        except BaseException as exception:
+            marshalled = marshal_exception(exception)
+
+        exc_type, exc_value, exc_traceback = marshalled
+        self.assertIsInstance(exc_type, str)
+        self.assertIsInstance(exc_value, str)
+        self.assertIsInstance(exc_traceback, str)
+
+        self.assertEqual(
+            exc_type,
+            "traits_futures.tests.test_exception_handling.CustomException",
+        )
+        self.assertIn(message, exc_value)
+        self.assertIn("test_marshal_exception", exc_traceback)
+
+    def test_marshal_exception_nested_exception(self):
+        class NestedException(Exception):
+            pass
+
+        try:
+            raise NestedException()
+        except BaseException as exception:
+            marshalled = marshal_exception(exception)
+
+        exc_type, exc_value, exc_traceback = marshalled
+        self.assertEqual(
+            exc_type,
+            f"{__name__}.TestExceptionHandling."
+            "test_marshal_exception_nested_exception.<locals>.NestedException",
+        )

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -44,3 +44,21 @@ class TestExceptionHandling(unittest.TestCase):
         self.assertEqual(exc_type, str(ValueError))
         self.assertIn(message, exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)
+
+    def test_marshal_exception_works_outside_except(self):
+        try:
+            raise RuntimeError("something went wrong")
+        except BaseException as exception:
+            stored_exception = exception
+
+        exc_type, exc_value, exc_traceback = marshal_exception(
+            stored_exception
+        )
+
+        self.assertIsInstance(exc_type, str)
+        self.assertIsInstance(exc_value, str)
+        self.assertIsInstance(exc_traceback, str)
+
+        self.assertEqual(exc_type, str(RuntimeError))
+        self.assertIn("something went wrong", exc_value)
+        self.assertIn("test_marshal_exception", exc_traceback)

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -81,7 +81,7 @@ class TestExceptionHandling(unittest.TestCase):
 
         self.assertEqual(
             exc_type,
-            "traits_futures.tests.test_exception_handling.CustomException",
+            f"{__name__}.CustomException",
         )
         self.assertIn(message, exc_value)
         self.assertIn("test_marshal_exception", exc_traceback)


### PR DESCRIPTION
[PR made against the branch for #390, for ease of review]

This PR changes the representation of the exception class used when reporting exceptions. Previously we just used the `str` of the exception class, giving strings like `"<class 'RuntimeError'>"`. With this PR we give a more direct string, including the module name where appropriate, for example `"RuntimeError"` or `"struct.error"`

Fixes #379.

See also #318.