### PR TITLE
Setup slack notifications for cron jobs

### DIFF
--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -34,6 +34,33 @@ jobs:
         cd testdir
         python -X faulthandler -m unittest discover -v traits_futures
 
+  notify-on-failure:
+    needs: test-all-platform-python-combinations
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-success:
+    needs: test-all-platform-python-combinations
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
   test-bleeding-edge:
     strategy:
@@ -72,3 +99,31 @@ jobs:
       with:
         working-directory: ${{ runner.temp }}
         run: python -X faulthandler -m unittest discover -v traits_futures
+
+  notify-on-bleeding-edge-failure:
+    needs: test-bleeding-edge
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-bleeding-edge-success:
+    needs: test-bleeding-edge
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -34,34 +34,6 @@ jobs:
         cd testdir
         python -X faulthandler -m unittest discover -v traits_futures
 
-  notify-on-failure:
-    needs: test-all-platform-python-combinations
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on failure
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
-  notify-on-success:
-    needs: test-all-platform-python-combinations
-    if: success()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on success
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: SUCCESS
-          color: good
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
   test-bleeding-edge:
     strategy:
       matrix:
@@ -100,8 +72,8 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: python -X faulthandler -m unittest discover -v traits_futures
 
-  notify-on-bleeding-edge-failure:
-    needs: test-bleeding-edge
+  notify-on-failure:
+    needs: [test-all-platform-python-combinations, test-bleeding-edge]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -114,8 +86,8 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
-  notify-on-bleeding-edge-success:
-    needs: test-bleeding-edge
+  notify-on-success:
+    needs: [test-all-platform-python-combinations, test-bleeding-edge]
     if: success()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR sets up the slack notifications for cron jobs on this repository. I manually triggered the cron job on this repository to ensure that the slack notification does get fired as expected. Ref https://github.com/enthought/traits-futures/actions/runs/1027349871.

One more step towards https://github.com/enthought/ets/issues/65.