### PR TITLE
Bump version for release

### DIFF
--- a/traits_futures/version.py
+++ b/traits_futures/version.py
@@ -12,4 +12,4 @@
 Version information for the traits_futures package.
 """
 #: Version of the traits_futures package, as a string.
-version = "0.3.0.dev0"
+version = "0.3.0"


### PR DESCRIPTION
Bump the version from "0.3.0.dev0" to "0.3.0", in preparation for the 0.3.0 feature release.

Note: this PR is against the `maint/0.3` branch. We're not planning to merge this PR; we're only making it to get the benefit of human and machine review. Instead, once it's approved by all the appropriate overlords, we'll tag the commit in this PR as `0.3.0`.