### PR TITLE
Fix out-of-order cancellation

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -169,6 +169,8 @@ Documentation
 * The ``pi_iterations`` example has been fixed to give correct counts.
   Previously it was giving incorrect results as a result of NumPy integer
   overflow.
+* The ``prime_counting`` example has been fixed to avoid an occasional
+  ``AttributeError`` under unusual timing conditions.
 
 
 Release 0.2.0

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -56,9 +56,10 @@ class ProgressDialog(Dialog, HasStrictTraits):
         """
         Cancel the running future when the cancel button is pressed.
         """
-        self.future.cancel()
         self._cancel_button.setEnabled(False)
-        self.message = "Cancelling\N{HORIZONTAL ELLIPSIS}"
+        cancelled = self.future.cancel()
+        if cancelled:
+            self.message = "Cancelling\N{HORIZONTAL ELLIPSIS}"
 
     # Private traits ##########################################################
 
@@ -83,7 +84,7 @@ class ProgressDialog(Dialog, HasStrictTraits):
             "Cancel", QtGui.QDialogButtonBox.RejectRole
         )
         self._cancel_button.setDefault(True)
-        buttons.rejected.connect(self.cancel)
+        buttons.rejected.connect(self.cancel, type=QtCore.Qt.QueuedConnection)
         return buttons
 
     def _create_message(self, dialog, layout):
@@ -127,7 +128,6 @@ class ProgressDialog(Dialog, HasStrictTraits):
 
     @observe("future:done")
     def _respond_to_completion(self, event):
-        self.future = None
         self.close()
 
 


### PR DESCRIPTION
Some experimental changes that may fix the cancellation issue with the prime-counting demo script (#442):

- Use `Qt.QueuedConnection` as the connection type for the buttons. This is a workaround for a macOS-only issue where refreshes don't happen as often as expected.
- Never set the `future` held by the dialog to `None`; there's no good reason to do this, and it makes reasoning about correctness more difficult.
- Allow for the possibility that by the time we're executing the `cancel` method, the future is no longer cancellable.

@rahulporuri Do you have bandwidth to test this?

Closes #442 (I hope).