### PR TITLE
Fix missing 'self' in method definition

### DIFF
--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -496,7 +496,7 @@ class BaseTask:
     for execution of the background task and sending of any custom messages.
     """
 
-    def run(send, cancelled):
+    def run(self, send, cancelled):
         """
         Run the body of the background task.
 


### PR DESCRIPTION
`BaseTask.run` was missing its first `self` argument. This didn't actually affect any code, since the base class method is never called (it's only there as a placeholder to be overridden by subclasses), and all the subclasses have the correct signature.