### PR TITLE
Add apt-get libxcb-cursor0 to workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -21,6 +21,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1
@@ -65,6 +66,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -50,6 +50,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libegl1
         sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-cursor0
         sudo apt-get install libxcb-icccm4
         sudo apt-get install libxcb-image0
         sudo apt-get install libxcb-keysyms1


### PR DESCRIPTION
The current workflows fail with the recently-released PySide6 6.5.0, which requires the `libxcb-cursor` library to be present.

This PR adds `libxcb-cursor` to the list of apt-get dependencies in order to fix those workflows with PySide6 6.5.0.