### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
     - name: Check out the main branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       # We need a full clone rather than a shallow clone so that setuptools-scm
       # can compute the right version number for the docs.
       # xref: https://github.com/pypa/setuptools_scm/issues/431
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Install graphviz

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
     - name: Set up Python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Check out the target commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install necessary Python packages
       run: |
         python -m pip install -r style-requirements.txt

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
     - name: Set up Python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Check out the target commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install necessary Python packages
       run: |
         python -m pip install -r style-requirements.txt

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Check out the release commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Install Python packages needed for build and upload

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Check out the target commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install Linux packages for PySide6 support
       run: |
         sudo apt-get update
@@ -34,7 +34,7 @@ jobs:
         sudo apt-get install libxcb-shape0
       if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
@@ -63,14 +63,14 @@ jobs:
 
     steps:
     - name: Check out the target commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install Linux packages for wx support
       run: |
         sudo apt-get update
         sudo apt-get install libsdl2-2.0-0
       if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -15,11 +15,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install graphviz
     - name: Set up Python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.10'
     - name: Check out the target commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install local package and documentation dependencies
       run: |
         python -m pip install -r docs/requirements.txt

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get install libxcb-shape0
       if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and test dependencies from PyPI sdist (with PySide6)
@@ -75,7 +75,7 @@ jobs:
         sudo apt-get install libxcb-shape0
       if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and test dependencies from PyPI wheel (with PySide6)

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
     - name: Check out the target commit
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Check out the main branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install Linux packages for PySide6 support
       run: |
         sudo apt-get update
@@ -59,7 +59,7 @@ jobs:
         sudo apt-get install libxcb-shape0
       if: matrix.os == 'ubuntu-latest'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and local packages


### PR DESCRIPTION
## Summary

Harden the GitHub Actions setup in two complementary ways: pin every action to a commit SHA, and give dependabot a cooldown before it proposes new versions. Both follow the model in [enthought/envisage](https://github.com/enthought/envisage).

### 1. Pin actions to commit SHAs

Replace mutable major-version tags with pinned commit SHAs, recording the intended release in a trailing comment. This prevents a compromised or force-moved tag from silently changing which action code runs in CI.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `@v6` | `@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0` |
| `actions/setup-python` | `@v6` | `@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0` |

Applied across all 8 workflow files (20 occurrences total). The pinned SHAs correspond to the latest release within the major version currently in use (recently bumped to v6 by dependabot in #524 / #525), so no behavioural change is expected.

### 2. Add a 7-day dependabot cooldown

```yaml
    cooldown:
      default-days: 7
```

Dependabot now waits 7 days after a new action release before opening an update PR, giving a buffer against versions that get yanked or patched shortly after release. Combined with SHA-pinning, dependabot continues to manage version bumps — updating both the SHA and the `# vX.Y.Z` comment — just with a short delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)