### PR TITLE
Try both 'exec' and 'exec_' methods on QCoreApplication.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -15,6 +15,11 @@ Release 0.4.0
 
 Release date: XXXX-XX-XX
 
+Features
+~~~~~~~~
+
+* Support Qt6-based toolkits PyQt6 and PySide6. (This is dependent on
+  corresponding support in Pyface.) (#488)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/traits_futures/qt/event_loop_helper.py
+++ b/traits_futures/qt/event_loop_helper.py
@@ -138,7 +138,15 @@ class EventLoopHelper:
                 timeout_timer.timeout.connect(stop_on_timeout)
                 timeout_timer.start()
                 try:
-                    timed_out = qt_app.exec_()
+                    # Qt wrapper support is a bit of a mess here. PyQt6 has
+                    # only "exec". PyQt5 and PySide6 support both "exec" and
+                    # "exec_", with "exec" the preferred spelling. PyQt4 and
+                    # PySide2 support only "exec_".
+                    try:
+                        exec_method = qt_app.exec
+                    except AttributeError:
+                        exec_method = qt_app.exec_
+                    timed_out = exec_method()
                 finally:
                     timeout_timer.stop()
                     timeout_timer.timeout.disconnect(stop_on_timeout)


### PR DESCRIPTION
This PR adds a compatibility fix for Qt6 support. Unfortunately there doesn't seem to be any reasonable way to avoid checking for both `exec` and `exec_` for the near future: PyQt6 _only_ has `exec`, while PySide2 _only_ has `exec_`. PySide6 and PyQt5 support both.

No tests because:
- ~support for Qt6 isn't yet in Pyface master~ support for Qt6 isn't yet in a Pyface release
- this code is effectively part of the test machinery anyway - it's not currently used by Traits Futures clients

Once Pyface has released support for Qt6, we should add GitHub Actions workflows for testing on the various flavours of Qt versions and wrappers. I'll open a separate issue for that.