### PR TITLE
Rename ProgressCancelled to TaskCancelled

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -91,7 +91,7 @@ Fixes
   queue. Instead, it will fail fast with a ``QueueError`` exception. This
   situation should never happen in normal use; please report it if you ever
   witness it.
-* The ``ProgressCancelled`` exception used by the background task submitted
+* The ``TaskCancelled`` exception used by the background task submitted
   via ``submit_progress`` is now public, in case that task needs to catch
   the exception.
 * The marshal_exception function has been fixed not to rely on the global

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -83,7 +83,7 @@ class ProgressDialog(Dialog, HasStrictTraits):
             "Cancel", QtGui.QDialogButtonBox.RejectRole
         )
         self._cancel_button.setDefault(True)
-        buttons.rejected.connect(self.cancel)
+        buttons.rejected.connect(self.cancel, type=QtCore.Qt.QueuedConnection)
         return buttons
 
     def _create_message(self, dialog, layout):

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -83,7 +83,7 @@ class ProgressDialog(Dialog, HasStrictTraits):
             "Cancel", QtGui.QDialogButtonBox.RejectRole
         )
         self._cancel_button.setDefault(True)
-        buttons.rejected.connect(self.cancel, type=QtCore.Qt.QueuedConnection)
+        buttons.rejected.connect(self.cancel)
         return buttons
 
     def _create_message(self, dialog, layout):

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -393,7 +393,7 @@ needed.
 .. |submit_iteration| replace:: :func:`~traits_futures.background_iteration.submit_iteration`
 .. |result_event| replace:: :attr:`~traits_futures.background_iteration.IterationFuture.result_event`
 
-.. |TaskCancelled| replace:: :exc:`~traits_futures.background_progress.TaskCancelled`
+.. |TaskCancelled| replace:: :exc:`~traits_futures.base_future.TaskCancelled`
 .. |ProgressFuture| replace:: :class:`~traits_futures.background_progress.ProgressFuture`
 .. |submit_progress| replace:: :func:`~traits_futures.background_progress.submit_progress`
 .. |progress| replace:: :attr:`~traits_futures.background_progress.ProgressFuture.progress`

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -56,7 +56,7 @@ from |traits_futures.api|:
   "progress" parameter can then be called to send progress reports to the
   associated |ProgressFuture| object. If the future has been cancelled, the
   next call to ``progress`` in the background task will raise a
-  |ProgressCancelled| exception.
+  |TaskCancelled| exception.
 
   For example, your callable might look like this::
 
@@ -393,7 +393,7 @@ needed.
 .. |submit_iteration| replace:: :func:`~traits_futures.background_iteration.submit_iteration`
 .. |result_event| replace:: :attr:`~traits_futures.background_iteration.IterationFuture.result_event`
 
-.. |ProgressCancelled| replace:: :exc:`~traits_futures.background_progress.ProgressCancelled`
+.. |TaskCancelled| replace:: :exc:`~traits_futures.background_progress.TaskCancelled`
 .. |ProgressFuture| replace:: :class:`~traits_futures.background_progress.ProgressFuture`
 .. |submit_progress| replace:: :func:`~traits_futures.background_progress.submit_progress`
 .. |progress| replace:: :attr:`~traits_futures.background_progress.ProgressFuture.progress`

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -28,7 +28,6 @@ Task submission functions
 - :func:`~.submit_call`
 - :func:`~.submit_iteration`
 - :func:`~.submit_progress`
-- :exc:`~.TaskCancelled`
 
 Types of futures
 ----------------
@@ -36,6 +35,7 @@ Types of futures
 - :class:`~.CallFuture`
 - :class:`~.IterationFuture`
 - :class:`~.ProgressFuture`
+- :exc:`~.TaskCancelled`
 
 Future states
 -------------
@@ -85,12 +85,8 @@ from traits_futures.background_iteration import (
     IterationFuture,
     submit_iteration,
 )
