### PR TITLE
Update trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     packages=find_packages(exclude=["ci"]),
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={
         "traits_futures.event_loops": [


### PR DESCRIPTION
This PR updates the trove classifiers in the setup script:

- Add Python 3.10
- Change "development status" to "beta"