### PR TITLE
Migrate static "_*_fired" methods with "observe" decorated methods

### DIFF
--- a/docs/source/guide/examples/background_processes.py
+++ b/docs/source/guide/examples/background_processes.py
@@ -29,6 +29,7 @@ from traits.api import (
     HasStrictTraits,
     Instance,
     List,
+    observe,
     Property,
     Range,
     Str,
@@ -127,15 +128,18 @@ class SquaringHelper(HasStrictTraits):
     #: Value that we'll square.
     input = Range(low=0, high=100)
 
-    def _square_fired(self):
+    @observe("square")
+    def _do_slow_square(self, event):
         future = submit_call(self.traits_executor, slow_square, self.input)
         self.current_futures.append(future)
 
-    def _cancel_all_fired(self):
+    @observe("cancel_all")
+    def _cancel_all_futures(self, event):
         for future in self.current_futures:
             future.cancel()
 
-    def _clear_finished_fired(self):
+    @observe("clear_finished")
+    def _clear_finished_futures(self, event):
         for future in list(self.current_futures):
             if future.done:
                 self.current_futures.remove(future)

--- a/docs/source/guide/examples/pi_iterations.py
+++ b/docs/source/guide/examples/pi_iterations.py
@@ -118,12 +118,14 @@ class PiIterator(HasStrictTraits):
     #: The plot.
     plot = Instance(Plot)
 
-    def _approximate_fired(self):
+    @observe("approximate")
+    def _calculate_pi_approximately(self, event):
         self.future = submit_iteration(
             self.traits_executor, pi_iterations, chunk_size=self.chunk_size
         )
 
-    def _cancel_fired(self):
+    @observe("cancel")
+    def _cancel_future(self, event):
         self.future.cancel()
 
     @observe("future")

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -199,7 +199,8 @@ class PrimeCounter(HasStrictTraits):
     #: Limit used for most recent run.
     _last_limit = Int()
 
-    def _count_fired(self):
+    @observe("count")
+    def _count_primes(self, event):
         self._last_limit = self.limit
         self.future = submit_progress(
             self.traits_executor,

--- a/docs/source/guide/examples/slow_squares.py
+++ b/docs/source/guide/examples/slow_squares.py
@@ -18,6 +18,7 @@ from traits.api import (
     HasStrictTraits,
     Instance,
     List,
+    observe,
     Property,
     Range,
     Str,
@@ -115,15 +116,18 @@ class SquaringHelper(HasStrictTraits):
     #: Value that we'll square.
     input = Range(low=0, high=100)
 
-    def _square_fired(self):
+    @observe("square")
+    def _do_slow_square(self, event):
         future = submit_call(self.traits_executor, slow_square, self.input)
         self.current_futures.append(future)
 
-    def _cancel_all_fired(self):
+    @observe("cancel_all")
+    def _cancel_all_futures(self, event):
         for future in self.current_futures:
             future.cancel()
 
-    def _clear_finished_fired(self):
+    @observe("clear_finished")
+    def _clear_finished_futures(self, event):
         for future in list(self.current_futures):
             if future.done:
                 self.current_futures.remove(future)

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -17,7 +17,7 @@ import queue
 import threading
 import weakref
 
-from traits.api import Event, HasStrictTraits, Int
+from traits.api import Event, HasStrictTraits, Int, observe
 
 #: Safety timeout, in seconds, for blocking operations, to prevent
 #: the test suite from blocking indefinitely if something goes wrong.
@@ -90,7 +90,8 @@ class PingListener(HasStrictTraits):
     #: Total number of pings received.
     ping_count = Int(0)
 
-    def _ping_fired(self):
+    @observe("ping")
+    def _handle_incoming_ping(self, event):
         self.ping_count += 1
 
     def fire_ping(self):


### PR DESCRIPTION
fixes #440 

This PR updates the static `_*_fired` methods with `observe` decorated methods.

Note to reviewer : I tested the examples locally but it would be a good idea to test them personally.