### PR TITLE
Turn on nitpicky mode for documentation builds

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -226,12 +226,7 @@ def doc(edm, python_version, toolkit):
     """
     pyenv = _get_devenv(edm, python_version, toolkit)
 
-    # Be nitpicky. This detects missing class references.
-    sphinx_options = ["-n"]
-
-    build_cmd = ["-m", "sphinx"]
-    build_cmd.extend(sphinx_options)
-    build_cmd.extend([cfg.DOCS_SOURCE_DIR, cfg.DOCS_BUILD_DIR])
+    build_cmd = ["-m", "sphinx", cfg.DOCS_SOURCE_DIR, cfg.DOCS_BUILD_DIR]
     pyenv.python(build_cmd)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,6 +98,9 @@ todo_include_todos = False
 # Don't include parentheses after function and method names.
 add_function_parentheses = False
 
+# Do use nitpicky mode: we want to know about broken references.
+nitpicky = True
+
 # Ignore complaints about references to classes in wx and pyface.qt.QtCore
 nitpick_ignore = [
     # Exclusions needed for Sphinx < 4.


### PR DESCRIPTION
Penultimate step towards solving #354: turn on nitpicky mode.

I'm expecting the CI to fail for this PR. It should pass after we've fixed the last of the broken references (in a separate PR: #430).