### PR TITLE
Update CI for Ubuntu 22.04; remove 3rd party xvfb action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,11 +75,11 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install .
-    - name: Install wxPython (not Linux)
+    - name: Install wxPython (not Ubuntu)
       run: |
         python -m pip install wxPython
-      if: runner.os != 'Linux'
-    - name: Install wxPython (Ubuntu 22.04)
+      if: matrix.os != 'ubuntu-latest'
+    - name: Install wxPython (Ubuntu)
       run: |
         python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
   tests-wx:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.8']
 
     env:
@@ -67,7 +67,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libsdl2-2.0-0
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -79,10 +79,10 @@ jobs:
       run: |
         python -m pip install wxPython
       if: runner.os != 'Linux'
-    - name: Install wxPython (Ubuntu 20.04)
+    - name: Install wxPython (Ubuntu 22.04)
       run: |
-        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04 wxPython
-      if: matrix.os == 'ubuntu-20.04'
+        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
+      if: matrix.os == 'ubuntu-latest'
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Run test suite for PySide2 and wxPython
+name: Run test suite for PySide6 and wxPython
 
 on: [pull_request, workflow_dispatch]
 
@@ -6,7 +6,7 @@ env:
   PYTHONUNBUFFERED: 1
 
 jobs:
-  tests-pyside2:
+  tests-pyside6:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -20,30 +20,34 @@ jobs:
     steps:
     - name: Check out the target commit
       uses: actions/checkout@v3
-    - name: Install Linux packages for Qt 5 support
+    - name: Install Linux packages for PySide6 support
       run: |
         sudo apt-get update
-        sudo apt-get install qt5-default
+        sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1
         sudo apt-get install libxcb-randr0
         sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-xinerama0
-      if: runner.os == 'Linux'
+        sudo apt-get install libxcb-shape0
+      if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
       run: |
-        python -m pip install .[pyside2]
-    - name: Run the test suite
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: ${{ runner.temp }}
-        run: python -X faulthandler -m unittest discover -v traits_futures
+        python -m pip install .[pyside6]
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Run the test suite (Linux)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os == 'ubuntu-latest'
+    - name: Run the test suite (Windows/macOS)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os != 'ubuntu-latest'
 
   tests-wx:
     strategy:
@@ -63,7 +67,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libsdl2-2.0-0
-      if: runner.os == 'Linux'
+      if: matrix.os == 'ubuntu-20.04'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -79,8 +83,12 @@ jobs:
       run: |
         python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04 wxPython
       if: matrix.os == 'ubuntu-20.04'
-    - name: Run the test suite
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: ${{ runner.temp }}
-        run: python -X faulthandler -m unittest discover -v traits_futures
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Run the test suite (Linux)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os == 'ubuntu-latest'
+    - name: Run the test suite (Windows/macOS)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
       run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os == 'ubuntu-latest'
     - name: Run the test suite (Windows/macOS)
-      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      run: cd testdir && python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os != 'ubuntu-latest'
 
   tests-wx:
@@ -90,5 +90,5 @@ jobs:
       run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os == 'ubuntu-latest'
     - name: Run the test suite (Windows/macOS)
-      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      run: cd testdir && python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -19,36 +19,37 @@ jobs:
     - name: Install Linux packages for Qt 5 support
       run: |
         sudo apt-get update
-        sudo apt-get install qt5-default
+        sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1
         sudo apt-get install libxcb-randr0
         sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-xinerama0
-      if: runner.os == 'Linux'
+        sudo apt-get install libxcb-shape0
+      if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package and test dependencies from PyPI sdist (with PySide2)
+    - name: Install package and test dependencies from PyPI sdist (with PySide6)
       run: |
-        python -m pip install --no-binary traits-futures traits-futures[pyside2]
+        python -m pip install --no-binary traits-futures traits-futures[pyside6]
       if: ${{ matrix.python-version != '3.11' }}
-    - name: Install package and test dependencies from PyPI sdist (no PySide2)
-      # PySide2 does not yet work on Python 3.11; test without it.
+    - name: Install package and test dependencies from PyPI sdist (no PySide6)
+      # PySide6 does not yet work on Python 3.11; test without it.
       run: |
         python -m pip install --no-binary traits-futures traits-futures
       if: ${{ matrix.python-version == '3.11' }}
     - name: Create clean test directory
       run: |
         mkdir testdir
