### PR TITLE
Repurpose IFuture

### DIFF
--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -181,11 +181,11 @@ of the new background task type:
 .. |BaseFuture| replace:: :class:`~.BaseFuture`
 .. |BaseTask| replace:: :class:`~.BaseTask`
 .. |dispatch| replace:: :meth:`~.BaseFuture.dispatch`
-.. |exception| replace:: :attr:`~traits_futures.i_future.IFuture.exception`
+.. |exception| replace:: :attr:`~traits_futures.base_future.BaseFuture.exception`
 .. |HasStrictTraits| replace:: :class:`~traits.has_traits.HasStrictTraits`
 .. |IFuture| replace:: :class:`~.IFuture`
 .. |ITaskSpecification| replace:: :class:`~.ITaskSpecification`
-.. |result| replace:: :attr:`~traits_futures.i_future.IFuture.result`
+.. |result| replace:: :attr:`~traits_futures.base_future.BaseFuture.result`
 .. |submit| replace:: :meth:`~.submit`
 .. |submit_call| replace:: :func:`~.submit_call`
 .. |submit_iteration| replace:: :func:`~.submit_iteration`

--- a/docs/source/guide/examples/interruptible_task.py
+++ b/docs/source/guide/examples/interruptible_task.py
@@ -34,7 +34,7 @@ from traits_futures.api import (
     CANCELLED,
     COMPLETED,
     FAILED,
-    IFuture,
+    IterationFuture,
     submit_iteration,
     TraitsExecutor,
 )
@@ -59,7 +59,7 @@ class InterruptibleTaskExample(HasStrictTraits):
     traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
-    future = Instance(IFuture)
+    future = Instance(IterationFuture)
 
     #: Number of points to use.
     sample_count = Int(10 ** 8)

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -31,10 +31,10 @@ from traits.api import (
     Str,
 )
 from traits_futures.api import (
+    CallFuture,
     CANCELLED,
     COMPLETED,
     FAILED,
-    IterationFuture,
     submit_call,
     TraitsExecutor,
 )
@@ -57,7 +57,7 @@ class NonInterruptibleTaskExample(HasStrictTraits):
     traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
-    future = Instance(IterationFuture)
+    future = Instance(CallFuture)
 
     #: Number of points to use.
     sample_count = Int(10 ** 8)

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -34,7 +34,7 @@ from traits_futures.api import (
     CANCELLED,
     COMPLETED,
     FAILED,
-    IFuture,
+    IterationFuture,
     submit_call,
     TraitsExecutor,
 )
@@ -57,7 +57,7 @@ class NonInterruptibleTaskExample(HasStrictTraits):
     traits_executor = Instance(TraitsExecutor)
 
     #: The future object returned on task submission.
-    future = Instance(IFuture)
+    future = Instance(IterationFuture)
 
     #: Number of points to use.
     sample_count = Int(10 ** 8)

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -374,12 +374,12 @@ needed.
 .. |STOPPING| replace:: :data:`~traits_futures.executor_states.STOPPING`
 .. |STOPPED| replace:: :data:`~traits_futures.executor_states.STOPPED`
 
-.. |cancel| replace:: :meth:`~traits_futures.i_future.IFuture.cancel`
-.. |cancellable| replace:: :attr:`~traits_futures.i_future.IFuture.cancellable`
-.. |done| replace:: :attr:`~traits_futures.i_future.IFuture.done`
-.. |future_state| replace:: :attr:`~traits_futures.i_future.IFuture.state`
-.. |result| replace:: :attr:`~traits_futures.i_future.IFuture.result`
-.. |exception| replace:: :attr:`~traits_futures.i_future.IFuture.exception`
+.. |cancel| replace:: :meth:`~traits_futures.base_future.BaseFuture.cancel`
+.. |cancellable| replace:: :attr:`~traits_futures.base_future.BaseFuture.cancellable`
+.. |done| replace:: :attr:`~traits_futures.base_future.BaseFuture.done`
+.. |future_state| replace:: :attr:`~traits_futures.base_future.BaseFuture.state`
+.. |result| replace:: :attr:`~traits_futures.base_future.BaseFuture.result`
+.. |exception| replace:: :attr:`~traits_futures.base_future.BaseFuture.exception`
 
 .. |CallFuture| replace:: :class:`~traits_futures.background_call.CallFuture`
 .. |submit_call| replace:: :func:`~traits_futures.background_call.submit_call`

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -33,7 +33,6 @@ Task submission functions
 Types of futures
 ----------------
 
-- :class:`~.IFuture`
 - :class:`~.CallFuture`
 - :class:`~.IterationFuture`
 - :class:`~.ProgressFuture`
@@ -62,6 +61,7 @@ Support for user-defined background tasks
 
 - :class:`~.BaseFuture`
 - :class:`~.BaseTask`
+- :class:`~.IFuture`
 - :class:`~.ITaskSpecification`
 
 Parallelism contexts
