### PR TITLE
Add workflow to validate PyPI installs

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,7 +1,6 @@
 name: Test installation from PyPI
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Run at 05:27 UTC on the 6th and 20th of every month

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -85,12 +85,12 @@ jobs:
     - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --only-binary traits-futures traits-futures[pyside2]
-      if: ${{ matrix.python-version != "3.10-dev" }}
+      if: ${{ matrix.python-version != '3.10-dev' }}
     - name: Install package and test dependencies from PyPI wheel (no PySide2)
       # PySide2 does not yet work on Python 3.10; test without it.
       run: |
         python -m pip install --only-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == "3.10-dev" }}
+      if: ${{ matrix.python-version == '3.10-dev' }}
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,6 +1,7 @@
 name: Test installation from PyPI
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     # Run at 05:27 UTC on the 6th and 20th of every month

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     runs-on: ${{ matrix.os }}
 
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -1,0 +1,88 @@
+name: Test installation from PyPI
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 05:27 UTC on the 6th and 20th of every month
+    - cron: '27 5 6,20 * *'
+
+jobs:
+  test-pypi-sdist:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Install Linux packages for Qt 5 support
+      run: |
+        sudo apt-get update
+        sudo apt-get install qt5-default
+        sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-icccm4
+        sudo apt-get install libxcb-image0
+        sudo apt-get install libxcb-keysyms1
+        sudo apt-get install libxcb-randr0
+        sudo apt-get install libxcb-render-util0
+        sudo apt-get install libxcb-xinerama0
+      if: runner.os == 'Linux'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+    - name: Install package and test dependencies from PyPI sdist
+      run: |
+        python -m pip install --no-binary traits-futures traits-futures[pyside2]
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Run the test suite
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: testdir
+        run: python -m unittest discover -v traits-futures
+
+  test-pypi-wheel:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Install Linux packages for Qt 5 support
+      run: |
+        sudo apt-get update
+        sudo apt-get install qt5-default
+        sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-icccm4
+        sudo apt-get install libxcb-image0
+        sudo apt-get install libxcb-keysyms1
+        sudo apt-get install libxcb-randr0
+        sudo apt-get install libxcb-render-util0
+        sudo apt-get install libxcb-xinerama0
+      if: runner.os == 'Linux'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+    - name: Install package and test dependencies from PyPI wheel
+      run: |
+        python -m pip install --only-binary traits-futures traits-futures[pyside2]
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Run the test suite
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: testdir
+        run: python -m unittest discover -v traits-futures

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -39,12 +39,12 @@ jobs:
     - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --no-binary traits-futures traits-futures[pyside2]
-      if: matrix.python-version != "3.10-dev"
+      if: ${{ matrix.python-version != '3.10-dev' }}
     - name: Install package and test dependencies from PyPI wheel (no PySide2)
       # PySide2 does not yet work on Python 3.10; test without it.
       run: |
         python -m pip install --no-binary traits-futures traits-futures
-      if: matrix.python-version == "3.10-dev"
+      if: ${{ matrix.python-version == '3.10-dev' }}
     - name: Create clean test directory
       run: |
         mkdir testdir
@@ -85,12 +85,12 @@ jobs:
     - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --only-binary traits-futures traits-futures[pyside2]
-      if: matrix.python-version != "3.10-dev"
+      if: ${{ matrix.python-version != "3.10-dev" }}
     - name: Install package and test dependencies from PyPI wheel (no PySide2)
       # PySide2 does not yet work on Python 3.10; test without it.
       run: |
         python -m pip install --only-binary traits-futures traits-futures
-      if: matrix.python-version == "3.10-dev"
+      if: ${{ matrix.python-version == "3.10-dev" }}
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -35,11 +35,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-    - name: Install package and test dependencies from PyPI wheel (with PySide2)
+    - name: Install package and test dependencies from PyPI sdist (with PySide2)
       run: |
         python -m pip install --no-binary traits-futures traits-futures[pyside2]
       if: ${{ matrix.python-version != '3.10-dev' }}
-    - name: Install package and test dependencies from PyPI wheel (no PySide2)
+    - name: Install package and test dependencies from PyPI sdist (no PySide2)
       # PySide2 does not yet work on Python 3.10; test without it.
       run: |
         python -m pip install --no-binary traits-futures traits-futures

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -36,9 +36,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-    - name: Install package and test dependencies from PyPI sdist
+    - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --no-binary traits-futures traits-futures[pyside2]
+      if: matrix.python-version != "3.10-dev"
+    - name: Install package and test dependencies from PyPI wheel (no PySide2)
+      # PySide2 does not yet work on Python 3.10; test without it.
+      run: |
+        python -m pip install --no-binary traits-futures traits-futures
+      if: matrix.python-version == "3.10-dev"
     - name: Create clean test directory
       run: |
         mkdir testdir
@@ -76,9 +82,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-    - name: Install package and test dependencies from PyPI wheel
+    - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --only-binary traits-futures traits-futures[pyside2]
+      if: matrix.python-version != "3.10-dev"
+    - name: Install package and test dependencies from PyPI wheel (no PySide2)
+      # PySide2 does not yet work on Python 3.10; test without it.
+      run: |
+        python -m pip install --only-binary traits-futures traits-futures
+      if: matrix.python-version == "3.10-dev"
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -46,7 +46,7 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: testdir
-        run: python -m unittest discover -v traits-futures
+        run: python -m unittest discover -v traits_futures
 
   test-pypi-wheel:
     strategy:
@@ -86,4 +86,4 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: testdir
-        run: python -m unittest discover -v traits-futures
+        run: python -m unittest discover -v traits_futures

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -10,6 +10,19 @@
    Thanks for using Enthought open source!
 
 
+Release 0.4.0
+-------------
+
+Release date: XXXX-XX-XX
+
+
+Continuous integration and build
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add cron-job-based workflow to validate installation of the latest
+  wheel and sdist from PyPI. (#465)
+
+
 Release 0.3.0
 -------------
 


### PR DESCRIPTION
We've successfully automated upload of sdists and wheels to PyPI, but we have nothing in place to test those uploads automatically.

This PR adds a workflow that can be triggered manually, and is also run every two weeks. It installs the latest Traits Futures wheel from PyPI, together with PySide2, and checks that all tests pass. It then does the same for the sdist.

The `pull_request:` trigger will be removed once it's established that this workflow is working correctly.