### PR TITLE
Remove the useless 'null' entry from extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     keywords="background concurrency futures gui traits traitsui",
     install_requires=install_requires,
     extras_require={
-        "null": [],
         "pyqt5": ["pyqt5"],
         "pyside2": ["pyside2"],
         "docs": ["enthought-sphinx-theme", "sphinx>=3.5"],


### PR DESCRIPTION
The `null` entry in `extras_require` isn't useful. I think there was a plan at one point to be able to do `pip install -e .[toolkit_name]` from CI scripts, but we're not doing that.

Closes #446.