### PR TITLE
Be less strict about the copyright end year in required CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,4 +4,6 @@ packages = find:
 [flake8]
 exclude = build
 max-line-length = 79
+# Pin the year so style checks don't fail when the year rolls over.
+copyright-end-year = 2024
 per-file-ignores = docs/source/guide/examples/*:E402

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -1,0 +1,24 @@
+name: Strict style check
+
+on: [pull_request, workflow_dispatch]
+
+env:
+  PYTHONUNBUFFERED: 1
+
+jobs:
+  strict-style:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
+    - name: Check out the target commit
+      uses: actions/checkout@v6
+    - name: Install necessary Python packages
+      run: |
+        python -m pip install -r style-requirements.txt
+    - name: Report out-of-date copyright end years
+      run: |
+        python -m flake8 --select H102 --copyright-end-year current

--- a/style-requirements.txt
+++ b/style-requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for CI style checks
 black ~= 22.0
 flake8
-flake8-ets
+# 1.1.0 adds "--copyright-end-year current" support.
+flake8-ets >= 1.1.0
 isort


### PR DESCRIPTION
## Summary

The required style check enforces (via `flake8-ets`' `H102`) that copyright headers end in the *current* year. That means the first PR opened after January 1st each year fails a required check through no fault of its own, blocking merges until every header is bumped (this is why the copyright checks are currently red on unrelated PRs).

This uses the config-driven pattern from [enthought/ets-copyright-checker](https://github.com/enthought/ets-copyright-checker) — an improvement on [enthought/envisage#596](https://github.com/enthought/envisage/pull/596), keeping the pinned year in configuration rather than hard-coded in the workflow command:

- **`.flake8`**: pins `copyright-end-year = 2024` (matching the headers currently in the tree), so the required `check-style.yml` no longer depends on the current date. The `check-style.yml` workflow itself is unchanged.
- **`check-style-strict.yml`** (new, *not* required): runs `flake8 --select H102 --copyright-end-year current`, overriding the pinned year with the special value `current` to report headers out of date with the current year. Expected to fail until headers are refreshed, keeping a visible red X.
- **`style-requirements.txt`**: requires `flake8-ets >= 1.1.0`, the release that introduced the `current` value.

## Follow-up needed after merge

The new `strict-style` check must be marked **not required** in the branch protection settings, otherwise it defeats the purpose by blocking merges. (I can't change repo settings — flagging for a maintainer.)

## Verification

In a clean venv with `style-requirements.txt` installed (flake8-ets 1.1.0):

- `flake8` → clean, exit 0 (picks up `copyright-end-year = 2024` from `.flake8`; the required check passes)
- `flake8 --select H102 --copyright-end-year current` → reports 81 headers as `end year (2024) should be 2026` (the strict check flags them, as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)