### PR TITLE
Update copyright end year to 2026

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,5 +5,5 @@ packages = find:
 exclude = build
 max-line-length = 79
 # Pin the year so style checks don't fail when the year rolls over.
-copyright-end-year = 2024
+copyright-end-year = 2026
 per-file-ignores = docs/source/guide/examples/*:E402

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-(C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+(C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/module.rst_t
+++ b/docs/source/api/templates/module.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/traits_futures.api.rst
+++ b/docs/source/api/traits_futures.api.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -61,7 +61,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Traits Futures"
-copyright = "2018-2024 Enthought, Inc., Austin, TX"
+copyright = "2018-2026 Enthought, Inc., Austin, TX"
 author = "Enthought"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/guide/advanced.rst
+++ b/docs/source/guide/advanced.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/cancel.rst
+++ b/docs/source/guide/cancel.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/contexts.rst
+++ b/docs/source/guide/contexts.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/background_processes.py
+++ b/docs/source/guide/examples/background_processes.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/calculate_in_main_thread.py
+++ b/docs/source/guide/examples/calculate_in_main_thread.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/calculate_in_worker_thread.py
+++ b/docs/source/guide/examples/calculate_in_worker_thread.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/fizz_buzz_task.py
+++ b/docs/source/guide/examples/fizz_buzz_task.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/fizz_buzz_ui.py
+++ b/docs/source/guide/examples/fizz_buzz_ui.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/headless.py
+++ b/docs/source/guide/examples/headless.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/interruptible_task.py
+++ b/docs/source/guide/examples/interruptible_task.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/non_interruptible_task.py
+++ b/docs/source/guide/examples/non_interruptible_task.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/pi_iterations.py
+++ b/docs/source/guide/examples/pi_iterations.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/prime_counting.py
+++ b/docs/source/guide/examples/prime_counting.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/quick_start.py
+++ b/docs/source/guide/examples/quick_start.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/simple_blocking_call.py
+++ b/docs/source/guide/examples/simple_blocking_call.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/slow_squares.py
+++ b/docs/source/guide/examples/slow_squares.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/examples/test_future.py
+++ b/docs/source/guide/examples/test_future.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/intro.rst
+++ b/docs/source/guide/intro.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/overview.rst
+++ b/docs/source/guide/overview.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/testing.rst
+++ b/docs/source/guide/testing.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/threading.rst
+++ b/docs/source/guide/threading.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/guide/toolkits.rst
+++ b/docs/source/guide/toolkits.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+   (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/traits_futures/__init__.py
+++ b/traits_futures/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/api.py
+++ b/traits_futures/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/asyncio/event_loop.py
+++ b/traits_futures/asyncio/event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/asyncio/event_loop_helper.py
+++ b/traits_futures/asyncio/event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/asyncio/pingee.py
+++ b/traits_futures/asyncio/pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/asyncio/tests/test_asyncio_event_loop.py
+++ b/traits_futures/asyncio/tests/test_asyncio_event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/asyncio/tests/test_event_loop_helper.py
+++ b/traits_futures/asyncio/tests/test_event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/asyncio/tests/test_pingee.py
+++ b/traits_futures/asyncio/tests/test_pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/background_call.py
+++ b/traits_futures/background_call.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/background_iteration.py
+++ b/traits_futures/background_iteration.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/background_progress.py
+++ b/traits_futures/background_progress.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/base_future.py
+++ b/traits_futures/base_future.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/ets_event_loop.py
+++ b/traits_futures/ets_event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/exception_handling.py
+++ b/traits_futures/exception_handling.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/executor_states.py
+++ b/traits_futures/executor_states.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/future_states.py
+++ b/traits_futures/future_states.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/i_event_loop.py
+++ b/traits_futures/i_event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/i_event_loop_helper.py
+++ b/traits_futures/i_event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/i_message_router.py
+++ b/traits_futures/i_message_router.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/i_parallel_context.py
+++ b/traits_futures/i_parallel_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/i_pingee.py
+++ b/traits_futures/i_pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/i_task_specification.py
+++ b/traits_futures/i_task_specification.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/multiprocessing_context.py
+++ b/traits_futures/multiprocessing_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/multiprocessing_router.py
+++ b/traits_futures/multiprocessing_router.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/multithreading_context.py
+++ b/traits_futures/multithreading_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/multithreading_router.py
+++ b/traits_futures/multithreading_router.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/qt/event_loop.py
+++ b/traits_futures/qt/event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/qt/event_loop_helper.py
+++ b/traits_futures/qt/event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/qt/pingee.py
+++ b/traits_futures/qt/pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/qt/tests/test_event_loop_helper.py
+++ b/traits_futures/qt/tests/test_event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/qt/tests/test_pingee.py
+++ b/traits_futures/qt/tests/test_pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/qt/tests/test_qt_event_loop.py
+++ b/traits_futures/qt/tests/test_qt_event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/testing/optional_dependencies.py
+++ b/traits_futures/testing/optional_dependencies.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/testing/test_assistant.py
+++ b/traits_futures/testing/test_assistant.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/background_call_tests.py
+++ b/traits_futures/tests/background_call_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/background_iteration_tests.py
+++ b/traits_futures/tests/background_iteration_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/background_progress_tests.py
+++ b/traits_futures/tests/background_progress_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/common_future_tests.py
+++ b/traits_futures/tests/common_future_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/i_event_loop_helper_tests.py
+++ b/traits_futures/tests/i_event_loop_helper_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/i_event_loop_tests.py
+++ b/traits_futures/tests/i_event_loop_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/i_message_router_tests.py
+++ b/traits_futures/tests/i_message_router_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/i_pingee_tests.py
+++ b/traits_futures/tests/i_pingee_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_api.py
+++ b/traits_futures/tests/test_api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_background_call.py
+++ b/traits_futures/tests/test_background_call.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_background_iteration.py
+++ b/traits_futures/tests/test_background_iteration.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_background_progress.py
+++ b/traits_futures/tests/test_background_progress.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_base_future.py
+++ b/traits_futures/tests/test_base_future.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_call_future.py
+++ b/traits_futures/tests/test_call_future.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_ets_event_loop.py
+++ b/traits_futures/tests/test_ets_event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_exception_handling.py
+++ b/traits_futures/tests/test_exception_handling.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_iteration_future.py
+++ b/traits_futures/tests/test_iteration_future.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_multiprocessing_router.py
+++ b/traits_futures/tests/test_multiprocessing_router.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_multithreading_router.py
+++ b/traits_futures/tests/test_multithreading_router.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_progress_future.py
+++ b/traits_futures/tests/test_progress_future.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_test_assistant.py
+++ b/traits_futures/tests/test_test_assistant.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_traits_executor.py
+++ b/traits_futures/tests/test_traits_executor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/test_traits_process_executor.py
+++ b/traits_futures/tests/test_traits_process_executor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/tests/traits_executor_tests.py
+++ b/traits_futures/tests/traits_executor_tests.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/traits_executor.py
+++ b/traits_futures/traits_executor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wrappers.py
+++ b/traits_futures/wrappers.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wx/event_loop.py
+++ b/traits_futures/wx/event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wx/event_loop_helper.py
+++ b/traits_futures/wx/event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wx/pingee.py
+++ b/traits_futures/wx/pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wx/tests/test_event_loop_helper.py
+++ b/traits_futures/wx/tests/test_event_loop_helper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wx/tests/test_pingee.py
+++ b/traits_futures/wx/tests/test_pingee.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/traits_futures/wx/tests/test_wx_event_loop.py
+++ b/traits_futures/wx/tests/test_wx_event_loop.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2024 Enthought, Inc., Austin, TX
+# (C) Copyright 2018-2026 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD


### PR DESCRIPTION
## Summary

Bring all copyright headers up to date with the current year (2026) so the `strict-style` check passes again.

- Bump the copyright end year `2018-2024` → `2018-2026` across all 98 files that carry the header (Python sources, docs `.rst`, the apidoc `.rst_t` templates, `README.rst`, `LICENSE.txt`, etc.).
- Update the pinned `copyright-end-year` in `.flake8` from 2024 to 2026 to match. H102 requires an exact match, so the headers and the pinned year have to move together.

Every changed line is just the year; no other edits (99 files, 99 insertions / 99 deletions).

## Context

The pin + strict-check split was introduced in #529: the required `check-style.yml` uses the pinned year (a buffer so a new year doesn't abruptly break required CI), while the non-required `check-style-strict.yml` checks headers against the *current* year and had been failing by design. This PR refreshes the headers and advances the pin, so both checks pass.

## Verification

In a clean venv with `style-requirements.txt` installed:

- `flake8` (uses `copyright-end-year = 2026` from `.flake8`) → clean, exit 0
- `flake8 --select H102 --copyright-end-year current` → clean, exit 0
- `isort --check` and `black --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)