### PR TITLE
Use the "sphinx-copybutton" extension in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     "traits.util.trait_documenter",
 ]
 
@@ -113,6 +114,13 @@ nitpick_ignore = [
     ("py:class", "pyface.qt.QtCore."),
     ("py:class", "wx."),
 ]
+
+# Options for Sphinx copybutton extension
+# ---------------------------------------
+
+# Matches prompts - "$ ", ">>>" and "..."
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # -- Options for Napoleon extension ---------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             # Jinja2 is pinned for compatibility with the Sphinx pin.
             # xref: sphinx-doc/sphinx#10291
             "Jinja2<3.1",
+            "sphinx-copybutton",
         ],
     },
     packages=find_packages(exclude=["ci"]),


### PR DESCRIPTION
This PR does the following - 

- Use the `sphinx_copybutton` extension when building the Sphinx documentation
- Make `sphinx-copybutton` a `docs` extra for the `traits-futures` package

Ref https://sphinx-copybutton.readthedocs.io/en/latest/