### PR TITLE
Auto doc build debugging: print git config

### DIFF
--- a/scripts/update_docs.py
+++ b/scripts/update_docs.py
@@ -176,6 +176,7 @@ def push_updates(clone_directory, doc_version, branch, token):
 
         commit_message = "Automated update of documentation"
         run_git("commit", "-m", commit_message)
+        run_git("config", "--list")
         run_git(
             "-c",
             (


### PR DESCRIPTION
Another debugging step in the automated documentation build: print the git config.