### PR TITLE
Remove bogus "message" trait from IFuture

### DIFF
--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -14,7 +14,7 @@ Interface for futures returned by the executor.
 
 import abc
 
-from traits.api import Any, Bool, Event, Interface, Property, Str, Tuple
+from traits.api import Bool, Interface, Property
 
 from traits_futures.future_states import FutureState
 
@@ -41,12 +41,6 @@ class IFuture(Interface):
     #: for changes: it will always fire exactly once, and when it fires
     #: it will be consistent with the ``state``.
     done = Property(Bool())
-
-    #: Event trait providing custom messages from the background task.
-    #: Subclasses of ``BaseFuture`` can listen to this trait and interpret
-    #: the messages in whatever way they like. Each message takes the
-    #: form ``(message_type, message_args)``.
-    message = Event(Tuple(Str(), Any()))
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
The `IFuture` interface declares a `message` trait that was a leftover from refactoring: it's not implemented by any of the concrete implementations, and is not used. This PR removes it.