### PR TITLE
Skip copyright headers in literalincludes

### DIFF
--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -29,6 +29,9 @@ calculation may fail randomly, with an increased chance of failure for larger
 inputs.
 
 .. literalinclude:: examples/slow_squares.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
+
 
 Prime counting
 --------------
@@ -41,6 +44,9 @@ This :download:`example script <examples/prime_counting.py>` demonstrates the
 GUI as the background computation progresses.
 
 .. literalinclude:: examples/prime_counting.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
+
 
 Approximating Pi
 ----------------
@@ -54,3 +60,5 @@ Successive approximations to π are computed and plotted, with the plot
 updated live with each new value reported by the background task.
 
 .. literalinclude:: examples/pi_iterations.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-

--- a/docs/source/guide/toolkits.rst
+++ b/docs/source/guide/toolkits.rst
@@ -58,6 +58,8 @@ Here's an :download:`example script <examples/headless.py>` that uses the
 of an asyncio event loop.
 
 .. literalinclude:: examples/headless.py
+   :start-after: Thanks for using Enthought
+   :lines: 2-
 
 ..
    substitutions


### PR DESCRIPTION
In most of the `literalinclude` example scripts we skip the copyright headers, but in some we missed that. This PR fixes that.