### PR TITLE
Add black check to the style checks

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install necessary Python packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install flake8 flake8-ets isort
+        python -m pip install black flake8 flake8-ets isort
     - name: Check out the PR branch
       uses: actions/checkout@v2
     - name: Run style checks
@@ -26,3 +26,4 @@ jobs:
         python -m flake8
         python -m isort . --check --diff
         python -m isort docs/source/guide/examples --check --diff
+        python -m black . --check --diff


### PR DESCRIPTION
A number of style-related problems have snuck into the main branch recently; I habitually run `black` while developing, so these show up as extraneous changes in PRs.

So with this PR I'm finally biting the bullet and adding a `black` check to the style checks, so that the `main` branch stays black-clean.

N.B. If the new style check works, this PR should fail. It'll pass once #415 is merged into this branch (via main).