### PR TITLE
Fix 'callable' type descriptions

### DIFF
--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -37,11 +37,11 @@ def fizz_buzz(send, cancelled):
 
     Parameters
     ----------
-    send : callable(object) -> None
+    send
         Callable accepting the message to be sent, and returning nothing. The
         message argument should be pickleable, and preferably immutable (or at
         least, not intended to be mutated).
-    cancelled : callable
+    cancelled
         Callable accepting no arguments and returning a boolean result. It
         returns ``True`` if cancellation has been requested, and ``False``
         otherwise.

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -33,7 +33,7 @@ class AsyncioEventLoop:
 
         Parameters
         ----------
-        on_ping : callable
+        on_ping
             Zero-argument callable, called on the main thread (under a running
             event loop) as a result of each ping sent. The return value of the
             callable is ignored.

--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -76,7 +76,7 @@ class EventLoopHelper:
             Object whose trait we monitor.
         trait : str
             Name of the trait to monitor for changes.
-        condition : callable
+        condition
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
         timeout : float

--- a/traits_futures/asyncio/pingee.py
+++ b/traits_futures/asyncio/pingee.py
@@ -32,7 +32,7 @@ class Pingee:
 
     Parameters
     ----------
-    on_ping : callable
+    on_ping
         Zero-argument callable that's called on the main thread
         every time a ping is received.
     event_loop : asyncio.AbstractEventLoop

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -71,7 +71,7 @@ class BackgroundCall(HasStrictTraits):
 
         Returns
         -------
-        collections.abc.Callable
+        CallTask
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
@@ -91,7 +91,7 @@ def submit_call(executor, callable, *args, **kwargs):
     ----------
     executor : TraitsExecutor
         Executor to submit the task to.
-    callable : collections.abc.Callable
+    callable
         Callable to execute in the background.
     *args
         Positional arguments to pass to the callable.

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -99,7 +99,7 @@ class BackgroundIteration(HasStrictTraits):
 
         Returns
         -------
-        collections.abc.Callable
+        task : IterationTask
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
@@ -119,7 +119,7 @@ def submit_iteration(executor, callable, *args, **kwargs):
     ----------
     executor : TraitsExecutor
         Executor to submit the task to.
-    callable : collections.abc.Callable
+    callable
         Callable returning an iterator when called with the given arguments.
     *args
         Positional arguments to pass to the callable.

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -145,7 +145,7 @@ class BackgroundProgress(HasStrictTraits):
 
         Returns
         -------
-        collections.abc.Callable
+        task : ProgressTask
             Callable accepting arguments ``send`` and ``cancelled``. The
             callable can use ``send`` to send messages and ``cancelled`` to
             check whether cancellation has been requested.
@@ -165,7 +165,7 @@ def submit_progress(executor, callable, *args, **kwargs):
     ----------
     executor : TraitsExecutor
         Executor to submit the task to.
-    callable : collections.abc.Callable
+    callable
         Callable that executes the progress-providing function. This callable
         must accept a "progress" named argument, in addition to the provided
         arguments. The callable may then call the "progress" argument to

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -393,7 +393,7 @@ class BaseFuture(HasStrictTraits):
 
         Parameters
         ----------
-        cancel : callable
+        cancel
             The callback to be called when the user requests cancellation.
             The callback accepts no arguments, and has no return value.
 

--- a/traits_futures/ets_event_loop.py
+++ b/traits_futures/ets_event_loop.py
@@ -44,7 +44,7 @@ class ETSEventLoop:
 
         Parameters
         ----------
-        on_ping : callable
+        on_ping
             Zero-argument callable, called on the main thread (under a running
             event loop) as a result of each ping sent. The return value of the
             callable is ignored.

--- a/traits_futures/i_event_loop.py
+++ b/traits_futures/i_event_loop.py
@@ -31,7 +31,7 @@ class IEventLoop(abc.ABC):
 
         Parameters
         ----------
-        on_ping : callable
+        on_ping
             Zero-argument callable, called on the main thread (under a running
             event loop) as a result of each ping sent. The return value of the
             callable is ignored.

--- a/traits_futures/i_event_loop_helper.py
+++ b/traits_futures/i_event_loop_helper.py
@@ -81,7 +81,7 @@ class IEventLoopHelper(abc.ABC):
             Object whose trait we monitor.
         trait : str
             Name of the trait to monitor for changes.
-        condition : callable
+        condition
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
         timeout : float

--- a/traits_futures/i_message_router.py
+++ b/traits_futures/i_message_router.py
@@ -239,7 +239,7 @@ class IMessageRouter(Interface):
 
         Parameters
         ----------
-        condition : callable
+        condition
             Zero-argument callable returning a boolean. When this condition
             becomes true, this method will stop routing messages. If the
             condition is already true on entry, no messages will be routed.

--- a/traits_futures/i_pingee.py
+++ b/traits_futures/i_pingee.py
@@ -31,7 +31,7 @@ class IPingee(abc.ABC):
 
     Parameters
     ----------
