### PR TITLE
Replace 3.11-dev with 3.11

### DIFF
--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: testdir
         run: python -m unittest discover -v traits_futures
 
-   :
+  test-pypi-wheel:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Install package and test dependencies from PyPI sdist (with PySide2)
       run: |
         python -m pip install --no-binary traits-futures traits-futures[pyside2]
-      if: ${{ matrix.python-version != '3.10' }}
+      if: ${{ matrix.python-version != '3.11' }}
     - name: Install package and test dependencies from PyPI sdist (no PySide2)
-      # PySide2 does not yet work on Python 3.10; test without it.
+      # PySide2 does not yet work on Python 3.11; test without it.
       run: |
         python -m pip install --no-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == '3.10' }}
+      if: ${{ matrix.python-version == '3.11' }}
     - name: Create clean test directory
       run: |
         mkdir testdir
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -78,12 +78,12 @@ jobs:
     - name: Install package and test dependencies from PyPI wheel (with PySide2)
       run: |
         python -m pip install --only-binary traits-futures traits-futures[pyside2]
-      if: ${{ matrix.python-version != '3.10' }}
+      if: ${{ matrix.python-version != '3.11' }}
     - name: Install package and test dependencies from PyPI wheel (no PySide2)
-      # PySide2 does not yet work on Python 3.10; test without it.
+      # PySide2 does not yet work on Python 3.11; test without it.
       run: |
         python -m pip install --only-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == '3.10' }}
+      if: ${{ matrix.python-version == '3.11' }}
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -50,11 +50,11 @@ jobs:
         working-directory: testdir
         run: python -m unittest discover -v traits_futures
 
-  test-pypi-wheel:
+   :
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Now that 3.11 is released, we should be using it in place of 3.11-dev.

We also update test-from-pypi.yml to test _with_ PySide2 on Python 3.10, but to exclude PySide2 when testing with Python 3.11.

Test run for the install-from-pypi workflow, which was broken prior to this PR: https://github.com/enthought/traits-futures/actions/runs/3513252094