-from traits_futures.background_progress import (
-    ProgressFuture,
-    submit_progress,
-    TaskCancelled,
-)
-from traits_futures.base_future import BaseFuture, BaseTask
+from traits_futures.background_progress import ProgressFuture, submit_progress
+from traits_futures.base_future import BaseFuture, BaseTask, TaskCancelled
 from traits_futures.ets_event_loop import ETSEventLoop
 from traits_futures.executor_states import (
     ExecutorState,

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -28,7 +28,7 @@ Task submission functions
 - :func:`~.submit_call`
 - :func:`~.submit_iteration`
 - :func:`~.submit_progress`
-- :exc:`~.ProgressCancelled`
+- :exc:`~.TaskCancelled`
 
 Types of futures
 ----------------
@@ -86,9 +86,9 @@ from traits_futures.background_iteration import (
     submit_iteration,
 )
 from traits_futures.background_progress import (
-    ProgressCancelled,
     ProgressFuture,
     submit_progress,
+    TaskCancelled,
 )
 from traits_futures.base_future import BaseFuture, BaseTask
 from traits_futures.ets_event_loop import ETSEventLoop
@@ -119,7 +119,7 @@ __all__ = [
     "CallFuture",
     "IterationFuture",
     "ProgressFuture",
-    "ProgressCancelled",
+    "TaskCancelled",
     # Future states
     "FutureState",
     "CANCELLED",

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -21,7 +21,7 @@ be cancelled.
 
 from traits.api import Callable, Dict, Event, HasStrictTraits, Str, Tuple
 
-from traits_futures.base_future import BaseFuture, BaseTask
+from traits_futures.base_future import BaseFuture, BaseTask, TaskCancelled
 from traits_futures.i_task_specification import ITaskSpecification
 
 # Message types for messages from ProgressTask
@@ -30,13 +30,6 @@ from traits_futures.i_task_specification import ITaskSpecification
 #: Task sends progress. Argument is a single object giving progress
 #: information. This module does not interpret the contents of the argument.
 PROGRESS = "progress"
-
-
-class TaskCancelled(Exception):
-    """
-    Exception raised when progress reporting is interrupted by
-    task cancellation.
-    """
 
 
 class ProgressReporter:

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -32,7 +32,7 @@ from traits_futures.i_task_specification import ITaskSpecification
 PROGRESS = "progress"
 
 
-class ProgressCancelled(Exception):
+class TaskCancelled(Exception):
     """
     Exception raised when progress reporting is interrupted by
     task cancellation.
@@ -63,13 +63,13 @@ class ProgressReporter:
 
         Raises
         ------
-        ProgressCancelled
+        TaskCancelled
             If a cancellation request for this task has already been made.
             In this case, the exception will be raised before any progress
             information is sent.
         """
         if self.cancelled():
-            raise ProgressCancelled("Task was cancelled")
+            raise TaskCancelled("Task was cancelled")
         self.send(PROGRESS, progress_info)
 
 
@@ -94,7 +94,7 @@ class ProgressTask(BaseTask):
                 **self.kwargs,
                 progress=progress.report,
             )
-        except ProgressCancelled:
+        except TaskCancelled:
             return None
 
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -125,6 +125,12 @@ _CANCELLABLE_INTERNAL_STATES = {
 }
 
 
+class TaskCancelled(Exception):
+    """
+    Exception raised within the background task on cancellation.
+    """
+
+
 class _StateTransitionError(Exception):
     """
     Exception used to indicate a bad state transition.

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -17,9 +17,9 @@ from traits_futures.api import (
     EXECUTING,
     FAILED,
     FutureState,
-    ProgressCancelled,
     ProgressFuture,
     submit_progress,
+    TaskCancelled,
     WAITING,
 )
 
@@ -81,7 +81,7 @@ def syncing_progress(test_ready, raised, progress):
     # so that we never get to the following code.
     try:
         progress("second")
-    except ProgressCancelled:
+    except TaskCancelled:
         raised.set()
         raise
 

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -33,7 +33,6 @@ class TestApi(unittest.TestCase):
             IterationFuture,
             MultiprocessingContext,
             MultithreadingContext,
-            ProgressCancelled,
             ProgressFuture,
             RUNNING,
             STOPPED,
@@ -41,6 +40,7 @@ class TestApi(unittest.TestCase):
             submit_call,
             submit_iteration,
             submit_progress,
+            TaskCancelled,
             TraitsExecutor,
             WAITING,
         )


### PR DESCRIPTION
This PR renames the `ProgressCancelled` exception to `TaskCancelled` and moves it to `base_future.py`. This is in anticipation of future task types that might want to re-use the same exception. (Notably the `StepsTask` in #367.)

Closes #445