### PR TITLE
Add RtD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "null": [],
         "pyqt5": ["pyqt5"],
         "pyside2": ["pyside2"],
+        "docs": ["enthought-sphinx-theme", "sphinx>=3.5"],
     },
     packages=find_packages(exclude=["ci"]),
     classifiers=[


### PR DESCRIPTION
This PR adds a basic configuration file for Read the Docs. These changes are based on https://github.com/enthought/traits/pull/1478. Along with the configuration file, I added a new `docs` `extras_require` to make it easy to install the additional requirements needed to build docs.

Ref https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install to understand the configuration file better.

~Note : Unlike the traits PR, I am unable to figure out where (URL) the docs built on this branch URL exist. I'm only seeing failed builds on https://readthedocs.org/projects/traits-futures/builds/ and they're all built from the `main` branch instead of this branch e.g. https://readthedocs.org/projects/traits-futures/builds/14237319/. I feel like there might be an issue with settings on traits-futures RtD.~ Never mind. Apparently the build from the traits branch was manually built.

This is the first step towards https://github.com/enthought/ets/issues/69