### PR TITLE
Decouple TraitsExecutor from future implementation

### DIFF
--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -19,15 +19,17 @@ Traits Futures comes with three basic background task types: background calls,
 background iterations and background progress calls, created via the
 |submit_call|, |submit_iteration| and |submit_progress| functions,
 respectively. In each case, communication from the background task to the
-corresponding foreground |IFuture| instance is implemented by sending
-custom task-type-specific messages, with the type of message identified by
-a suitable string. For example, the background progress task sends messages
-of type ``"progress"`` to report progress, while the background iteration task
-sends messages of type ``"generated"``.
+corresponding foreground |IFuture| instance is implemented by sending custom
+task-type-specific messages of the form ``(message_type, message_value)``,
+where ``message_type`` is a suitable string describing the type of the message.
+For example, the progress task sends messages of type ``"progress"`` to report
+progress, while the background iteration task sends messages of type
+``"generated"``.
 
 If none of the standard task types meets your needs, it's possible to write
-your own background task type, that sends whatever messages you like. This
-section describes how to do this in detail.
+your own background task type, that sends whatever messages you like. Two base
+classes, |BaseFuture| and |BaseTask|, are made available to make this easier.
+This section describes how to do this in detail.
 
 To create your own task type, you'll need three ingredients:
 
@@ -37,6 +39,9 @@ To create your own task type, you'll need three ingredients:
   interface. The |submit| method of the TraitsExecutor expects an instance of
   |ITaskSpecification|, and interrogates that instance to get the background
   callable and the corresponding foreground future.
+
+You may optionally also want to create a convenience function analogous to the
+existing |submit_call|, |submit_iteration| and |submit_progress| functions.
 
 Below we give a worked example that demonstrates how to create each of these
 ingredients for a simple case.
@@ -54,7 +59,7 @@ is accompanied by the corresponding number.
 Message types
 ~~~~~~~~~~~~~
 
-In general, the message sent from the background task to the future can be any
+In general, each message sent from the background task to the future can be any
 Python object, and the future can interpret the sent object in any way that it
 likes. However, the |BaseFuture| and |BaseTask| convenience base classes that
 we'll use below provide helper functions to handle and dispatch messages of

--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -56,9 +56,9 @@ Message types
 
 In general, the message sent from the background task to the future can be any
 Python object, and the future can interpret the sent object in any way that it
-likes. However, the |BaseFuture| base class that we'll use below provides a
-default dispatcher for messages, and that dispatcher expects those messages to
-have the form ``(message_type, message_args)``. Here the message type should be
+likes. However, the |BaseFuture| and |BaseTask| convenience base classes that
+we'll use below provide helper functions to handle and dispatch messages of
+the form ``(message_type, message_args)``. Here the message type should be
 a string that's valid as a Python identifier, while the message argument can be
 any Python object (though it should usually be pickleable and immutable).
 
@@ -76,8 +76,12 @@ Next, we define the callable that will be run in the background. This callable
 must accept two arguments (which will be passed by position): ``send`` and
 ``cancelled``. The ``send`` object is a callable which will be used to send
 messages to the foreground. The ``cancelled`` object is a zero-argument
-callable which can be used to check for cancellation requests. Here's the
-``fizz_buzz`` callable.
+callable which can be used to check for cancellation requests. For convenience,
+we inherit from |BaseTask|, which takes care of sending standard messages
+to the future letting the future know that the background task has started,
+stopped, or raised an exception.
+
+Here's the ``fizz_buzz`` callable.
 
 .. literalinclude:: examples/fizz_buzz_task.py
     :start-after: start fizz_buzz
@@ -172,6 +176,7 @@ of the new background task type:
    substitutions
 
 .. |BaseFuture| replace:: :class:`~.BaseFuture`
+.. |BaseTask| replace:: :class:`~.BaseTask`
 .. |exception| replace:: :attr:`~traits_futures.i_future.IFuture.exception`
 .. |HasStrictTraits| replace:: :class:`~traits.has_traits.HasStrictTraits`
 .. |IFuture| replace:: :class:`~.IFuture`

--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -30,10 +30,14 @@ FIZZ_BUZZ = "fizz_buzz"
 # -- start fizz_buzz --
 import time
 
+from traits_futures.api import BaseTask
 
