### PR TITLE
Doc: fix descriptions coming after Parameters

### DIFF
--- a/traits_futures/i_message_router.py
+++ b/traits_futures/i_message_router.py
@@ -101,13 +101,13 @@ class IMessageSender(contextlib.AbstractContextManager):
         """
         Send a message to the router.
 
+        Not thread-safe. The 'start', 'send' and 'stop' methods should
+        all be called from the same thread.
+
         Parameters
         ----------
         message : object
             Typically this will be immutable, small, and pickleable.
-
-        Not thread-safe. The 'start', 'send' and 'stop' methods should
-        all be called from the same thread.
 
         Raises
         ------

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -137,13 +137,13 @@ class MultiprocessingSender:
         """
         Send a message to the router.
 
+        Not thread-safe. The 'start', 'send' and 'stop' methods should
+        all be called from the same thread.
+
         Parameters
         ----------
         message : object
             Typically this will be immutable, small, and pickleable.
-
-        Not thread-safe. The 'start', 'send' and 'stop' methods should
-        all be called from the same thread.
 
         Raises
         ------

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -107,13 +107,13 @@ class MultithreadingSender:
         """
         Send a message to the router.
 
+        Not thread-safe. The 'start', 'send' and 'stop' methods should
+        all be called from the same thread.
+
         Parameters
         ----------
         message : object
             Typically this will be immutable, small, and pickleable.
-
-        Not thread-safe. The 'start', 'send' and 'stop' methods should
-        all be called from the same thread.
 
         Raises
         ------


### PR DESCRIPTION
Fix three misplaced documentation descriptions, which confuse the napoleon Sphinx extension.