### PR TITLE
More TraitsExecutor / IFuture decoupling

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,6 @@ nitpick_ignore = [
     ("py:class", "wx.App"),
     ("py:class", "wx.EvtHandler"),
     ("py:class", "wx.Timer"),
-
     # These two slightly strange class descriptions (note the trailing dot)
     # appear with Sphinx >= 4. This may be a bug in Sphinx.
     ("py:class", "pyface.qt.QtCore."),

--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -131,7 +131,7 @@ Putting it all together: the task specification
 The last piece we need is a task specification, which is the object that can be
 submitted to the |TraitsExecutor|. This object needs to have two attributes:
 ``future`` and ``background_task``. Given an instance ``task`` of a task
-specification, the |TraitsExecutor| calls ``task.future()``
+specification, the |TraitsExecutor| calls ``task.future(cancel)``
 to create the future, and ``task.background_task()`` to create the background
 callable. For the background task, we want to return (but not call!) the
 ``fizz_buzz`` function that we defined above. For the future, we create and

--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -114,9 +114,16 @@ class BackgroundFizzBuzz:
     Task specification for Fizz Buzz background tasks.
     """
 
-    def future(self):
+    def future(self, cancel):
         """
         Return a Future for the background task.
+
+        Parameters
+        ----------
+        cancel
+            Zero-argument callable, returning no useful result. The returned
+            future's ``cancel`` method should call this to request cancellation
+            of the associated background task.
 
         Returns
         -------
@@ -124,7 +131,7 @@ class BackgroundFizzBuzz:
             Future object that can be used to monitor the status of the
             background task.
         """
-        return FizzBuzzFuture()
+        return FizzBuzzFuture(_cancel=cancel)
 
     def background_task(self):
         """

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -53,9 +53,16 @@ class BackgroundCall(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str())
 
-    def future(self):
+    def future(self, cancel):
         """
         Return a Future for the background task.
+
+        Parameters
+        ----------
+        cancel
+            Zero-argument callable, returning no useful result. The returned
+            future's ``cancel`` method should call this to request cancellation
+            of the associated background task.
 
         Returns
         -------
@@ -63,7 +70,7 @@ class BackgroundCall(HasStrictTraits):
             Future object that can be used to monitor the status of the
             background task.
         """
-        return CallFuture()
+        return CallFuture(_cancel=cancel)
 
     def background_task(self):
         """

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -81,9 +81,16 @@ class BackgroundIteration(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str())
 
-    def future(self):
+    def future(self, cancel):
         """
         Return a Future for the background task.
+
+        Parameters
+        ----------
+        cancel
+            Zero-argument callable, returning no useful result. The returned
+            future's ``cancel`` method should call this to request cancellation
+            of the associated background task.
 
         Returns
         -------
@@ -91,7 +98,7 @@ class BackgroundIteration(HasStrictTraits):
             Future object that can be used to monitor the status of the
             background task.
         """
-        return IterationFuture()
+        return IterationFuture(_cancel=cancel)
 
     def background_task(self):
         """

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -127,9 +127,16 @@ class BackgroundProgress(HasStrictTraits):
     #: Named arguments to be passed to the callable.
     kwargs = Dict(Str())
 
-    def future(self):
+    def future(self, cancel):
         """
         Return a Future for the background task.
+
+        Parameters
+        ----------
+        cancel
+            Zero-argument callable, returning no useful result. The returned
+            future's ``cancel`` method should call this to request cancellation
+            of the associated background task.
 
         Returns
         -------
@@ -137,7 +144,7 @@ class BackgroundProgress(HasStrictTraits):
             Future object that can be used to monitor the status of the
             background task.
         """
-        return ProgressFuture()
+        return ProgressFuture(_cancel=cancel)
 
     def background_task(self):
         """

--- a/traits_futures/i_task_specification.py
+++ b/traits_futures/i_task_specification.py
@@ -62,9 +62,16 @@ class ITaskSpecification(ABC):
         """
 
     @abstractmethod
-    def future(self):
+    def future(self, cancel):
         """
         Return a Future for the background task.
+
+        Parameters
+        ----------
+        cancel
+            Zero-argument callable, returning no useful result. The returned
+            future's ``cancel`` method should call this to request cancellation
+            of the associated background task.
 
         Returns
         -------

--- a/traits_futures/tests/test_base_future.py
+++ b/traits_futures/tests/test_base_future.py
@@ -47,8 +47,7 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         self.future_class = PingFuture
 
     def test_normal_lifecycle(self):
-        future = self.future_class()
-        future._executor_initialized(dummy_cancel_callback)
+        future = self.future_class(_cancel=dummy_cancel_callback)
         future._task_started(None)
         future._task_sent(("ping", 123))
         future._task_sent(("ping", 999))
@@ -59,8 +58,7 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
     def test_ping_after_cancellation_is_ignored(self):
         message = ("ping", 32)
 
-        future = self.future_class()
-        future._executor_initialized(dummy_cancel_callback)
+        future = self.future_class(_cancel=dummy_cancel_callback)
 
         future._task_started(None)
         future._user_cancelled()
@@ -75,12 +73,10 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         # in EXECUTING or CANCELLING states.
         message = ("ping", 32)
 
-        future = self.future_class()
+        future = self.future_class(_cancel=dummy_cancel_callback)
 
         with self.assertRaises(_StateTransitionError):
             future._task_sent(message)
-
-        future._executor_initialized(dummy_cancel_callback)
 
         with self.assertRaises(_StateTransitionError):
             future._task_sent(message)
@@ -94,8 +90,7 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
     def test_impossible_ping_cancelled_task(self):
         message = ("ping", 32)
 
-        future = self.future_class()
-        future._executor_initialized(dummy_cancel_callback)
+        future = self.future_class(_cancel=dummy_cancel_callback)
 
         future._user_cancelled()
 

--- a/traits_futures/tests/test_base_future.py
+++ b/traits_futures/tests/test_base_future.py
@@ -78,9 +78,6 @@ class TestBaseFuture(CommonFutureTests, unittest.TestCase):
         with self.assertRaises(_StateTransitionError):
             future._task_sent(message)
 
-        with self.assertRaises(_StateTransitionError):
-            future._task_sent(message)
-
         future._task_started(None)
         future._task_returned(1729)
 

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -304,13 +304,12 @@ class TraitsExecutor(HasStrictTraits):
 
         sender, receiver = self._message_router.pipe()
         runner = task.background_task()
-        future = task.future()
+        future = task.future(cancel_event.set)
 
         self._worker_pool.submit(
             run_background_task, runner, sender, cancel_event.is_set
         )
 
-        future._executor_initialized(cancel_event.set)
         future_wrapper = FutureWrapper(
             future=future,
             receiver=receiver,


### PR DESCRIPTION
This PR builds on #396 to further decouple the `TraitsExecutor` from the details of the `IFuture` objects.

The motivating change is to remove the need for the executor to call `future._executor_initialized(cancel.set)`: https://github.com/enthought/traits-futures/blob/e5510abb36a44eb3790640130b982ce6a802a4d4/traits_futures/traits_executor.py#L313

Instead we pass the cancellation callback to the `future` method, which in turn sets the corresponding trait directly. In addition, in this PR:

- The `BaseFuture._executor_intialized` method has been entirely removed
- The `_INITIALIZED` and `_NOT_INITIALIZED` states have been folded back into a the single `WAITING` state
- The `_cancel` trait in `BaseFuture` is now a required trait. (Note that this is a detail of the `BaseFuture` implementation, not a requirement of the `IFuture` interface.)

With this change, the `TraitsExecutor` needs to know only about the `message` and `cancel` methods and the `cancellable` attribute of an `IFuture` instance. (From the perspective of the executor, the future doesn't even need to be a `HasTraits` object.)