### PR TITLE
Fix a test that returned an exception instead of a result

### DIFF
--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -100,7 +100,7 @@ class CommonFutureTests:
         # Record initial, synthesize some state changes, then record final.
         record_states()
         future._task_started(None)
-        future._task_returned(self.fake_exception())
+        future._task_returned(23)
         record_states()
 
         # Check consistency.


### PR DESCRIPTION
This PR fixes a test that uses `_task_returned` to return an exception rather than a result.

The test works, but it's potentially confusing: there's no good reason for it to be returning exception information instead of a result.