@@ -117,7 +117,6 @@ from traits_futures.traits_executor import TraitsExecutor
 
 __all__ = [
     # Different types of Future
-    "IFuture",
     "CallFuture",
     "IterationFuture",
     "ProgressFuture",
@@ -144,6 +143,7 @@ __all__ = [
     # Support for creating new task types
     "BaseFuture",
     "BaseTask",
+    "IFuture",
     "ITaskSpecification",
     # Contexts
     "IParallelContext",

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -14,96 +14,32 @@ Interface for futures returned by the executor.
 
 import abc
 
-from traits.api import Bool, Interface
 
-from traits_futures.future_states import FutureState
-
-
-class IFuture(Interface):
+class IFuture(abc.ABC):
     """
     Interface for futures returned by the executor.
+
+    This interface is provided for use by those who want to implement new
+    background task types. It represents the knowledge that the executor needs
+    to interact with futures.
     """
-
-    #: The state of the background task, to the best of the knowledge of
-    #: this future. One of the six constants ``WAITING``, ``EXECUTING``,
-    #: ``COMPLETED``, ``FAILED``, ``CANCELLING`` or ``CANCELLED``. Users
-    #: should treat this trait as read-only.
-    state = FutureState
-
-    #: True if cancellation of the background task can be requested,
-    #: else False. Cancellation of the background task can be requested
-    #: only if the ``state`` is one of ``WAITING`` or ``EXECUTING``. Users
-    #: should treat this trait as read-only.
-    cancellable = Bool()
-
-    #: True when communications from the background task are complete.
-    #: At that point, no further state changes can occur for this future.
-    #: This trait has value True if the ``state`` is one of ``COMPLETED``,
-    #: ``FAILED``, or ``CANCELLED``. It's safe to listen to this trait
-    #: for changes: it will always fire exactly once, and when it fires
-    #: it will be consistent with the ``state``. Users should treat this
-    #: trait as read-only.
-    done = Bool()
-
-    @property
-    @abc.abstractmethod
-    def result(self):
-        """
-        Result of the background task.
-
-        This attribute is only available if the state of the future is
-        ``COMPLETED``. If the future has not reached the ``COMPLETED`` state,
-        any attempt to access this attribute will raise an ``AttributeError``.
-
-        Returns
-        -------
-        result : object
-            The result obtained from the background task.
-
-        Raises
-        ------
-        AttributeError
-            If the task is still executing, or was cancelled, or raised an
-            exception instead of returning a result.
-        """
-
-    @property
-    @abc.abstractmethod
-    def exception(self):
-        """
-        Information about any exception raised by the background task.
-
-        This attribute is only available if the state of this future is
-        ``FAILED``. If the future has not reached the ``FAILED`` state, any
-        attempt to access this attribute will raise an ``AttributeError.``
-
-        Returns
-        -------
-        exc_info : tuple
-            Tuple containing exception information in string form:
-            (exception type, exception value, formatted traceback).
-
-        Raises
-        ------
-        AttributeError
-            If the task is still executing, or was cancelled, or completed
-            without raising an exception.
-        """
 
     @abc.abstractmethod
     def cancel(self):
         """
         Request cancellation of the background task.
 
-        A task in ``WAITING`` or ``EXECUTING`` state will immediately be moved
-        to ``CANCELLING`` state. If the task is not in ``WAITING`` or
-        ``EXECUTING`` state, this function will raise ``RuntimeError``.
+        For a future that has not yet completed and has not previously been
+        cancelled, this method requests cancellation of the associated
+        background task and returns ``True``. For a future that has already
+        completed, or that has previously been cancelled, this method
+        does nothing, and returns ``False``.
 
-        Raises
-        ------
-        RuntimeError
-            If the task has already completed or cancellation has already
-            been requested.
+        Returns
+        -------
+        cancelled : bool
+            True if the task was cancelled, False if the task was not
+            cancellable.
         """
 
     @abc.abstractmethod

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -19,9 +19,8 @@ class IFuture(abc.ABC):
     """
     Interface for futures returned by the executor.
 
-    This interface can be used to implement new
-    background task types. It represents the knowledge that the executor needs
-    to interact with futures.
+    This interface can be used to implement new background task types. It
+    represents the knowledge that the executor needs to interact with futures.
     """
 
     @abc.abstractmethod

--- a/traits_futures/i_future.py
+++ b/traits_futures/i_future.py
@@ -19,7 +19,7 @@ class IFuture(abc.ABC):
     """
     Interface for futures returned by the executor.
 
-    This interface is provided for use by those who want to implement new
+    This interface can be used to implement new
     background task types. It represents the knowledge that the executor needs
     to interact with futures.
     """


### PR DESCRIPTION
[Should only be considered for merging once #420 is merged - the code here assumes that `cancellable` is no longer needed by the executor]

`IFuture` is currently being used for two separate purposes: documenting the methods available to a user of the futures implementation, and documenting the methods that the executor expects to interact with.

For the first purpose, `IFuture` isn't really useful: the user is typically calling a specific submission function (like `submit_call`) and getting back a specific future type (like `CallFuture`), and they can use that future type in trait declarations and the like.

This PR removes the ambiguity and specialises `IFuture` for the second use-case - that of documenting what the executor expects from a future.

In more detail, we:
- Move `IFuture` to the "Support for creating new task types" section in the api documentation
- Fix some examples to use explicit future types in their trait declarations instead of using `IFuture`
- Fix docs (other than the documentation on new task types) to refer to `BaseFuture` everywhere instead of `IFuture`
- Remove all methods except for `cancel` and `receive` from `IFuture`, since these two methods are all that the executor needs.
- Make `IFuture` a plain old `abc.ABC` - it's no longer a `HasTraits` subclass