### PR TITLE
Fix bad string interpolation in shutdown log message

### DIFF
--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -235,7 +235,7 @@ class TraitsExecutorTests:
     def test_shutdown_timeout(self):
         start_time = time.monotonic()
         with self.long_running_task(self.executor):
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, "1 tasks still running"):
                 self.executor.shutdown(timeout=0.1)
 
         actual_timeout = time.monotonic() - start_time

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -367,7 +367,7 @@ class TraitsExecutor(HasStrictTraits):
                 # Re-raise with a more user-friendly error message.
                 raise RuntimeError(
                     "Shutdown timed out; "
-                    "f{len(self._wrappers)} tasks still running"
+                    f"{len(self._wrappers)} tasks still running"
                 ) from exc
 
         self._complete_stop()


### PR DESCRIPTION
Fix an f-string that wasn't.

To do: could use a regression test.