### PR TITLE
Reduce Sphinx warnings from 'callable' and 'optional'

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,6 +98,17 @@ todo_include_todos = False
 # Don't include parentheses after function and method names.
 add_function_parentheses = False
 
+# -- Options for Napoleon extension ---------------------------------------
+
+# Do pre-process NumPyDoc - style type strings. This prevents warnings
+# resembling "py:class reference target not found: optional".
+napoleon_preprocess_types = True
+
+# Other terms that might appear in type strings.
+napoleon_type_aliases = {
+    "callable": ":class:`collections.abc.Callable`",
+}
+
 # -- Options for Graphviz extension ---------------------------------------
 
 # Output format when building HTML files

--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -127,7 +127,7 @@ class BackgroundFizzBuzz:
 
         Returns
         -------
-        collections.abc.Callable
+        callable
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -71,7 +71,7 @@ class BackgroundCall(HasStrictTraits):
 
         Returns
         -------
-        collections.abc.Callable
+        callable
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
@@ -91,7 +91,7 @@ def submit_call(executor, callable, *args, **kwargs):
     ----------
     executor : TraitsExecutor
         Executor to submit the task to.
-    callable : collections.abc.Callable
+    callable : callable
         Callable to execute in the background.
     *args
         Positional arguments to pass to the callable.

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -99,7 +99,7 @@ class BackgroundIteration(HasStrictTraits):
 
         Returns
         -------
-        collections.abc.Callable
+        callable
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
@@ -119,7 +119,7 @@ def submit_iteration(executor, callable, *args, **kwargs):
     ----------
     executor : TraitsExecutor
         Executor to submit the task to.
-    callable : collections.abc.Callable
+    callable : callable
         Callable returning an iterator when called with the given arguments.
     *args
         Positional arguments to pass to the callable.

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -145,7 +145,7 @@ class BackgroundProgress(HasStrictTraits):
 
         Returns
         -------
-        collections.abc.Callable
+        callable
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
@@ -165,7 +165,7 @@ def submit_progress(executor, callable, *args, **kwargs):
     ----------
     executor : TraitsExecutor
         Executor to submit the task to.
-    callable : collections.abc.Callable
+    callable : callable
         Callable that executes the progress-providing function. This callable
         must accept a "progress" named argument, in addition to the provided
         arguments. The callable may then call the "progress" argument to

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -86,12 +86,12 @@ class BackgroundTaskWrapper:
 
     Parameters
     ----------
-    background_task : collections.abc.Callable
+    background_task : callable
         Callable representing the background task. This will be called
         with arguments ``send`` and ``cancelled``.
     sender : IMessageSender
         Object used to send messages.
-    cancelled : collections.abc.Callable
+    cancelled : callable
         Zero-argument callable returning bool. This can be called to check
         whether cancellation has been requested.
     """


### PR DESCRIPTION
Towards #354:

- Enable preprocessing of type strings, which should fix complaints about use of things like "float, optional" in numpydoc type declarations
- Enable special understanding of the type notation "callable".
- Remove existing uses of `collections.abc.Callable`, which were part of a previous attempt to reduce the number of Sphinx warnings