### PR TITLE
Refactor to add ABANDONED message

### DIFF
--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -40,8 +40,10 @@ def dummy_cancel_callback():
 # A future must always be initialized before anything else happens, and then a
 # complete run must always involve "abandoned", "started, raised" or "started,
 # returned" in that order. In addition, a single cancellation is possible at
-# any time before the end of the sequence (and "abandoned" must always be
-# preceded by cancellation).
+# any time before the end of the sequence, and abandoned can only ever occur
+# following cancellation.
+
+MESSAGE_TYPES = "IASRXC"
 
 COMPLETE_VALID_SEQUENCES = {
     "ISR",
@@ -178,7 +180,7 @@ class CommonFutureTests:
             seq[:i] + msg
             for seq in valid_initial_sequences
             for i in range(len(seq) + 1)
-            for msg in "ICRSX"
+            for msg in MESSAGE_TYPES
         }
         invalid_sequences = continuations - valid_initial_sequences
 
@@ -220,10 +222,10 @@ class CommonFutureTests:
             future._task_abandoned(None)
         elif message == "S":
             future._task_started(None)
-        elif message == "X":
-            future._task_raised(self.fake_exception())
         elif message == "R":
             future._task_returned(23)
+        elif message == "X":
+            future._task_raised(self.fake_exception())
         elif message == "C":
             future._user_cancelled()
         else:

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -31,15 +31,17 @@ def dummy_cancel_callback():
 # that a future might encounter. Here:
 #
 # * I represents the executor initializing the future
+# * A represents the background task being abandoned before starting
 # * S represents the background task starting
 # * X represents the background task failing with an exception
 # * R represents the background task returning a result
 # * C represents the user cancelling.
 #
 # A future must always be initialized before anything else happens, and then a
-# complete run must always involve "started, raised" or "started, returned" in
-# that order. In addition, a single cancellation is possible at any time before
-# the end of the sequence.
+# complete run must always involve "abandoned", "started, raised" or "started,
+# returned" in that order. In addition, a single cancellation is possible at
+# any time before the end of the sequence (and "abandoned" must always be
+# preceded by cancellation).
 
 COMPLETE_VALID_SEQUENCES = {
     "ISR",
@@ -48,6 +50,7 @@ COMPLETE_VALID_SEQUENCES = {
     "ICSX",
     "ISCR",
     "ISCX",
+    "ICA",
 }
 
 
@@ -213,15 +216,18 @@ class CommonFutureTests:
         """Send a particular message to a future."""
         if message == "I":
             future._executor_initialized(cancel_callback)
+        elif message == "A":
+            future._task_abandoned(None)
         elif message == "S":
             future._task_started(None)
         elif message == "X":
             future._task_raised(self.fake_exception())
         elif message == "R":
             future._task_returned(23)
-        else:
-            assert message == "C"
+        elif message == "C":
             future._user_cancelled()
+        else:
+            raise ValueError(f"message {message} not understood")
 
     def send_message_sequence(self, messages, cancel_callback=None):
         """Create a new future, and send the given message sequence to it."""


### PR DESCRIPTION
This is a slight cleanup of the `BaseFuture` and wrapper logic.

Previously, when execution of the background task's callable was abandoned due to cancellation, we acted as though it had run anyway, sending a STARTED message followed by a RETURNED message (with an argument of None) to the future. That was slightly smelly (inventing a return result when none existed), and involved sending and processing two messages when one would have been sufficient.

This PR introduces a new ABANDONED message for this. It also:

- expands the `CANCELLED` future state into three different internal states, depending on whether the task's callable completed, failed, or was never executed (abandoned)
- keeps the result and/or the exception information from the background task even when cancellation occurred. It's private, but it's there to be used during debugging if necessary
- annotates the semi-private methods in the `BaseFuture` to add explicit state changes

This PR is pure refactoring: it introduces no user-visible changes. The tests for the internals of the `BaseFuture` did need to be updated to take account of the extra message type. I'll self-merge after self-review.