### PR TITLE
Remove 'event-like' as a type

### DIFF
--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -52,8 +52,8 @@ class IParallelContext(abc.ABC):
         -------
         event : object
             An event that can be shared safely with workers.
-            The event should have the same API as ``threading.Event``
-            and ``multiprocessing.Event``, providing at a minimum
+            The event should have the same API as :class:`threading.Event`
+            and :class:`multiprocessing.Event`, providing at a minimum
             the ``set`` and ``is_set`` methods from that API.
         """
 

--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -50,7 +50,7 @@ class IParallelContext(abc.ABC):
 
         Returns
         -------
-        event : event-like
+        event : object
             An event that can be shared safely with workers.
             The event should have the same API as ``threading.Event``
             and ``multiprocessing.Event``, providing at a minimum

--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -52,8 +52,8 @@ class MultiprocessingContext(IParallelContext):
         -------
         event : object
             An event that can be shared safely with workers.
-            The event should have the same API as ``threading.Event``
-            and ``multiprocessing.Event``, providing at a minimum
+            The event should have the same API as :class:`threading.Event`
+            and :class:`multiprocessing.Event`, providing at a minimum
             the ``set`` and ``is_set`` methods from that API.
         """
         return self._manager.Event()

--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -50,8 +50,11 @@ class MultiprocessingContext(IParallelContext):
 
         Returns
         -------
-        event : event-like
+        event : object
             An event that can be shared safely with workers.
+            The event should have the same API as ``threading.Event``
+            and ``multiprocessing.Event``, providing at a minimum
+            the ``set`` and ``is_set`` methods from that API.
         """
         return self._manager.Event()
 

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -49,8 +49,11 @@ class MultithreadingContext(IParallelContext):
 
         Returns
         -------
-        event : event-like
+        event : object
             An event that can be shared safely with workers.
+            The event should have the same API as ``threading.Event``
+            and ``multiprocessing.Event``, providing at a minimum
+            the ``set`` and ``is_set`` methods from that API.
         """
         return threading.Event()
 

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -51,8 +51,8 @@ class MultithreadingContext(IParallelContext):
         -------
         event : object
             An event that can be shared safely with workers.
-            The event should have the same API as ``threading.Event``
-            and ``multiprocessing.Event``, providing at a minimum
+            The event should have the same API as :class:`threading.Event`
+            and :class:`multiprocessing.Event`, providing at a minimum
             the ``set`` and ``is_set`` methods from that API.
         """
         return threading.Event()


### PR DESCRIPTION
Replaces "event-like" with just "object", and makes the descriptions match between the interface and its implementations.

We _could_ introduce an actual interface, but it doesn't seem worth it.