### PR TITLE
Change 3.10-dev to 3.10, and make all Python versions strings

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Install graphviz
       run: |
         sudo apt-get update

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Install necessary Python packages
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Install Python packages needed for build and upload
       run: |
         python -m pip install build twine

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.8]
+        python-version: ['3.6', '3.8']
 
     env:
       ETS_TOOLKIT: qt
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
-        python-version: [3.8]
+        python-version: ['3.8']
 
     env:
       ETS_TOOLKIT: wx

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Install necessary Python packages
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 
@@ -38,12 +38,12 @@ jobs:
     - name: Install package and test dependencies from PyPI sdist (with PySide2)
       run: |
         python -m pip install --no-binary traits-futures traits-futures[pyside2]
-      if: ${{ matrix.python-version != '3.10-dev' }}
+      if: ${{ matrix.python-version != '3.10' }}
     - name: Install package and test dependencies from PyPI sdist (no PySide2)
       # PySide2 does not yet work on Python 3.10; test without it.
       run: |
         python -m pip install --no-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == '3.10-dev' }}
+      if: ${{ matrix.python-version == '3.10' }}
     - name: Create clean test directory
       run: |
         mkdir testdir
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 
@@ -84,12 +84,12 @@ jobs:
     - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --only-binary traits-futures traits-futures[pyside2]
-      if: ${{ matrix.python-version != '3.10-dev' }}
+      if: ${{ matrix.python-version != '3.10' }}
     - name: Install package and test dependencies from PyPI wheel (no PySide2)
       # PySide2 does not yet work on Python 3.10; test without it.
       run: |
         python -m pip install --only-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == '3.10-dev' }}
+      if: ${{ matrix.python-version == '3.10' }}
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.8, 3.9]
+        python-version: ['3.6', '3.8', '3.9']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR updates the Python versions in GitHub Actions workflows:

- Replace `3.10-dev` with `3.10`
- Make all Python versions strings (which is what they should have been all along, but the problem didn't become apparent until we a version of `3.10` was interpreted as `3.1`).