### PR TITLE
Replace use of the deprecated asyncio.get_event_loop function.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -34,7 +34,10 @@ Changes
   ``asyncio.new_event_loop`` if no event loop is explicitly passed in, instead
   of trying to get the currently-set event loop using the (now deprecated)
   ``asyncio.get_event_loop`` function. A new ``AsyncioEventLoop.close`` method
-  is available to close the event loop owned by ``AsyncioEventLoop``. (#492)
+  is available to close the event loop owned by ``AsyncioEventLoop``.
+  Moreover, in a future version of Traits Futures it will be required to
+  pass an explicit event loop. Instantiating an ``AsyncioEventLoop`` without
+  an ``asyncio`` event loop is deprecated. (#492)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -20,6 +20,8 @@ Features
 
 * Support Qt6-based toolkits PyQt6 and PySide6. (This is dependent on
   corresponding support in Pyface.) (#488)
+* Allow an ``asyncio`` event loop to be specified when creating an
+  instance of ``AsyncioEventLoop``. (#492)
 
 Changes
 ~~~~~~~
@@ -28,6 +30,11 @@ Changes
   entry point group have been removed. Their behaviour was ill-defined, and
   dependent on ``asyncio.get_event_loop``, which is deprecated in Python.
   (#490)
+* ``AsyncioEventLoop`` now creates a new ``asyncio`` event loop using
+  ``asyncio.new_event_loop`` if no event loop is explicitly passed in, instead
+  of trying to get the currently-set event loop using the (now deprecated)
+  ``asyncio.get_event_loop`` function. A new ``AsyncioEventLoop.close`` method
+  is available to close the event loop owned by ``AsyncioEventLoop``. (#492)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/source/guide/examples/headless.py
+++ b/docs/source/guide/examples/headless.py
@@ -14,6 +14,7 @@ Running Traits Futures without a GUI, using the asyncio event loop.
 
 import asyncio
 import random
+import sys
 
 from traits_futures.api import (
     AsyncioEventLoop,
@@ -47,9 +48,13 @@ async def future_wrapper(traits_future):
         traits_future = event.object
         asyncio_future.set_result(traits_future.result)
 
-    # Once we can assume a minimum Python version of 3.7, this should
-    # be changed to use get_running_event_loop instead of get_event_loop.
-    asyncio_future = asyncio.get_event_loop().create_future()
+    if sys.version_info < (3, 7):
+        # We want to use get_running_loop, but it's new in Python 3.7.
+        # This branch can be dropped once we can assume a minimum Python
+        # version of 3.7.
+        asyncio_future = asyncio.get_event_loop().create_future()
+    else:
+        asyncio_future = asyncio.get_running_loop().create_future()
 
     traits_future.observe(set_result, "done")
 

--- a/docs/source/guide/examples/headless.py
+++ b/docs/source/guide/examples/headless.py
@@ -64,9 +64,11 @@ def print_progress(event):
 
 
 if __name__ == "__main__":
-    traits_executor = TraitsExecutor(event_loop=AsyncioEventLoop())
+    asyncio_event_loop = asyncio.new_event_loop()
+    traits_executor = TraitsExecutor(
+        event_loop=AsyncioEventLoop(event_loop=asyncio_event_loop)
+    )
     traits_future = submit_iteration(traits_executor, approximate_pi)
     traits_future.observe(print_progress, "result_event")
 
-    # For Python 3.7 and later, just use asyncio.run.
-    asyncio.get_event_loop().run_until_complete(future_wrapper(traits_future))
+    asyncio_event_loop.run_until_complete(future_wrapper(traits_future))

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -25,7 +25,7 @@ class AsyncioEventLoop:
 
     Parameters
     ----------
-    event_loop : asyncio.events.AbstractEventLoop, optional
+    event_loop : asyncio.AbstractEventLoop, optional
         The asyncio event loop to wrap. If not provided, a new
         event loop will be created and used.
     """

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 """
-IEventLoop implementation for the main-thread asyncio event loop.
+IEventLoop implementation wrapping an asyncio event loop.
 """
 import asyncio
 
@@ -21,11 +21,17 @@ from traits_futures.i_event_loop import IEventLoop
 @IEventLoop.register
 class AsyncioEventLoop:
     """
-    IEventLoop implementation for the main-thread asyncio event loop.
+    IEventLoop implementation wrapping an asyncio event loop.
     """
 
     def __init__(self):
-        self._event_loop = asyncio.get_event_loop()
+        self._event_loop = asyncio.new_event_loop()
+
+    def close(self):
+        """
+        Free any resources allocated by this object.
+        """
+        self._event_loop.close()
 
     def pingee(self, on_ping):
         """

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -22,16 +22,28 @@ from traits_futures.i_event_loop import IEventLoop
 class AsyncioEventLoop:
     """
     IEventLoop implementation wrapping an asyncio event loop.
+
+    Parameters
+    ----------
+    event_loop : asyncio.BaseEventLoop, optional
+        The asyncio event loop to wrap. If not provided, a new
+        event loop will be created and used.
     """
 
-    def __init__(self):
-        self._event_loop = asyncio.new_event_loop()
+    def __init__(self, event_loop=None):
+        own_event_loop = event_loop is None
+        if own_event_loop:
+            event_loop = asyncio.new_event_loop()
+
+        self._own_event_loop = own_event_loop
+        self._event_loop = event_loop
 
     def close(self):
         """
         Free any resources allocated by this object.
         """
-        self._event_loop.close()
+        if self._own_event_loop:
+            self._event_loop.close()
 
     def pingee(self, on_ping):
         """

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -12,6 +12,7 @@
 IEventLoop implementation wrapping an asyncio event loop.
 """
 import asyncio
+import warnings
 
 from traits_futures.asyncio.event_loop_helper import EventLoopHelper
 from traits_futures.asyncio.pingee import Pingee
@@ -30,9 +31,16 @@ class AsyncioEventLoop:
         event loop will be created and used.
     """
 
-    def __init__(self, event_loop=None):
+    def __init__(self, *, event_loop=None):
         own_event_loop = event_loop is None
         if own_event_loop:
+            warnings.warn(
+                (
+                    "The event_loop parameter to AsyncioEventLoop will "
+                    "become required in a future version of Traits Futures"
+                ),
+                DeprecationWarning,
+            )
             event_loop = asyncio.new_event_loop()
 
         self._own_event_loop = own_event_loop

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -25,7 +25,7 @@ class AsyncioEventLoop:
 
     Parameters
     ----------
-    event_loop : asyncio.BaseEventLoop, optional
+    event_loop : asyncio.events.AbstractEventLoop, optional
         The asyncio event loop to wrap. If not provided, a new
         event loop will be created and used.
     """

--- a/traits_futures/asyncio/tests/test_asyncio_event_loop.py
+++ b/traits_futures/asyncio/tests/test_asyncio_event_loop.py
@@ -22,4 +22,7 @@ from traits_futures.tests.i_event_loop_tests import IEventLoopTests
 class TestAsyncioEventLoop(IEventLoopTests, unittest.TestCase):
 
     #: Factory for instances of the event loop.
-    event_loop_factory = AsyncioEventLoop
+    def event_loop_factory(self):
+        event_loop = AsyncioEventLoop()
+        self.addCleanup(event_loop.close)
+        return event_loop

--- a/traits_futures/asyncio/tests/test_asyncio_event_loop.py
+++ b/traits_futures/asyncio/tests/test_asyncio_event_loop.py
@@ -33,7 +33,8 @@ class TestAsyncioEventLoop(IEventLoopTests, unittest.TestCase):
         return AsyncioEventLoop(event_loop=asyncio_event_loop)
 
     def test_asyncio_event_loop_closed(self):
-        event_loop = AsyncioEventLoop()
+        with self.assertWarns(DeprecationWarning):
+            event_loop = AsyncioEventLoop()
         # Dig out the underlying asyncio event loop.
         asyncio_event_loop = event_loop._event_loop
         self.assertFalse(asyncio_event_loop.is_closed())

--- a/traits_futures/asyncio/tests/test_asyncio_event_loop.py
+++ b/traits_futures/asyncio/tests/test_asyncio_event_loop.py
@@ -20,9 +20,14 @@ from traits_futures.tests.i_event_loop_tests import IEventLoopTests
 
 
 class TestAsyncioEventLoop(IEventLoopTests, unittest.TestCase):
-
-    #: Factory for instances of the event loop.
     def event_loop_factory(self):
+        """
+        Factory for the event loop.
+
+        Returns
+        -------
+        event_loop: IEventLoop
+        """
         event_loop = AsyncioEventLoop()
         self.addCleanup(event_loop.close)
         return event_loop

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -23,4 +23,7 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
 
     #: Zero-parameter callable that creates a suitable IEventLoop instance.
-    event_loop_factory = AsyncioEventLoop
+    def event_loop_factory(self):
+        event_loop = AsyncioEventLoop()
+        self.addCleanup(event_loop.close)
+        return event_loop

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -21,9 +21,14 @@ from traits_futures.tests.i_event_loop_helper_tests import (
 
 
 class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
-
-    #: Zero-parameter callable that creates a suitable IEventLoop instance.
     def event_loop_factory(self):
+        """
+        Factory for the event loop.
+
+        Returns
+        -------
+        event_loop: IEventLoop
+        """
         event_loop = AsyncioEventLoop()
         self.addCleanup(event_loop.close)
         return event_loop

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -12,6 +12,7 @@
 Tests for the asyncio implementation of IEventLoopHelper.
 """
 
+import asyncio
 import unittest
 
 from traits_futures.asyncio.event_loop import AsyncioEventLoop
@@ -29,6 +30,6 @@ class TestEventLoopHelper(IEventLoopHelperTests, unittest.TestCase):
         -------
         event_loop: IEventLoop
         """
-        event_loop = AsyncioEventLoop()
-        self.addCleanup(event_loop.close)
-        return event_loop
+        asyncio_event_loop = asyncio.new_event_loop()
+        self.addCleanup(asyncio_event_loop.close)
+        return AsyncioEventLoop(event_loop=asyncio_event_loop)

--- a/traits_futures/asyncio/tests/test_pingee.py
+++ b/traits_futures/asyncio/tests/test_pingee.py
@@ -20,5 +20,7 @@ from traits_futures.tests.i_pingee_tests import IPingeeTests
 
 
 class TestPingee(TestAssistant, IPingeeTests, unittest.TestCase):
-
-    event_loop_factory = AsyncioEventLoop
+    def event_loop_factory(self):
+        event_loop = AsyncioEventLoop()
+        self.addCleanup(event_loop.close)
+        return event_loop

--- a/traits_futures/asyncio/tests/test_pingee.py
+++ b/traits_futures/asyncio/tests/test_pingee.py
@@ -21,6 +21,13 @@ from traits_futures.tests.i_pingee_tests import IPingeeTests
 
 class TestPingee(TestAssistant, IPingeeTests, unittest.TestCase):
     def event_loop_factory(self):
+        """
+        Factory for the event loop.
+
+        Returns
+        -------
+        event_loop: IEventLoop
+        """
         event_loop = AsyncioEventLoop()
         self.addCleanup(event_loop.close)
         return event_loop

--- a/traits_futures/asyncio/tests/test_pingee.py
+++ b/traits_futures/asyncio/tests/test_pingee.py
@@ -12,6 +12,7 @@
 Tests for the asyncio implementations of IPingee and IPinger.
 """
 
+import asyncio
 import unittest
 
 from traits_futures.asyncio.event_loop import AsyncioEventLoop
@@ -28,6 +29,6 @@ class TestPingee(TestAssistant, IPingeeTests, unittest.TestCase):
         -------
         event_loop: IEventLoop
         """
-        event_loop = AsyncioEventLoop()
-        self.addCleanup(event_loop.close)
-        return event_loop
+        asyncio_event_loop = asyncio.new_event_loop()
+        self.addCleanup(asyncio_event_loop.close)
+        return AsyncioEventLoop(event_loop=asyncio_event_loop)

--- a/traits_futures/testing/test_assistant.py
+++ b/traits_futures/testing/test_assistant.py
@@ -13,6 +13,8 @@ Test support, providing the ability to run the event loop from within tests.
 """
 
 
+import asyncio
+
 from traits.api import Bool, HasStrictTraits
 
 from traits_futures.asyncio.event_loop import AsyncioEventLoop
@@ -52,9 +54,9 @@ class TestAssistant:
         -------
         event_loop: IEventLoop
         """
-        event_loop = AsyncioEventLoop()
-        self.addCleanup(event_loop.close)
-        return event_loop
+        asyncio_event_loop = asyncio.new_event_loop()
+        self.addCleanup(asyncio_event_loop.close)
+        return AsyncioEventLoop(event_loop=asyncio_event_loop)
 
     def setUp(self):
         self._event_loop = self.event_loop_factory()

--- a/traits_futures/testing/test_assistant.py
+++ b/traits_futures/testing/test_assistant.py
@@ -47,7 +47,10 @@ class TestAssistant:
     #: Factory for the event loop. This should be a zero-argument callable
     #: that provides an IEventLoop instance. Override in subclasses to
     #: run tests with a particular toolkit.
-    event_loop_factory = AsyncioEventLoop
+    def event_loop_factory(self):
+        event_loop = AsyncioEventLoop()
+        self.addCleanup(event_loop.close)
+        return event_loop
 
     def setUp(self):
         self._event_loop = self.event_loop_factory()

--- a/traits_futures/testing/test_assistant.py
+++ b/traits_futures/testing/test_assistant.py
@@ -44,10 +44,14 @@ class TestAssistant:
     Most of the logic is devolved to a toolkit-specific EventLoopHelper class.
     """
 
-    #: Factory for the event loop. This should be a zero-argument callable
-    #: that provides an IEventLoop instance. Override in subclasses to
-    #: run tests with a particular toolkit.
     def event_loop_factory(self):
+        """
+        Factory for the event loop.
+
+        Returns
+        -------
+        event_loop: IEventLoop
+        """
         event_loop = AsyncioEventLoop()
         self.addCleanup(event_loop.close)
         return event_loop


### PR DESCRIPTION
This PR replaces the use of `asyncio.get_event_loop` in the Traits Futures core. ~There's a remaining example that still uses `get_event_loop`, but I'll address that separately.~

There are some remaining warnings in the test run resulting from the fact that we have no way to clean up asyncio event loops created through `ETSToolkit`, but I believe `ETSToolkit` should not have been supporting asyncio in the first place - see #490.

Together with #490, this addresses #491.

Also closes #333.