### PR TITLE
Fix documentation build failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,11 @@ setup(
     extras_require={
         "pyqt5": ["pyqt5"],
         "pyside2": ["pyside2"],
-        "docs": ["enthought-sphinx-theme", "sphinx>=3.5,<4"],
+        "docs": [
+            "enthought-sphinx-theme",
+            "sphinx>=3.5,<4",
+            "Jinja2<3.1",
+        ],
     },
     packages=find_packages(exclude=["ci"]),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,12 @@ setup(
         "pyside2": ["pyside2"],
         "docs": [
             "enthought-sphinx-theme",
+            # We pin Sphinx to avoid having to deal with the (unfortunately
+            # frequent) breakage that occurs when Sphinx is updated.
+            # xref: enthought/traits-futures#456
             "sphinx>=3.5,<4",
+            # Jinja2 is pinned for compatibility with the Sphinx pin.
+            # xref: sphinx-doc/sphinx#10291
             "Jinja2<3.1",
         ],
     },


### PR DESCRIPTION
The documentation build failed in PR #501, with error:
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.8.[12](https://github.com/enthought/traits-futures/runs/6780129495?check_suite_focus=true#step:7:13)/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/__main__.py", line [13](https://github.com/enthought/traits-futures/runs/6780129495?check_suite_focus=true#step:7:14), in <module>
    from sphinx.cmd.build import main
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/cmd/build.py", line 25, in <module>
    from sphinx.application import Sphinx
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/application.py", line 43, in <module>
    from sphinx.registry import SphinxComponentRegistry
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/registry.py", line 24, in <module>
    from sphinx.builders import Builder
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 26, in <module>
    from sphinx.util import import_object, logging, progress_message, rst, status_iterator
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/util/rst.py", line [21](https://github.com/enthought/traits-futures/runs/6780129495?check_suite_focus=true#step:7:22), in <module>
    from jinja2 import Environment, environmentfilter
ImportError: cannot import name 'environmentfilter' from 'jinja2' (/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/jinja2/__init__.py)
```

https://github.com/sphinx-doc/sphinx/issues/10291 looks related.

Link to the failing CI job: https://github.com/enthought/traits-futures/runs/6780129495?check_suite_focus=true