### PR TITLE
Add build-system section to pyproject.toml

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: '3.8'
     - name: Install necessary Python packages
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install black flake8 flake8-ets isort
     - name: Check out the PR branch
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install .[pyside2]
     - name: Run the test suite
       uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install .
     - name: Run the test suite
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'
+
 [tool.black]
 line-length = 79
 target-version = ['py36']


### PR DESCRIPTION
The `pyproject.toml` file was missing information about the build system; this PR adds that information, and removes unnecessary installations of `wheel` and `setuptools` in the CI workflows.