### PR TITLE
Change cancel method to never raise

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -40,8 +40,12 @@ of Traits Futures.
 * The ``state`` trait of the ``~.TraitsExecutor`` is now read-only;
   previously, it was writable.
 * The ``cancel`` method of a future no longer raises :exc:`RuntimeError` when a
-  future is not cancellable; instead it does nothing. The return value from
-  ``cancel`` can be used to detect whether cancellation occurred.
+  future is not cancellable. Instead, it communicates the information via its
+  return value. If a future is already done, or has previously been cancelled,
+  calling ``cancel`` on that future does not change the state of the future,
+  and returns ``False``. Otherwise it changes the future's state to
+  ``CANCELLING`` state, requests cancellation of the associated task, and
+  returns ``True``.
 
 Other Changes
 ~~~~~~~~~~~~~

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -39,9 +39,9 @@ of Traits Futures.
   background task types.
 * The ``state`` trait of the ``~.TraitsExecutor`` is now read-only;
   previously, it was writable.
-* The ``cancel`` method a future no longer raises :exc:`RuntimeError` when a
+* The ``cancel`` method of a future no longer raises :exc:`RuntimeError` when a
   future is not cancellable; instead it does nothing. The return value from
-  ``cancel`` can be used to detect when cancellation occurred.
+  ``cancel`` can be used to detect whether cancellation occurred.
 
 Other Changes
 ~~~~~~~~~~~~~

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -39,6 +39,9 @@ of Traits Futures.
   background task types.
 * The ``state`` trait of the ``~.TraitsExecutor`` is now read-only;
   previously, it was writable.
+* The ``cancel`` method a future no longer raises :exc:`RuntimeError` when a
+  future is not cancellable; instead it does nothing. The return value from
+  ``cancel`` can be used to detect when cancellation occurred.
 
 Other Changes
 ~~~~~~~~~~~~~

--- a/docs/source/guide/examples/background_processes.py
+++ b/docs/source/guide/examples/background_processes.py
@@ -133,8 +133,7 @@ class SquaringHelper(HasStrictTraits):
 
     def _cancel_all_fired(self):
         for future in self.current_futures:
-            if future.cancellable:
-                future.cancel()
+            future.cancel()
 
     def _clear_finished_fired(self):
         for future in list(self.current_futures):

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -125,11 +125,6 @@ class ProgressDialog(Dialog, HasStrictTraits):
             current_step, max_steps, count_so_far
         )
 
-    @observe("closing")
-    def _cancel_future_if_necessary(self, event):
-        if self.future is not None and self.future.cancellable:
-            self.future.cancel()
-
     @observe("future:done")
     def _respond_to_completion(self, event):
         self.future = None

--- a/docs/source/guide/examples/slow_squares.py
+++ b/docs/source/guide/examples/slow_squares.py
@@ -121,8 +121,7 @@ class SquaringHelper(HasStrictTraits):
 
     def _cancel_all_fired(self):
         for future in self.current_futures:
-            if future.cancellable:
-                future.cancel()
+            future.cancel()
 
     def _clear_finished_fired(self):
         for future in list(self.current_futures):

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -242,11 +242,11 @@ task to abort the next time that task calls ``progress``. No further
 progress results are received after calling |cancel|.
 
 In all cases, a task may only be cancelled if the state of the associated
-future is either |WAITING| or |EXECUTING|. Calling |cancel| on a future in
-another state will have no effect. You can determine whether a future is
-cancellable by inspecting its |cancellable| property. Alternatively, you can
-examine the return value of the |cancel| method to determine whether
-cancellation occurred.
+future is either |WAITING| or |EXECUTING|. When |cancel| is called on a future
+in one of these two states, the future's state is changed to |CANCELLING|,
+a cancellation request is sent to the associated task, and the call returns
+``True``. When |cancel| is called on a future in another state, the call has
+no effect, and returns ``False``.
 
 A successful |cancel| immediately puts the future into |CANCELLING| state, and
 the state is updated to |CANCELLED| once the future has finished executing. No

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -241,13 +241,16 @@ task to abort the next time that task calls ``progress``. No further
 progress results are received after calling |cancel|.
 
 In all cases, a future may only be cancelled if its state is one of |WAITING|
