### PR TITLE
Allow BaseFuture instances to be instantiated without arguments (#467)

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -10,6 +10,18 @@
    Thanks for using Enthought open source!
 
 
+Release 0.3.1
+-------------
+
+Release date: XXXX-XX-XX
+
+Fixes
+~~~~~
+
+* Fix regression where |BaseFuture| subclasses could not be instantiated
+  without any arguments. (#467)
+
+
 Release 0.3.0
 -------------
 

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -20,7 +20,7 @@ from traits.api import (
     Bool,
     Callable,
     Enum,
-    HasRequiredTraits,
+    HasStrictTraits,
     observe,
     Property,
     Str,
@@ -142,7 +142,7 @@ class _StateTransitionError(Exception):
 
 
 @IFuture.register
-class BaseFuture(HasRequiredTraits):
+class BaseFuture(HasStrictTraits):
     """
     Convenience base class for the various flavours of Future.
     """
@@ -460,7 +460,7 @@ class BaseFuture(HasRequiredTraits):
 
     #: Callback called (with no arguments) when user requests cancellation.
     #: This is reset to ``None`` once cancellation is impossible.
-    _cancel = Callable(allow_none=True, required=True)
+    _cancel = Callable(allow_none=True)
 
     #: The internal state of the future.
     _internal_state = Enum(WAITING, list(_INTERNAL_STATE_TO_STATE))

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -199,6 +199,11 @@ class CommonFutureTests:
         future = self.future_class(_cancel=dummy_cancel_callback)
         self.assertIsInstance(future, IFuture)
 
+    def test_zero_argument_instantiation(self):
+        # Regression test for enthought/traits-futures#466
+        future = self.future_class()
+        self.assertIsInstance(future, IFuture)
+
     def send_message(self, future, message, cancel_callback):
         """Send a particular message to a future."""
         if message == "A":


### PR DESCRIPTION
(cherry picked from commit 63005f7b9b9cc0711a386840d371e4a1f8e73a63)

This is a backport of the fix in #467 to the 0.3.x maintenance branch.

The code has already been reviewed. I'll self-merge when the CI completes.