### PR TITLE
Fix last of the Sphinx warnings

### DIFF
--- a/docs/source/guide/testing.rst
+++ b/docs/source/guide/testing.rst
@@ -61,7 +61,7 @@ safe to remove the wait for ``future.done``, so long as you keep the |shutdown|
 call.
 
 
-.. |assertEventuallyTrueInGui| replace:: :meth:`pyface.ui.qt4.util.gui_test_assistant.GuiTestAssistant.assertEventuallyTrueInGui`
-.. |GuiTestAssistant| replace:: :class:`pyface.ui.qt4.util.gui_test_assistant.GuiTestAssistant`
+.. |assertEventuallyTrueInGui| replace:: ``assertEventuallyTrueInGui``
+.. |GuiTestAssistant| replace:: ``GuiTestAssistant``
 
 .. |shutdown| replace:: :meth:`~traits_futures.traits_executor.TraitsExecutor.shutdown`


### PR DESCRIPTION
Closes #354 (and then merging #429 should reinforce this by ensuring that the CI detects Sphinx warnings in future).

In theory, now that https://github.com/enthought/pyface/pull/933 is merged, we should be able to restore these links once a new version of Pyface has been released. However, the remaining tasks in the 0.3.0 milestone may eliminate the need to refer to the `GuiTestAssistant` altogether.