-def fizz_buzz(send, cancelled):
+
+class FizzBuzzTask(BaseTask):
     """
-    Count slowly from 1, sending FIZZ / BUZZ messages to the foreground.
+    Background task for Fizz Buzz
+
+    Counts slowly from 1, sending FIZZ / BUZZ messages to the foreground.
 
     Parameters
     ----------
@@ -46,21 +50,22 @@ def fizz_buzz(send, cancelled):
         returns ``True`` if cancellation has been requested, and ``False``
         otherwise.
     """
-    n = 1
-    while not cancelled():
+    def run(self, send, cancelled):
+        n = 1
+        while not cancelled():
 
-        n_is_multiple_of_3 = n % 3 == 0
-        n_is_multiple_of_5 = n % 5 == 0
+            n_is_multiple_of_3 = n % 3 == 0
+            n_is_multiple_of_5 = n % 5 == 0
 
-        if n_is_multiple_of_3 and n_is_multiple_of_5:
-            send((FIZZ_BUZZ, n))
-        elif n_is_multiple_of_3:
-            send((FIZZ, n))
-        elif n_is_multiple_of_5:
-            send((BUZZ, n))
+            if n_is_multiple_of_3 and n_is_multiple_of_5:
+                send((FIZZ_BUZZ, n))
+            elif n_is_multiple_of_3:
+                send((FIZZ, n))
+            elif n_is_multiple_of_5:
+                send((BUZZ, n))
 
-        time.sleep(1.0)
-        n += 1
+            time.sleep(1.0)
+            n += 1
 # -- end fizz_buzz --
 
 
@@ -132,7 +137,7 @@ class BackgroundFizzBuzz:
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return fizz_buzz
+        return FizzBuzzTask()
 # -- end BackgroundFizzBuzz
 
 

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -61,6 +61,7 @@ Support for user-defined background tasks
 -----------------------------------------
 
 - :class:`~.BaseFuture`
+- :class:`~.BaseTask`
 - :class:`~.ITaskSpecification`
 
 Parallelism contexts
@@ -89,7 +90,7 @@ from traits_futures.background_progress import (
     ProgressFuture,
     submit_progress,
 )