-    on_ping : callable
+    on_ping
         Zero-argument callable that's called on the main thread
         every time a ping is received.
     """

--- a/traits_futures/i_task_specification.py
+++ b/traits_futures/i_task_specification.py
@@ -55,7 +55,10 @@ class ITaskSpecification(ABC):
 
         Returns
         -------
-        task : callable
+        task : object
+            Callable accepting arguments ``send`` and ``cancelled``. The
+            callable can use ``send`` to send messages and ``cancelled`` to
+            check whether cancellation has been requested.
         """
 
     @abstractmethod

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -370,7 +370,7 @@ class MultiprocessingRouter(HasRequiredTraits):
 
         Parameters
         ----------
-        condition : callable
+        condition
             Zero-argument callable returning a boolean. When this condition
             becomes true, this method will stop routing messages. If the
             condition is already true on entry, no messages will be routed.

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -320,7 +320,7 @@ class MultithreadingRouter(HasRequiredTraits):
 
         Parameters
         ----------
-        condition : callable
+        condition
             Zero-argument callable returning a boolean. When this condition
             becomes true, this method will stop routing messages. If the
             condition is already true on entry, no messages will be routed.

--- a/traits_futures/qt/event_loop.py
+++ b/traits_futures/qt/event_loop.py
@@ -31,7 +31,7 @@ class QtEventLoop:
 
         Parameters
         ----------
-        on_ping : callable
+        on_ping
             Zero-argument callable, called on the main thread (under a running
             event loop) as a result of each ping sent. The return value of the
             callable is ignored.

--- a/traits_futures/qt/event_loop_helper.py
+++ b/traits_futures/qt/event_loop_helper.py
@@ -101,7 +101,7 @@ class EventLoopHelper:
             Object whose trait we monitor.
         trait : str
             Name of the trait to monitor for changes.
-        condition : callable
+        condition
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
         timeout : float

--- a/traits_futures/qt/pingee.py
+++ b/traits_futures/qt/pingee.py
@@ -42,7 +42,7 @@ class Pingee(QObject):
 
     Parameters
     ----------
-    on_ping : callable
+    on_ping
         Zero-argument callable that's called on the main thread
         every time a ping is received.
     """

--- a/traits_futures/testing/test_assistant.py
+++ b/traits_futures/testing/test_assistant.py
@@ -72,7 +72,7 @@ class TestAssistant:
             Object whose trait we monitor.
         trait : str
             Name of the trait to monitor for changes.
-        condition : callable
+        condition
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
         timeout : float, optional

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -244,7 +244,7 @@ class IPingeeTests:
 
         Parameters
         ----------
-        on_ping : callable
+        on_ping
             Callback to execute whenever a ping is received.
         """
         pingee = self._event_loop.pingee(on_ping=on_ping)

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -193,7 +193,7 @@ class TraitsExecutor(HasStrictTraits):
 
         Parameters
         ----------
-        callable : an arbitrary callable
+        callable
             Function to execute in the background.
         *args
             Positional arguments to pass to that function.
@@ -222,7 +222,7 @@ class TraitsExecutor(HasStrictTraits):
 
         Parameters
         ----------
-        callable : an arbitrary callable
+        callable
             Function executed in the background to provide the iterable.
         *args
             Positional arguments to pass to that function.
@@ -251,7 +251,7 @@ class TraitsExecutor(HasStrictTraits):
 
         Parameters
         ----------
-        callable : callable accepting a "progress" named argument
+        callable
             Function executed in the background to provide the iterable. This
             should accept a "progress" named argument. The callable can then
             call the "progress" object to report progress.

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -86,12 +86,12 @@ class BackgroundTaskWrapper:
 
     Parameters
     ----------
-    background_task : collections.abc.Callable
+    background_task
         Callable representing the background task. This will be called
         with arguments ``send`` and ``cancelled``.
     sender : IMessageSender
         Object used to send messages.
-    cancelled : collections.abc.Callable
+    cancelled
         Zero-argument callable returning bool. This can be called to check
         whether cancellation has been requested.
     """

--- a/traits_futures/wx/event_loop.py
+++ b/traits_futures/wx/event_loop.py
@@ -31,7 +31,7 @@ class WxEventLoop:
 
         Parameters
         ----------
-        on_ping : callable
+        on_ping
             Zero-argument callable, called on the main thread (under a running
             event loop) as a result of each ping sent. The return value of the
             callable is ignored.

--- a/traits_futures/wx/event_loop_helper.py
+++ b/traits_futures/wx/event_loop_helper.py
@@ -38,7 +38,7 @@ class TimeoutTimer(wx.Timer):
     ----------
     timeout : float
         Timeout in seconds.
-    callback : callable
+    callback
         Callable taking no arguments, to be executed when the timer
         times out.
     args : tuple, optional
@@ -195,7 +195,7 @@ class EventLoopHelper:
             Object whose trait we monitor.
         trait : str
             Name of the trait to monitor for changes.
-        condition : callable
+        condition
             Single-argument callable, returning a boolean. This will be
             called with *object* as the only input.
         timeout : float

--- a/traits_futures/wx/pingee.py
+++ b/traits_futures/wx/pingee.py
@@ -44,7 +44,7 @@ class Pingee(wx.EvtHandler):
 
     Parameters
     ----------
-    on_ping : callable
+    on_ping
         Zero-argument callable that's called on the main thread
         every time a ping is received.
     """


### PR DESCRIPTION
Fix Sphinx warnings resulting from Napoleon trying to interpret "callable" as a type. In almost all cases, the "callable" description is redundant and we simply remove it.