### PR TITLE
Run the wxPython test job on Python 3.11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8']
+        python-version: ['3.11']
 
     env:
       ETS_TOOLKIT: wx
@@ -82,7 +82,7 @@ jobs:
       if: matrix.os != 'ubuntu-latest'
     - name: Install wxPython (Ubuntu)
       run: |
-        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
+        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 wxPython
       if: matrix.os == 'ubuntu-latest'
     - name: Create clean test directory
       run: |


### PR DESCRIPTION
## Summary

The `tests-wx` job has been failing on Ubuntu. Two changes combined to break it:

1. `pip install wxPython` now resolves to **4.2.2**, which ships **no cp38 Linux wheel** (4.2.1 was the last one).
2. `ubuntu-latest` has moved to **24.04**, whose [wheel index](https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/) provides **no cp38 wheels at all**.

With no matching wheel, pip fell back to building wxPython from source, which fails on the runner for lack of GTK development files:

```
configure: error: The development files for GTK+ were not found.
ERROR: Failed building wheel for wxPython
```

(The Windows leg of this job showed as failed only because it was *cancelled* by fail-fast; wxPython 4.2.2 has a cp38 Windows wheel on PyPI, so it would have passed.)

## Fix

Python 3.8 and 3.9 are both end of life, so rather than freezing the runner to `ubuntu-22.04` and pinning an old wxPython, bump the wxPython test job to **Python 3.11** (the version EDM targets) and install the Linux wheel from the **ubuntu-24.04** index, which has a `cp311` wheel for the current wxPython 4.2.2.

```diff
-        python-version: ['3.8']
+        python-version: ['3.11']
...
-        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
+        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 wxPython
```

The minimum supported Python (3.8) remains covered by the PySide6 test jobs.

## Verification

Confirmed the required wheels exist for wxPython 4.2.2:
- Linux (ubuntu-24.04 index): `wxPython-4.2.2-cp311-cp311-linux_x86_64.whl`
- Windows (PyPI): `wxPython-4.2.2-cp311-cp311-win_amd64.whl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)