-from traits_futures.base_future import BaseFuture
+from traits_futures.base_future import BaseFuture, BaseTask
 from traits_futures.ets_event_loop import ETSEventLoop
 from traits_futures.executor_states import (
     ExecutorState,
@@ -142,6 +143,7 @@ __all__ = [
     "submit_progress",
     # Support for creating new task types
     "BaseFuture",
+    "BaseTask",
     "ITaskSpecification",
     # Contexts
     "IParallelContext",

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -13,11 +13,11 @@ Background task consisting of a simple callable.
 """
 from traits.api import Callable, Dict, HasStrictTraits, Str, Tuple
 
-from traits_futures.base_future import BaseFuture
+from traits_futures.base_future import BaseFuture, BaseTask
 from traits_futures.i_task_specification import ITaskSpecification
 
 
-class CallBackgroundTask:
+class CallTask(BaseTask):
     """
     Wrapper around the actual callable to be run. This wrapper provides the
     task that will be submitted to the concurrent.futures executor
@@ -28,7 +28,7 @@ class CallBackgroundTask:
         self.args = args
         self.kwargs = kwargs
 
-    def __call__(self, send, cancelled):
+    def run(self, send, cancelled):
         return self.callable(*self.args, **self.kwargs)
 
 
@@ -76,7 +76,7 @@ class BackgroundCall(HasStrictTraits):
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return CallBackgroundTask(
+        return CallTask(
             callable=self.callable,
             args=self.args,
             kwargs=self.kwargs,

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -14,7 +14,7 @@ Background task that sends results from an iteration.
 
 from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
-from traits_futures.base_future import BaseFuture
+from traits_futures.base_future import BaseFuture, BaseTask
 from traits_futures.i_task_specification import ITaskSpecification
 
 #: Message sent whenever the iteration yields a result.
@@ -22,7 +22,7 @@ from traits_futures.i_task_specification import ITaskSpecification
 GENERATED = "generated"
 
 
-class IterationBackgroundTask:
+class IterationTask(BaseTask):
     """
     Iteration to be executed in the background.
     """
@@ -32,7 +32,7 @@ class IterationBackgroundTask:
         self.args = args
         self.kwargs = kwargs
 
-    def __call__(self, send, cancelled):
+    def run(self, send, cancelled):
         iterable = iter(self.callable(*self.args, **self.kwargs))
 
         while True:
@@ -104,7 +104,7 @@ class BackgroundIteration(HasStrictTraits):
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return IterationBackgroundTask(
+        return IterationTask(
             callable=self.callable,
             args=self.args,
             kwargs=self.kwargs,

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -21,7 +21,7 @@ be cancelled.
 
 from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
-from traits_futures.base_future import BaseFuture
+from traits_futures.base_future import BaseFuture, BaseTask
 from traits_futures.i_task_specification import ITaskSpecification
 
 # Message types for messages from ProgressBackgroundTask
@@ -73,7 +73,7 @@ class ProgressReporter:
         self.send((PROGRESS, progress_info))
 
 
-class ProgressBackgroundTask:
+class ProgressTask(BaseTask):
     """
     Background portion of a progress background task.
 
@@ -86,7 +86,7 @@ class ProgressBackgroundTask:
         self.args = args
         self.kwargs = kwargs
 
-    def __call__(self, send, cancelled):
+    def run(self, send, cancelled):
         progress = ProgressReporter(send=send, cancelled=cancelled)
         try:
             return self.callable(
@@ -150,7 +150,7 @@ class BackgroundProgress(HasStrictTraits):
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return ProgressBackgroundTask(
+        return ProgressTask(
             callable=self.callable,
             args=self.args,
             kwargs=self.kwargs,

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -12,14 +12,6 @@
 Base class providing common pieces of the Future machinery.
 """
 
-# XXX To do: consider a return value from 'message' instead of having
-# the executor make use of the 'done' trait.
-# XXX Add 'receive' to IFuture interface.
-# XXX Consider not using trait for receiver.
-# XXX Better receiver cleanup.
-# XXX Where should the responsibility for not passing on messages after
-#     cancellation lie?
-
 from traits.api import (
     Any,
     Bool,
@@ -69,6 +61,9 @@ RAISED = "raised"
 #: and returned a result. The argument is that result.
 RETURNED = "returned"
 
+#: Message types that indicate a "final" message. After a message of this
+#: type is received, no more messages will be received.
+FINAL_MESSAGES = {ABANDONED, RAISED, RETURNED}
 
 # The BaseFuture class maintains an internal state. That internal state maps to
 # the user-facing state, but is more fine-grained, allowing the class to keep
@@ -258,6 +253,7 @@ class BaseFuture(HasStrictTraits):
         message_type, message_arg = message
         method_name = "_task_{}".format(message_type)
         getattr(self, method_name)(message_arg)
+        return message_type in FINAL_MESSAGES
 
     # Semi-private methods ####################################################
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -12,6 +12,14 @@
 Base class providing common pieces of the Future machinery.
 """
 
+# XXX To do: consider a return value from 'message' instead of having
+# the executor make use of the 'done' trait.
+# XXX Add 'receive' to IFuture interface.
+# XXX Consider not using trait for receiver.
+# XXX Better receiver cleanup.
+# XXX Where should the responsibility for not passing on messages after
+#     cancellation lie?
+
 from traits.api import (
     Any,
     Bool,

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -39,7 +39,7 @@ from traits_futures.future_states import (
 )
 from traits_futures.i_future import IFuture
 
-# Messages sent by the InnerWrapper, and interpreted by BaseFuture.
+# Messages sent by the BaseTask, and interpreted by BaseFuture.
 
 #: Custom message from the future. The argument is a pair
 #: (message_type, message_args); the message type and message args

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -102,3 +102,23 @@ class IFuture(Interface):
             If the task has already completed or cancellation has already
             been requested.
         """
+
+    @abc.abstractmethod
+    def receive(self, message):
+        """
+        Receive and process a message from the task associated to this future.
+
+        This method is primarily for use by the executors, but may also be of
+        use in testing.
+
+        Parameters
+        ----------
+        message : object
+            The message received from the associated task.
+
+        Returns
+        -------
+        final : bool
+            True if the received message should be the last one ever received
+            from the paired task.
+        """

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -16,6 +16,7 @@ class TestApi(unittest.TestCase):
         from traits_futures.api import (  # noqa: F401
             AsyncioEventLoop,
             BaseFuture,
+            BaseTask,
             CallFuture,
             CANCELLED,
             CANCELLING,

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -41,7 +41,7 @@ from traits_futures.executor_states import (
 from traits_futures.i_event_loop import IEventLoop
 from traits_futures.i_parallel_context import IParallelContext
 from traits_futures.multithreading_context import MultithreadingContext
-from traits_futures.wrappers import BackgroundTaskWrapper, FutureWrapper
+from traits_futures.wrappers import FutureWrapper, run_background_task
 
 logger = logging.getLogger(__name__)
 
@@ -306,10 +306,9 @@ class TraitsExecutor(HasStrictTraits):
         runner = task.background_task()
         future = task.future()
 
-        background_task_wrapper = BackgroundTaskWrapper(
-            runner, sender, cancel_event.is_set
+        self._worker_pool.submit(
+            run_background_task, runner, sender, cancel_event.is_set
         )
-        self._worker_pool.submit(background_task_wrapper)
 
         future._executor_initialized(cancel_event.set)
         future_wrapper = FutureWrapper(
@@ -367,7 +366,7 @@ class TraitsExecutor(HasStrictTraits):
                 # Re-raise with a more user-friendly error message.
                 raise RuntimeError(
                     "Shutdown timed out; "
-                    "f{len(self._wrappers)} tasks still running"
+                    f"{len(self._wrappers)} tasks still running"
                 ) from exc
 
         self._complete_stop()

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -366,7 +366,7 @@ class TraitsExecutor(HasStrictTraits):
                 # Re-raise with a more user-friendly error message.
                 raise RuntimeError(
                     "Shutdown timed out; "
-                    f"{len(self._wrappers)} tasks still running"
+                    "f{len(self._wrappers)} tasks still running"
                 ) from exc
 
         self._complete_stop()

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -41,20 +41,15 @@ class FutureWrapper(HasStrictTraits):
     #: its own internal state.
     done = Bool(False)
 
-    @observe("future:done")
-    def _update_done_trait(self, event):
-        """
-        Update our own 'done' trait to reflect the future's 'done' trait.
-        """
-        self.done = event.new
-
     @observe("receiver:message")
     def _dispatch_to_future(self, event):
         """
         Pass on a message to the future.
         """
         message = event.new
-        self.future.receive(message)
+        done = self.future.receive(message)
+        if done:
+            self.done = True
 
 
 def run_background_task(background_task, sender, cancelled):

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -18,42 +18,16 @@ import logging
 
 from traits.api import Bool, HasStrictTraits, HasTraits, Instance, observe
 
-from traits_futures.exception_handling import marshal_exception
 from traits_futures.i_future import IFuture
 
 logger = logging.getLogger(__name__)
-
-
-# Messages sent by the BackgroundTaskWrapper, and interpreted by the
-# FutureWrapper.
-
-#: Custom message from the future. The argument is a pair
-#: (message_type, message_args); the message type and message args
-#: are interpreted by the future.
-SENT = "sent"
-
-#: Control message sent when the callable is abandoned before execution.
-ABANDONED = "abandoned"
-
-#: Control message sent before we start to process the target callable.
-#: The argument is always ``None``.
-STARTED = "started"
-
-#: Control message sent when an exception was raised by the background
-#: callable. The argument is a tuple containing exception information.
-RAISED = "raised"
-
-#: Control message sent to indicate that the background callable succeeded
-#: and returned a result. The argument is that result.
-RETURNED = "returned"
 
 
 class FutureWrapper(HasStrictTraits):
     """
     Wrapper for the IFuture.
 
-    This wrapper handles control messages from the background task, and
-    delegates custom messages to the future.
+    Passes on messages received for this future.
     """
 
     #: The Traits Futures future being wrapped
@@ -67,20 +41,22 @@ class FutureWrapper(HasStrictTraits):
     #: its own internal state.
     done = Bool(False)
 
+    @observe("future:done")
+    def _update_done_trait(self, event):
+        """
+        Update our own 'done' trait to reflect the future's 'done' trait.
+        """
+        self.done = event.new
+
     @observe("receiver:message")
     def _dispatch_to_future(self, event):
         """
         Pass on a message to the future.
         """
-        message = event.new
-        message_type, message_arg = message
-        method_name = "_task_{}".format(message_type)
-        getattr(self.future, method_name)(message_arg)
-        if message_type in {ABANDONED, RAISED, RETURNED}:
-            self.done = True
+        self.future._message = event.new
 
 
-class BackgroundTaskWrapper:
+def run_background_task(background_task, sender, cancelled):
     """
     Wrapper for callables submitted to the underlying executor.
 
@@ -92,45 +68,15 @@ class BackgroundTaskWrapper:
     sender : IMessageSender
         Object used to send messages.
     cancelled : collections.abc.Callable
-        Zero-argument callable returning bool. This can be called to check
-        whether cancellation has been requested.
+        Zero-argument callable returning bool, used to check whether
+        cancellation has been requested.
     """
-
-    def __init__(self, background_task, sender, cancelled):
-        self._background_task = background_task
-        self._sender = sender
-        self._cancelled = cancelled
-
-    def __call__(self):
-        try:
-            with self._sender:
-                if self._cancelled():
-                    self._sender.send((ABANDONED, None))
-                    return
-
-                self._sender.send((STARTED, None))
-                try:
-                    result = self._background_task(
-                        self._send_custom_message, self._cancelled
-                    )
-                except BaseException as e:
-                    self._sender.send((RAISED, marshal_exception(e)))
-                else:
-                    self._sender.send((RETURNED, result))
-        except BaseException:
-            # We'll only ever get here in the case of a coding error. But in
-            # case that happens, it's useful to have the exception logged to
-            # help the developer.
-            logger.exception("Unexpected exception in background task.")
-            raise
-
-    def _send_custom_message(self, message):
-        """
-        Send a custom message from the background task to the future.
-
-        Parameters
-        ----------
-        message : object
-            The message to be sent.
-        """
-        self._sender.send((SENT, message))
+    try:
+        with sender:
+            background_task(sender.send, cancelled)
+    except BaseException:
+        # We'll only ever get here in the case of a coding error. But in
+        # case that happens, it's useful to have the exception logged to
+        # help the developer.
+        logger.exception("Unexpected exception in background task.")
+        raise

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -53,7 +53,8 @@ class FutureWrapper(HasStrictTraits):
         """
         Pass on a message to the future.
         """
-        self.future._message = event.new
+        message = event.new
+        self.future.receive(message)
 
 
 def run_background_task(background_task, sender, cancelled):


### PR DESCRIPTION
This PR refactors the `TraitsExecutor`, wrapper, and `BaseFuture` machinery to better decouple the `TraitsExecutor` from the tasks it's executing. 

Previously, the `TraitsExecutor`, via the `BackgroundTaskWrapper`, sent messages of types `STARTED`, `RAISED`, `RETURNED`, `ABANDONED` and `SENT` to the future, and relied on the machinery in the `BaseFuture` to interpret those messages. The knowledge of the message types was partly encoded in the wrapper and partly in the `BaseFuture`.

But the `TraitsExecutor` needs much less than this: it shouldn't care about the details of these messages and their formats. All it cares about is that it can:

- send arbitrary messages received from a background task to its corresponding future
- know when a future has completed
- know when a future is cancellable, and be able to cancel it

So the `TraitsExecutor` really needs just a subset of the `IFuture` interface: `cancel` and `cancellable`, along with a way to deliver messages. The `STARTED`, `RAISED` etc. machinery can be moved next to the various future implementations.

This PR implements that change. In more detail:

- The `BackgroundTaskWrapper` has been removed. Its functionality is now split between the new `run_background_task` function and the new `BaseTask` base class. This is the most fundamental change in this PR - it achieves the separation of concerns that was missing in the `BackgroundTaskWrapper`: `run_background_task` encapsulates that part of the `BackgroundTaskWrapper` that was catering to the `TraitsExecutor`, while `BaseTask` encapsulates the task-side knowledge that the executor shouldn't need to concern itself with
- The new `BaseTask` class has been added to `traits_futures.api` (and a test for it added to `test_api`)
- The `IFuture` interface has a new, documented, `receive` method, and the `BaseFuture` implements this with the same default message dispatch mechanism that previously existed. Only the location of that code, its name, and the fact that it's now public and a documented part of the `IFuture` interface has changed. The actual code has not. Except: ...
- The `receive` method now returns a boolean indicating whether the message received represents the final message from the task or not. The executor uses this to determine when it can clean up, instead of listening to the future's `done` trait.
- Existing background task types have been adapted to use `BaseTask`
- The documentation on writing your own task type has been updated, as has the `fizz_buzz_task` example task, to use the new `BaseTask`
 

See also:
- PR #364, which partially enabled this PR
- The proposed change in #398, which would reduce the set of `IFuture` methods that the `TraitsExecutor` needs to know about to just `received` and `cancel`.