### PR TITLE
Pin black to version 22.x

### DIFF
--- a/style-requirements.txt
+++ b/style-requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for CI style checks
-black
+black ~= 22.0
 flake8
 flake8-ets
 isort


### PR DESCRIPTION
This PR pins the `black` version to 22.x, to avoid the style workflow picking up and using the latest black version (which reports errors on the current codebase).

Some day we should update black and re-apply style fixes. But not today.

Related: https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy