### PR TITLE
Fix Sphinx warnings about 'callable'

### DIFF
--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -502,11 +502,11 @@ class BaseTask:
 
         Parameters
         ----------
-        send : callable
+        send
             single-argument callable used to send a message to the
             associated future. It takes the message to be sent, and returns
             no useful value.
-        cancelled : callable
+        cancelled
             zero-argument callable that can be used to check whether
             cancellation has been requested for this task. Returns ``True``
             if cancellation has been requested, else ``False``.


### PR DESCRIPTION
We recently accidentally re-introduced some Sphinx warnings (see below). This PR fixes them.

```
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/background_call.py:docstring of traits_futures.background_call.CallTask.run:6: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/background_call.py:docstring of traits_futures.background_call.CallTask.run:10: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/background_iteration.py:docstring of traits_futures.background_iteration.IterationTask.run:6: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/background_iteration.py:docstring of traits_futures.background_iteration.IterationTask.run:10: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/background_progress.py:docstring of traits_futures.background_progress.ProgressTask.run:6: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/background_progress.py:docstring of traits_futures.background_progress.ProgressTask.run:10: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/base_future.py:docstring of traits_futures.base_future.BaseTask.run:6: WARNING: py:class reference target not found: callable
/Users/mdickinson/Enthought/Projects/traits-futures/traits_futures/base_future.py:docstring of traits_futures.base_future.BaseTask.run:10: WARNING: py:class reference target not found: callable
```