### PR TITLE
Add build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /docs/source/api/*.rst
 !/docs/source/api/traits_futures.api.rst
 /docs/build/
+/build/
 /coverage/
 *.egg-info/


### PR DESCRIPTION
When using the most recent setuptools and pip, a `pip install` creates a `build` directory. This PR adds that `build` directory to the `.gitignore`.