### PR TITLE
Make sure that the version number for a doc build can be computed

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Check out the main branch
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The automated documentation build workflow currently miscomputes the version number because GitHub Actions makes a shallow clone without tags, so there's no way to compute the version number from the tags.

This PR fixes that by having the action clone the whole repository.

See also https://github.com/pypa/setuptools_scm/issues/480