### PR TITLE
Doc: fix bad standard library references

### DIFF
--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -22,7 +22,7 @@ class EventLoopHelper:
 
     Parameters
     ----------
-    event_loop : asyncio.events.AbstractEventLoop
+    event_loop : asyncio.AbstractEventLoop
         The asyncio event loop that this object wraps.
     """
 

--- a/traits_futures/asyncio/pingee.py
+++ b/traits_futures/asyncio/pingee.py
@@ -35,7 +35,7 @@ class Pingee:
     on_ping : callable
         Zero-argument callable that's called on the main thread
         every time a ping is received.
-    event_loop : asyncio.events.AbstractEventLoop
+    event_loop : asyncio.AbstractEventLoop
         The asyncio event loop that pings will be sent to.
 
     """
@@ -93,7 +93,7 @@ class Pinger:
     pingee : Pingee
         The target receiver for the pings. The receiver must already be
         connected.
-    event_loop : asyncio.events.AbstractEventLoop
+    event_loop : asyncio.AbstractEventLoop
         The asyncio event loop that will execute the ping callback.
     """
 

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -212,7 +212,7 @@ class MultiprocessingRouter(HasRequiredTraits):
     ----------
     event_loop : IEventLoop
         The event loop used to trigger message dispatch.
-    manager : multiprocessing.Manager
+    manager : multiprocessing.managers.SyncManager
         Manager to be used for creating the shared-process queue.
     """
 


### PR DESCRIPTION
Fix incorrect references to `AbstractEventLoop` and `multiprocessing.Manager` that Sphinx was unable to resolve.

Will self-merge when the CI completes.