### PR TITLE
Remove an unused method

### DIFF
--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -125,11 +125,6 @@ class ProgressDialog(Dialog, HasStrictTraits):
             current_step, max_steps, count_so_far
         )
 
-    @observe("closing")
-    def _cancel_future_if_necessary(self, event):
-        if self.future is not None and self.future.cancellable:
-            self.future.cancel()
-
     @observe("future:done")
     def _respond_to_completion(self, event):
         self.future = None


### PR DESCRIPTION
[Extracted from #420]

This method should have been removed as part of #385, but wasn't. The `closing` trait exists on the TraitsUI `Handler` class, but since #385 we're no longer subclassing `Handler` and we have no need to cancel on exit - the shutdown machinery takes care of that for us.