### PR TITLE
Update the minimum Python version to 3.8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.10']
+        python-version: ['3.8', '3.10']
 
     env:
       ETS_TOOLKIT: qt

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.10']
+        python-version: ['3.8', '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -19,7 +19,7 @@ Getting started
 ---------------
 
 You'll need a Python 3 environment for development. Any environment using
-Python >= 3.7 will do. For example, you could create and activate a new venv
+Python >= 3.8 will do. For example, you could create and activate a new venv
 using something like::
 
     python3.10 -m venv ../traits-futures && source ../traits-futures/bin/activate

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Limitations
 
 - By design, and unlike :mod:`concurrent.futures`, |traits_futures| requires the
   UI event loop to be running in order to process results.
-- Requires Python 3.7 or later.
+- Requires Python 3.8 or later.
 
 
 Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'traits-futures'
 description = 'Patterns for reactive background tasks'
 readme = 'README.rst'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 authors = [{name='Enthought', email='info@enthought.com'}]
 keywords = ['background', 'concurrency', 'futures', 'gui', 'traits', 'traitsui']
 classifiers = [


### PR DESCRIPTION
This PR removes support for Python 3.7, mainly because that's no longer supported by the dependent Traits library. The minimum Python version is now Python 3.8.