### PR TITLE
Rename task classes

### DIFF
--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -17,7 +17,7 @@ from traits_futures.base_future import BaseFuture
 from traits_futures.i_task_specification import ITaskSpecification
 
 
-class CallBackgroundTask:
+class CallTask:
     """
     Wrapper around the actual callable to be run. This wrapper provides the
     task that will be submitted to the concurrent.futures executor
@@ -76,7 +76,7 @@ class BackgroundCall(HasStrictTraits):
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return CallBackgroundTask(
+        return CallTask(
             callable=self.callable,
             args=self.args,
             kwargs=self.kwargs,

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -22,7 +22,7 @@ from traits_futures.i_task_specification import ITaskSpecification
 GENERATED = "generated"
 
 
-class IterationBackgroundTask:
+class IterationTask:
     """
     Iteration to be executed in the background.
     """
@@ -104,7 +104,7 @@ class BackgroundIteration(HasStrictTraits):
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return IterationBackgroundTask(
+        return IterationTask(
             callable=self.callable,
             args=self.args,
             kwargs=self.kwargs,

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -24,7 +24,7 @@ from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 from traits_futures.base_future import BaseFuture
 from traits_futures.i_task_specification import ITaskSpecification
 
-# Message types for messages from ProgressBackgroundTask
+# Message types for messages from ProgressTask
 # to ProgressFuture.
 
 #: Task sends progress. Argument is a single object giving progress
@@ -73,7 +73,7 @@ class ProgressReporter:
         self.send((PROGRESS, progress_info))
 
 
-class ProgressBackgroundTask:
+class ProgressTask:
     """
     Background portion of a progress background task.
 
@@ -100,7 +100,7 @@ class ProgressBackgroundTask:
 
 class ProgressFuture(BaseFuture):
     """
-    Object representing the front-end handle to a ProgressBackgroundTask.
+    Object representing the front-end handle to a ProgressTask.
     """
 
     #: Event fired whenever a progress message arrives from the background.
@@ -150,7 +150,7 @@ class BackgroundProgress(HasStrictTraits):
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
         """
-        return ProgressBackgroundTask(
+        return ProgressTask(
             callable=self.callable,
             args=self.args,
             kwargs=self.kwargs,

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -403,7 +403,7 @@ class BackgroundIterationTests:
 
         try:
             # midpoint won't be set until we next invoke "next(iterable)",
-            # by which time the IterationBackgroundTask's reference should
+            # by which time the IterationTask's reference should
             # have been deleted.
             self.assertTrue(midpoint.wait(timeout=TIMEOUT))
             self.assertIsNone(ref())


### PR DESCRIPTION
This PR renames some internal classes that aren't exposed in `traits_futures.api`:

`BackgroundCallTask` -> `CallTask`
`BackgroundIterationTask` -> `IterationTask`
`BackgroundProgressTask` -> `ProgressTask`

The original names are unwieldy, and the `Background` portion of the names is both inaccurate (objects of these classes could equally well be run in any thread) and doesn't add anything useful.