### PR TITLE
Pin traits < 7.1.0 for the documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,6 @@
 Sphinx
 enthought-sphinx-theme
 sphinx-copybutton
+# traits 7.1.0's TraitDocumenter fails on module-level traits (e.g.
+# ExecutorState); see enthought/traits. Remove once fixed upstream.
+traits < 7.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ Sphinx
 enthought-sphinx-theme
 sphinx-copybutton
 # traits 7.1.0's TraitDocumenter fails on module-level traits (e.g.
-# ExecutorState); see enthought/traits. Remove once fixed upstream.
+# ExecutorState); see enthought/traits#1883. Remove once fixed upstream.
 traits < 7.1.0


### PR DESCRIPTION
## Summary

The `docs` / `test-docs` builds crash while documenting module-level traits:

```
File ".../traits/util/trait_documenter.py", line 120, in add_directive_header
    classes = list(types.resolve_bases(parent.__bases__))
AttributeError: module 'traits_futures.executor_states' has no attribute '__bases__'
```

### Root cause

This is an upstream regression in **traits 7.1.0**, reported as [enthought/traits#1883](https://github.com/enthought/traits/issues/1883). Its `TraitDocumenter.add_directive_header` was rewritten to walk an object's base classes via `parent.__bases__`:

```python
parent = self.parent
classes = list(types.resolve_bases(parent.__bases__))   # parent is a *module* here
```

`can_document_member` still accepts module-level traits (e.g. `ExecutorState = Enum(...)` in `traits_futures.executor_states`), for which `self.parent` is the module — and modules have no `__bases__`. traits 7.0.2 used `self.parent` directly inside a `try/except ValueError`, so it was unaffected.

I bisected this locally:

| traits | docs build |
| --- | --- |
| 6.2.0 – 7.0.2 | ✅ OK |
| **7.1.0** | ❌ `AttributeError` |

Sphinx version is not a factor — it fails identically on Sphinx 5 through 8.

### Fix

Pin `traits < 7.1.0` in `docs/requirements.txt` (7.0.2 is the last good release). This affects **only the documentation build environment**, not the traits-futures runtime dependency. With the pin, the exact CI command (`sphinx -b html -d doctrees -W source build`) succeeds cleanly on the current Sphinx 8.1.3.

The pin can be removed once [enthought/traits#1883](https://github.com/enthought/traits/issues/1883) is fixed and released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)