### PR TITLE
Fix behaviour of route_until with timeout and queued messages

### DIFF
--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -481,10 +481,9 @@ class MultiprocessingRouter(HasRequiredTraits):
         queue.Empty
             If no message arrives within the given timeout.
         """
-        if block and timeout is not None and timeout <= 0.0:
-            raise queue.Empty
         connection_id, message = self._local_message_queue.get(
-            block=block, timeout=timeout
+            block=block,
+            timeout=None if timeout is None else max(timeout, 0.0),
         )
         try:
             receiver = self._receivers[connection_id]

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -425,10 +425,9 @@ class MultithreadingRouter(HasRequiredTraits):
         queue.Empty
             If no message arrives within the given timeout.
         """
-        if block and timeout is not None and timeout <= 0.0:
-            raise queue.Empty
         connection_id, message = self._message_queue.get(
-            block=block, timeout=timeout
+            block=block,
+            timeout=None if timeout is None else max(timeout, 0.0),
         )
         try:
             receiver = self._receivers[connection_id]


### PR DESCRIPTION
This PR modifies the behaviour of `route_until` so that it always processes messages that are already on the queue, regardless of the timeout given. Previously, given a small timeout, it would fail even when there were messages already present to be processed.

Key technical point for understanding the implementation: for a `queue.Queue`, the `get` operation always returns a result if there's one queued. (Relevant source: https://github.com/python/cpython/blob/919ad537510fdc2c750109e0bc4eceea234324b2/Lib/queue.py#L176)

Fixes #417