### PR TITLE
Don't use Sphinx 4 for the moment

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install sphinx enthought-sphinx-theme
-        python -m pip install .
+        python -m pip install .[doc]
     - name: Build HTML documentation with Sphinx
       run: |
         cd docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install .[doc]
+        python -m pip install .[docs]
     - name: Build HTML documentation with Sphinx
       run: |
         cd docs

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install local package and documentation dependencies
       run: |
-        python -m pip install .[doc]
+        python -m pip install .[docs]
     - name: Build HTML documentation
       run: |
         cd docs

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -22,12 +22,11 @@ jobs:
     - name: Install necessary Python packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install sphinx enthought-sphinx-theme
     - name: Check out the PR branch
       uses: actions/checkout@v2
-    - name: Install local package
+    - name: Install local package and documentation dependencies
       run: |
-        python -m pip install .
+        python -m pip install .[doc]
     - name: Build HTML documentation
       run: |
         cd docs

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     extras_require={
         "pyqt5": ["pyqt5"],
         "pyside2": ["pyside2"],
-        "docs": ["enthought-sphinx-theme", "sphinx>=3.5"],
+        "docs": ["enthought-sphinx-theme", "sphinx>=3.5,<4"],
     },
     packages=find_packages(exclude=["ci"]),
     classifiers=[


### PR DESCRIPTION
Using the latest version of Sphinx to build documentation is proving problematic: we're ending up with broken documentation builds too often as a result of Sphinx changes.

This PR doesn't actually pin the version of Sphinx to use, but does avoid Sphinx >= 4 for the moment. We can upgrade later when things seem more stable.

This PR also changes the workflows to use `pip install .[doc]`, so that the information about the packages needed for docs is in a single place.

Closes #456.