### PR TITLE
Examples: don't raise in a Traits observer

### DIFF
--- a/docs/source/guide/examples/interruptible_task.py
+++ b/docs/source/guide/examples/interruptible_task.py
@@ -98,7 +98,7 @@ class InterruptibleTaskExample(HasStrictTraits):
         else:
             # Shouldn't ever get here: CANCELLED, FAILED and COMPLETED
             # are the only possible final states of a future.
-            raise RuntimeError(f"Unexpected state: {self.future.state}")
+            assert False, f"Impossible state: {self.future.state}"
         self.future = None
 
     @observe("future:result_event")

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -96,7 +96,7 @@ class NonInterruptibleTaskExample(HasStrictTraits):
         else:
             # Shouldn't ever get here: CANCELLED, FAILED and COMPLETED
             # are the only possible final states of a future.
-            raise RuntimeError(f"Unexpected state: {self.future.state}")
+            assert False, f"Impossible state: {self.future.state}"
         self.future = None
 
     def _get_can_calculate(self):


### PR DESCRIPTION
This PR fixes two examples that were raising within a Traits observer, albeit in a theoretically impossible situation. The PR replaces the `raise` with an `assert`. Context: deliberately raising an exception within a Traits listener is an antipattern, and we shouldn't feature that antipattern in our examples.