### PR TITLE
Remove asyncio toolkit support

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -21,6 +21,14 @@ Features
 * Support Qt6-based toolkits PyQt6 and PySide6. (This is dependent on
   corresponding support in Pyface.) (#488)
 
+Changes
+~~~~~~~
+
+* The "asyncio" and "null" entry points for the "traits_futures.event_loops"
+  entry point group have been removed. Their behaviour was ill-defined, and
+  dependent on ``asyncio.get_event_loop``, which is deprecated in Python.
+  (#490)
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ setup(
     ],
     entry_points={
         "traits_futures.event_loops": [
-            "asyncio = traits_futures.asyncio.event_loop:AsyncioEventLoop",
-            "null = traits_futures.asyncio.event_loop:AsyncioEventLoop",
             "qt = traits_futures.qt.event_loop:QtEventLoop",
             "qt4 = traits_futures.qt.event_loop:QtEventLoop",
             "wx = traits_futures.wx.event_loop:WxEventLoop",


### PR DESCRIPTION
This PR removes the `asyncio` and `null` entry points, and adjusts the tests accordingly. We're not removing the `AsyncioEventLoop` or its uses in testing: we're only removing the ability to do `export ETS_TOOLKIT=asyncio` and pick up an `AsyncioEventLoop` as a result. That functionality was questionable at best, is causing deprecation warnings in Python 3.10, and will become broken in future Python versions with the current code.

Rationale:

- The idea of asyncio as a drop-in replacement for Qt or Wx at this level doesn't make a lot of sense right now. There are ways it could be made to make sense in the future, but there would need to be a significant design phase, and we'd likely want to consider the whole of ETS rather than just Traits Futures.
- asyncio has a particular technical issue that sets it apart from Qt and Wx: in both Qt and Wx we have the idea of the "current event loop" (or at least, the event loop associated to the current thread), even if that event loop hasn't been started yet. But asyncio has been moving away from the idea of a current event loop, and has deprecated the `asyncio.get_event_loop` function. It's possible to set a current event loop using `set_event_loop`, but that event loop isn't then picked up by `asyncio.run`: `asyncio.run` instead creates a brand new event loop. This means that the (relatively common) pattern of placing tasks on the event loop's task queue before starting the event loop becomes problematic with asyncio. See related discussion in https://bugs.python.org/issue39529

The trigger for this PR was that our uses of `get_event_loop` are now causing warnings on Python 3.10, so we need to find a way to get rid of them. That change will happen in a separate PR from this one, but this one was necessary to enable getting rid of `get_event_loop`.

Related: #491