### PR TITLE
Remove the blocking wait during message routing

### DIFF
--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -388,9 +388,8 @@ class MultiprocessingRouter(HasRequiredTraits):
             end_time = time.monotonic() + timeout
             try:
                 while not condition():
-                    self._route_message(
-                        block=True, timeout=end_time - time.monotonic()
-                    )
+                    time_remaining = end_time - time.monotonic()
+                    self._route_message(block=True, timeout=time_remaining)
             except queue.Empty:
                 raise RuntimeError("Timed out waiting for messages")
 

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -383,22 +383,16 @@ class MultiprocessingRouter(HasRequiredTraits):
 
         if timeout is None:
             while not condition():
-                self._route_message()
+                self._route_message(block=True)
         else:
             end_time = time.monotonic() + timeout
-            while not condition():
-                time_remaining = end_time - time.monotonic()
-                if time_remaining < 0.0:
-                    break
-                try:
-                    self._route_message(timeout=time_remaining)
-                except queue.Empty:
-                    break
-            else:
-                # Success: condition became true.
-                return
-
-            raise RuntimeError("Timed out waiting for messages")
+            try:
+                while not condition():
+                    self._route_message(
+                        block=True, timeout=end_time - time.monotonic()
+                    )
+            except queue.Empty:
+                raise RuntimeError("Timed out waiting for messages")
 
     # Public traits ###########################################################
 
@@ -468,8 +462,31 @@ class MultiprocessingRouter(HasRequiredTraits):
             self._pingee.disconnect()
             self._linked = False
 
-    def _route_message(self, timeout=None):
-        connection_id, message = self._local_message_queue.get(timeout=timeout)
+    def _route_message(self, *, block=False, timeout=None):
+        """
+        Get and dispatch a message from the local message queue.
+
+        Parameters
+        ----------
+        block : bool, optional
+            If True, block until either a message arrives or until timeout. If
+            False (the default), we expect a message to already be present in
+            the queue.
+        timeout : float, optional
+            Maximum time to wait for a message to arrive. If no timeout
+            is given and ``block`` is True, wait indefinitely. If ``block``
+            is False, this parameter is ignored.
+
+        Raises
+        ------
+        queue.Empty
+            If no message arrives within the given timeout.
+        """
+        if block and timeout is not None and timeout <= 0.0:
+            raise queue.Empty
+        connection_id, message = self._local_message_queue.get(
+            block=block, timeout=timeout
+        )
         try:
             receiver = self._receivers[connection_id]
         except KeyError:

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -336,22 +336,16 @@ class MultithreadingRouter(HasRequiredTraits):
 
         if timeout is None:
             while not condition():
-                self._route_message()
+                self._route_message(block=True)
         else:
             end_time = time.monotonic() + timeout
             while not condition():
-                time_remaining = end_time - time.monotonic()
-                if time_remaining < 0.0:
-                    break
                 try:
-                    self._route_message(timeout=time_remaining)
+                    self._route_message(
+                        block=True, timeout=end_time - time.monotonic()
+                    )
                 except queue.Empty:
-                    break
-            else:
-                # Success: condition became true.
-                return
-
-            raise RuntimeError("Timed out waiting for messages")
+                    raise RuntimeError("Timed out waiting for messages")
 
     # Public traits ###########################################################
 
@@ -412,8 +406,31 @@ class MultithreadingRouter(HasRequiredTraits):
             self._pingee.disconnect()
             self._linked = False
 
-    def _route_message(self, timeout=None):
-        connection_id, message = self._message_queue.get(timeout=timeout)
+    def _route_message(self, *, block=False, timeout=None):
+        """
+        Get and dispatch a message from the local message queue.
+
+        Parameters
+        ----------
+        block : bool, optional
+            If True, block until either a message arrives or until timeout. If
+            False (the default), we expect a message to already be present in
+            the queue.
+        timeout : float, optional
+            Maximum time to wait for a message to arrive. If no timeout
+            is given and ``block`` is True, wait indefinitely. If ``block``
+            is False, this parameter is ignored.
+
+        Raises
+        ------
+        queue.Empty
+            If no message arrives within the given timeout.
+        """
+        if block and timeout is not None and timeout <= 0.0:
+            raise queue.Empty
+        connection_id, message = self._message_queue.get(
+            block=block, timeout=timeout
+        )
         try:
             receiver = self._receivers[connection_id]
         except KeyError:

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -341,9 +341,8 @@ class MultithreadingRouter(HasRequiredTraits):
             end_time = time.monotonic() + timeout
             while not condition():
                 try:
-                    self._route_message(
-                        block=True, timeout=end_time - time.monotonic()
-                    )
+                    time_remaining = end_time - time.monotonic()
+                    self._route_message(block=True, timeout=time_remaining)
                 except queue.Empty:
                     raise RuntimeError("Timed out waiting for messages")
 


### PR DESCRIPTION
This PR simultaneously improves a failure mode *and* makes failure more likely. :-)

In more detail:

When a message is sent from a background task to the corresponding future, the following sequence of events occurs:
   1. The background task puts the message on the message queue (a regular `queue.Queue` instance)
   2. The background task sends a "ping" to the message router to let it know that there's a message to be processed
   3. When the message router receives the "ping", it gets the message from the message queue and dispatches it.

Currently, in the main branch, for step 3 we use a blocking `message_queue.get()` operation to get the message. In effect we're assuming that if a message has been put on the queue, `message_queue.get()` will not block for long while the message is retrieved. If something goes wrong with some part of the machinery and we somehow get a ping without a corresponding message, then the router will block forever. That's not a great failure mode.

With this PR, we use a non-blocking `message_queue.get` operation to get the message. We're now making a stronger assumption than before, namely that we don't need to wait _at all_ for the message that's been put on the queue to arrive. I believe that assumption is justified, though it's difficult to extract a promise of this from the documentation. Now if something goes wrong (a ping arriving without a message being queued), the router will crash with a `queue.Empty` exception. This seems like a better failure mode.

While we're touching the `route_until` methods, this PR takes a liberty and cleans up the implementations of those methods slightly. It also adds docstrings for the `_route_message` private method.

Closes #313 (really, this PR makes #313 invalid, but it resolves the issue that prompted #313).

N.B. The duplication between the `MultithreadingRouter` and `MultiprocessingRouter` is still biting us. (cf. #383)