-or |EXECUTING|. Attempting to cancel a future in another state will raise a
-``RuntimeError``. Calling |cancel| immediately puts the future into
-|CANCELLING| state, and the state is updated to |CANCELLED| once the future has
-finished executing. No results or exception information are received from a
-future in |CANCELLING| state. A cancelled future will never reach |FAILED|
-state, and will never record information from a background task exception that
-occurs after the |cancel| call.
+or |EXECUTING|. Attempting to cancel a future in another state will have no
+effect. You can determine whether a future is cancellable by inspecting its
+|cancellable| property. Alternatively, you can examing the return value of the
+|cancel| method to determine whether cancellation occurred. A successful
+|cancel| immediately puts the future into |CANCELLING| state, and the state is
+updated to |CANCELLED| once the future has finished executing. No results or
+exception information are received from a future in |CANCELLING| state. A
+cancelled future will never reach |FAILED| state, and will never record
+information from a background task exception that occurs after the |cancel|
+call.
 
 
 Stopping the executor

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -377,6 +377,7 @@ needed.
 .. |STOPPED| replace:: :data:`~traits_futures.executor_states.STOPPED`
 
 .. |cancel| replace:: :meth:`~traits_futures.base_future.BaseFuture.cancel`
+.. |cancellable| replace:: :meth:`~trait_futures.i_future.IFuture.cancellable`
 
 .. |CallFuture| replace:: :class:`~traits_futures.background_call.CallFuture`
 .. |submit_call| replace:: :func:`~traits_futures.background_call.submit_call`

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -94,13 +94,18 @@ class IFuture(Interface):
 
         A task in ``WAITING`` or ``EXECUTING`` state will immediately be moved
         to ``CANCELLING`` state. If the task is not in ``WAITING`` or
-        ``EXECUTING`` state, this function will raise ``RuntimeError``.
+        ``EXECUTING`` state, this function does nothing.
 
-        Raises
-        ------
-        RuntimeError
-            If the task has already completed or cancellation has already
-            been requested.
+        .. versionchanged:: 0.3.0
+
+           This method no longer raises for a task that isn't cancellable.
+           In previous versions, :exc:`RuntimeError` was raised.
+
+        Returns
+        -------
+        cancelled : bool
+            True if the task was cancelled, False if the task was not
+            cancellable.
         """
 
     @abc.abstractmethod

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -191,8 +191,8 @@ class BackgroundCallTests:
         self.wait_until_done(future)
 
         self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
 
         self.assertResult(future, 8)
         self.assertNoException(future)
@@ -208,8 +208,8 @@ class BackgroundCallTests:
         self.wait_until_done(future)
 
         self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
 
         self.assertNoResult(future)
         self.assertException(future, ZeroDivisionError)
@@ -223,10 +223,12 @@ class BackgroundCallTests:
         listener = CallFutureListener(future=future)
 
         self.assertTrue(future.cancellable)
-        future.cancel()
+        cancelled = future.cancel()
+        self.assertTrue(cancelled)
         self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
+        self.assertFalse(future.cancellable)
 
         self.wait_until_done(future)
 
@@ -254,8 +256,8 @@ class BackgroundCallTests:
         test_ready.set()
 
         self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
 
         self.wait_until_done(future)
 

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -337,8 +337,8 @@ class BackgroundIterationTests:
         future.cancel()
         self.assertFalse(future.cancellable)
 
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
 
     def test_completed_cancel(self):
         future = submit_iteration(self.executor, squares, 0, 10)
@@ -346,8 +346,8 @@ class BackgroundIterationTests:
         self.wait_until_done(future)
 
         self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
 
     def test_generator_closed_on_cancellation(self):
         resource_acquired = self._context.event()

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -247,8 +247,8 @@ class BackgroundProgressTests:
         future.cancel()
 
         self.assertFalse(future.cancellable)
-        with self.assertRaises(RuntimeError):
-            future.cancel()
+        cancelled = future.cancel()
+        self.assertFalse(cancelled)
 
     def test_cancel_raising_task(self):
         signal = self._context.event()

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -469,10 +469,7 @@ class TraitsExecutor(HasStrictTraits):
         logger.debug(f"{self} cancelling incomplete tasks")
         cancel_count = 0
         for wrapper in self._wrappers:
-            future = wrapper.future
-            if future.cancellable:
-                future.cancel()
-                cancel_count += 1
+            cancel_count += wrapper.future.cancel()
         logger.debug(f"{self} cancelled {cancel_count} tasks")
 
     def _stop_router(self):


### PR DESCRIPTION
This PR changes the `IFuture.cancel` method to silently do nothing instead of raising `RuntimeError` when a future isn't cancellable. I believe that this better reflects the most common use-case.

See #398 for the original proposal and discussion.

Closes #418.