### PR TITLE
Always send an ABANDONED message to acknowledge cancellation

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -91,7 +91,7 @@ Fixes
   queue. Instead, it will fail fast with a ``QueueError`` exception. This
   situation should never happen in normal use; please report it if you ever
   witness it.
-* The ``ProgressCancelled`` exception used by the background task submitted
+* The ``TaskCancelled`` exception used by the background task submitted
   via ``submit_progress`` is now public, in case that task needs to catch
   the exception.
 * The marshal_exception function has been fixed not to rely on the global

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -56,7 +56,7 @@ from |traits_futures.api|:
   "progress" parameter can then be called to send progress reports to the
   associated |ProgressFuture| object. If the future has been cancelled, the
   next call to ``progress`` in the background task will raise a
-  |ProgressCancelled| exception.
+  |TaskCancelled| exception.
 
   For example, your callable might look like this::
 
@@ -393,10 +393,11 @@ needed.
 .. |submit_iteration| replace:: :func:`~traits_futures.background_iteration.submit_iteration`
 .. |result_event| replace:: :attr:`~traits_futures.background_iteration.IterationFuture.result_event`
 
-.. |ProgressCancelled| replace:: :exc:`~traits_futures.background_progress.ProgressCancelled`
 .. |ProgressFuture| replace:: :class:`~traits_futures.background_progress.ProgressFuture`
 .. |submit_progress| replace:: :func:`~traits_futures.background_progress.submit_progress`
 .. |progress| replace:: :attr:`~traits_futures.background_progress.ProgressFuture.progress`
+
+.. |TaskCancelled| replace:: :exc:`~.TaskCancelled`
 
 .. |FutureState| replace:: :data:`~traits_futures.future_states.FutureState`
 .. |WAITING| replace:: :data:`~traits_futures.future_states.WAITING`

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -28,7 +28,7 @@ Task submission functions
 - :func:`~.submit_call`
 - :func:`~.submit_iteration`
 - :func:`~.submit_progress`
-- :exc:`~.ProgressCancelled`
+- :exc:`~.TaskCancelled`
 
 Types of futures
 ----------------
@@ -85,12 +85,8 @@ from traits_futures.background_iteration import (
     IterationFuture,
     submit_iteration,
 )
-from traits_futures.background_progress import (
-    ProgressCancelled,
-    ProgressFuture,
-    submit_progress,
-)
-from traits_futures.base_future import BaseFuture, BaseTask
+from traits_futures.background_progress import ProgressFuture, submit_progress
+from traits_futures.base_future import BaseFuture, BaseTask, TaskCancelled
 from traits_futures.ets_event_loop import ETSEventLoop
 from traits_futures.executor_states import (
     ExecutorState,
@@ -119,7 +115,7 @@ __all__ = [
     "CallFuture",
     "IterationFuture",
     "ProgressFuture",
-    "ProgressCancelled",
+    "TaskCancelled",
     # Future states
     "FutureState",
     "CANCELLED",

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -14,7 +14,7 @@ Background task that sends results from an iteration.
 
 from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
-from traits_futures.base_future import BaseFuture, BaseTask
+from traits_futures.base_future import BaseFuture, BaseTask, TaskCancelled
 from traits_futures.i_task_specification import ITaskSpecification
 
 #: Message sent whenever the iteration yields a result.
@@ -37,7 +37,7 @@ class IterationTask(BaseTask):
 
         while True:
             if self.cancelled():
-                return None
+                raise TaskCancelled
 
             try:
                 result = next(iterable)

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -21,7 +21,7 @@ be cancelled.
 
 from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
-from traits_futures.base_future import BaseFuture, BaseTask
+from traits_futures.base_future import BaseFuture, BaseTask, TaskCancelled
 from traits_futures.i_task_specification import ITaskSpecification
 
 # Message types for messages from ProgressTask
@@ -30,13 +30,6 @@ from traits_futures.i_task_specification import ITaskSpecification
 #: Task sends progress. Argument is a single object giving progress
 #: information. This module does not interpret the contents of the argument.
 PROGRESS = "progress"
-
-
-class ProgressCancelled(Exception):
-    """
-    Exception raised when progress reporting is interrupted by
-    task cancellation.
-    """
 
 
 class ProgressReporter:
@@ -63,13 +56,13 @@ class ProgressReporter:
 
         Raises
         ------
-        ProgressCancelled
+        TaskCancelled
             If a cancellation request for this task has already been made.
             In this case, the exception will be raised before any progress
             information is sent.
         """
         if self.cancelled():
-            raise ProgressCancelled("Task was cancelled")
+            raise TaskCancelled
         self.send(PROGRESS, progress_info)
 
 
@@ -88,14 +81,11 @@ class ProgressTask(BaseTask):
 
     def run(self):
         progress = ProgressReporter(send=self.send, cancelled=self.cancelled)
-        try:
-            return self.callable(
-                *self.args,
-                **self.kwargs,
-                progress=progress.report,
-            )
-        except ProgressCancelled:
-            return None
+        return self.callable(
+            *self.args,
+            **self.kwargs,
+            progress=progress.report,
+        )
 
 
 class ProgressFuture(BaseFuture):

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -17,9 +17,9 @@ from traits_futures.api import (
     EXECUTING,
     FAILED,
     FutureState,
-    ProgressCancelled,
     ProgressFuture,
     submit_progress,
+    TaskCancelled,
     WAITING,
 )
 
@@ -81,7 +81,7 @@ def syncing_progress(test_ready, raised, progress):
     # so that we never get to the following code.
     try:
         progress("second")
-    except ProgressCancelled:
+    except TaskCancelled:
         raised.set()
         raise
 

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -48,8 +48,10 @@ COMPLETE_VALID_SEQUENCES = {
     "SX",
     "CSR",
     "CSX",
+    "CSA",
     "SCR",
     "SCX",
+    "SCA",
     "CA",
 }
 

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -33,7 +33,6 @@ class TestApi(unittest.TestCase):
             IterationFuture,
             MultiprocessingContext,
             MultithreadingContext,
-            ProgressCancelled,
             ProgressFuture,
             RUNNING,
             STOPPED,
@@ -41,6 +40,7 @@ class TestApi(unittest.TestCase):
             submit_call,
             submit_iteration,
             submit_progress,
+            TaskCancelled,
             TraitsExecutor,
             WAITING,
         )


### PR DESCRIPTION
This completes the refactor started in #392

In #392, a task that was cancelled prior to execution starting sent an ABANDONED message instead of a STARTED message; that way we weren't inventing a `None` return value.

In this PR, a task where cancellation is discovered *during* execution also sends an ABANDONED message, instead of inventing a return value of `None`.

Closes #445 
Closes #437