-    - name: Run the test suite
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: testdir
-        run: python -m unittest discover -v traits_futures
+    - name: Run the test suite (Linux)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os == 'ubuntu-latest'
+    - name: Run the test suite (Windows/macOS)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os != 'ubuntu-latest'
 
   test-pypi-wheel:
     strategy:
@@ -62,33 +63,34 @@ jobs:
     - name: Install Linux packages for Qt 5 support
       run: |
         sudo apt-get update
-        sudo apt-get install qt5-default
+        sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1
         sudo apt-get install libxcb-randr0
         sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-xinerama0
-      if: runner.os == 'Linux'
+        sudo apt-get install libxcb-shape0
+      if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package and test dependencies from PyPI wheel (with PySide2)
+    - name: Install package and test dependencies from PyPI wheel (with PySide6)
       run: |
-        python -m pip install --only-binary traits-futures traits-futures[pyside2]
+        python -m pip install --only-binary traits-futures traits-futures[pyside6]
       if: ${{ matrix.python-version != '3.11' }}
-    - name: Install package and test dependencies from PyPI wheel (no PySide2)
-      # PySide2 does not yet work on Python 3.11; test without it.
+    - name: Install package and test dependencies from PyPI wheel (no PySide6)
+      # PySide6 does not yet work on Python 3.11; test without it.
       run: |
         python -m pip install --only-binary traits-futures traits-futures
       if: ${{ matrix.python-version == '3.11' }}
     - name: Create clean test directory
       run: |
         mkdir testdir
-    - name: Run the test suite
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: testdir
-        run: python -m unittest discover -v traits_futures
+    - name: Run the test suite (Linux)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os == 'ubuntu-latest'
+    - name: Run the test suite (Windows/macOS)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -48,7 +48,7 @@ jobs:
       run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os == 'ubuntu-latest'
     - name: Run the test suite (Windows/macOS)
-      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      run: cd testdir && python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os != 'ubuntu-latest'
 
   test-pypi-wheel:
@@ -92,5 +92,5 @@ jobs:
       run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os == 'ubuntu-latest'
     - name: Run the test suite (Windows/macOS)
-      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      run: cd testdir && python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -73,7 +73,7 @@ jobs:
       run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os == 'ubuntu-latest'
     - name: Run the test suite (Windows/macOS)
-      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      run: cd testdir && python -X faulthandler -m unittest discover -v traits_futures
       if: matrix.os != 'ubuntu-latest'
 
   notify-on-failure:

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -45,18 +45,18 @@ jobs:
     steps:
     - name: Check out the main branch
       uses: actions/checkout@v3
-    - name: Install Linux packages for Qt 5 support
+    - name: Install Linux packages for PySide6 support
       run: |
         sudo apt-get update
-        sudo apt-get install qt5-default
+        sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1
         sudo apt-get install libxcb-randr0
         sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-xinerama0
-      if: runner.os == 'Linux'
+        sudo apt-get install libxcb-shape0
+      if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -65,12 +65,16 @@ jobs:
       run: |
         python -m pip install git+https://github.com/enthought/traits
         python -m pip install git+https://github.com/enthought/pyface
-        python -m pip install .[pyside2]
-    - name: Run the test suite
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        working-directory: ${{ runner.temp }}
-        run: python -X faulthandler -m unittest discover -v traits_futures
+        python -m pip install .[pyside6]
+    - name: Create clean test directory
+      run: |
+        mkdir testdir
+    - name: Run the test suite (Linux)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os == 'ubuntu-latest'
+    - name: Run the test suite (Windows/macOS)
+      run: cd testdir && xvfb-run -a python -X faulthandler -m unittest discover -v traits_futures
+      if: matrix.os != 'ubuntu-latest'
 
   notify-on-failure:
     needs: [test-all-platform-python-combinations, test-bleeding-edge]


### PR DESCRIPTION
This PR brings the CI back to working state on ubuntu-latest.

- Update the wx tests to use the ubuntu-22.04 wheel for wxPython; update the workflow to use ubuntu-latest
- Update apt-get requirements for Qt on Linux
- Use PySide6 throughout instead of PySide2
- Replace the 3rd party xvfb action with xvfb-run.