### PR TITLE
Use extend-exclude for flake8 and skip dist and .venv

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 packages = find:
 
 [flake8]
-exclude = build
+extend-exclude = build, dist, .venv
 max-line-length = 79
 # Pin the year so style checks don't fail when the year rolls over.
 copyright-end-year = 2026


### PR DESCRIPTION
## Summary

Switch the flake8 config from `exclude` to `extend-exclude`, and add `dist` and `.venv`:

```diff
-exclude = build
+extend-exclude = build, dist, .venv
```

Two improvements:

- **`extend-exclude` vs `exclude`**: plain `exclude` *replaces* flake8's built-in default exclude list (`.git`, `__pycache__`, `.tox`, `.eggs`, `*.egg`). `extend-exclude` *adds* to it, so those defaults are restored while still excluding `build`.
- **`.venv`**: avoids spurious style errors when a local virtual environment is created in the working tree (e.g. by `uv`). `dist` is added alongside `build` for build artefacts.

This is a strict superset of what was excluded before, so no previously-linted file stops being linted (nothing newly passes by omission).

Follows the `extend-exclude` pattern used in [enthought/ets-copyright-checker](https://github.com/enthought/ets-copyright-checker), and picks up the `.venv` exclusion that [enthought/envisage](https://github.com/enthought/envisage) uses.

## Verification

With `style-requirements.txt` installed:

- `flake8` → clean, exit 0 (unchanged from before).
- Dropping a deliberately-broken `.py` into `.venv/` and `dist/` and re-running `flake8` → still clean (both directories excluded); the same file flagged when linted explicitly, confirming it's the exclude doing the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)