### PR TITLE
Drop Python 3.8/3.9; test Python 3.10 through 3.14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.14']
 
     env:
       ETS_TOOLKIT: qt
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.11']
+        python-version: ['3.10', '3.14']
 
     env:
       ETS_TOOLKIT: wx

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.10']
+        python-version: ['3.10', '3.11']
 
     env:
       ETS_TOOLKIT: qt

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -33,15 +33,9 @@ jobs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package and test dependencies from PyPI sdist (with PySide6)
+    - name: Install package and test dependencies from PyPI sdist
       run: |
         python -m pip install --no-binary traits-futures traits-futures[pyside6]
-      if: ${{ matrix.python-version != '3.11' }}
-    - name: Install package and test dependencies from PyPI sdist (no PySide6)
-      # PySide6 does not yet work on Python 3.11; test without it.
-      run: |
-        python -m pip install --no-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == '3.11' }}
     - name: Create clean test directory
       run: |
         mkdir testdir
@@ -56,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -78,15 +72,9 @@ jobs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package and test dependencies from PyPI wheel (with PySide6)
+    - name: Install package and test dependencies from PyPI wheel
       run: |
         python -m pip install --only-binary traits-futures traits-futures[pyside6]
-      if: ${{ matrix.python-version != '3.11' }}
-    - name: Install package and test dependencies from PyPI wheel (no PySide6)
-      # PySide6 does not yet work on Python 3.11; test without it.
-      run: |
-        python -m pip install --only-binary traits-futures traits-futures
-      if: ${{ matrix.python-version == '3.11' }}
     - name: Create clean test directory
       run: |
         mkdir testdir

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # Python 3.14 is missing here deliberately; see #539.
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 
@@ -50,7 +51,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # Python 3.14 is missing here deliberately; see #539.
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-from-pypi.yml
+++ b/.github/workflows/test-from-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 
@@ -38,9 +38,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Development versions of our dependencies (traits and PySide6)
-        # require Python >= 3.10, so we can't exercise the bleeding edge
-        # on the older Python versions that traits-futures still supports.
         python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/weekly-scheduled-tests.yml
+++ b/.github/workflows/weekly-scheduled-tests.yml
@@ -38,7 +38,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.10']
+        # Development versions of our dependencies (traits and PySide6)
+        # require Python >= 3.10, so we can't exercise the bleeding edge
+        # on the older Python versions that traits-futures still supports.
+        python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -19,7 +19,7 @@ Getting started
 ---------------
 
 You'll need a Python 3 environment for development. Any environment using
-Python >= 3.8 will do. For example, you could create and activate a new venv
+Python >= 3.10 will do. For example, you could create and activate a new venv
 using something like::
 
     python3.10 -m venv ../traits-futures && source ../traits-futures/bin/activate

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -56,6 +56,8 @@ Continuous integration and build
 
 * Add cron-job-based workflow to validate installation of the latest
   wheel and sdist from PyPI. (#465)
+* Extend the test matrices to cover Python 3.12, Python 3.13 and
+  Python 3.14. (#537)
 
 
 Release 0.3.1

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -29,6 +29,8 @@ Changes
 * Support for Python 3.8 and Python 3.9 has been dropped. Traits Futures now
   requires Python 3.10 or later, following the corresponding change in Traits.
   (#537)
+* The minimum supported version of Traits is now 6.3.0, which is the first
+  release of Traits to support Python 3.10. (#537)
 * The "asyncio" and "null" entry points for the "traits_futures.event_loops"
   entry point group have been removed. Their behaviour was ill-defined, and
   dependent on ``asyncio.get_event_loop``, which is deprecated in Python.

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -26,6 +26,9 @@ Features
 Changes
 ~~~~~~~
 
+* Support for Python 3.8 and Python 3.9 has been dropped. Traits Futures now
+  requires Python 3.10 or later, following the corresponding change in Traits.
+  (#537)
 * The "asyncio" and "null" entry points for the "traits_futures.event_loops"
   entry point group have been removed. Their behaviour was ill-defined, and
   dependent on ``asyncio.get_event_loop``, which is deprecated in Python.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Limitations
 
 - By design, and unlike :mod:`concurrent.futures`, |traits_futures| requires the
   UI event loop to be running in order to process results.
-- Requires Python 3.8 or later.
+- Requires Python 3.10 or later.
 
 
 Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.black]
 line-length = 79
-target-version = ['py36']
+target-version = ['py310']
 # black introduces extra blank lines that we don't want in the Sphinx
 # rendering. xref: https://github.com/sphinx-doc/sphinx/issues/9407
 exclude = '/docs/source/guide/examples/fizz_buzz_task.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     'pyface',
-    'traits>=6.2',
+    'traits>=6.3',
 ]
 dynamic = ['version']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'traits-futures'
 description = 'Patterns for reactive background tasks'
 readme = 'README.rst'
-requires-python = '>=3.8'
+requires-python = '>=3.10'
 authors = [{name='Enthought', email='info@enthought.com'}]
 keywords = ['background', 'concurrency', 'futures', 'gui', 'traits', 'traitsui']
 classifiers = [


### PR DESCRIPTION
This PR drops support for Python 3.8 and Python 3.9, so that Traits Futures now requires Python 3.10 or later, and extends the test matrices to cover Python 3.10 through Python 3.14.

Traits has already bumped `python_requires` to `>=3.10` on its development branch, and the next Traits release will drop Python 3.8 and 3.9. Once that release reaches PyPI, every workflow that resolves dependencies from PyPI will fail on the older Pythons. The weekly [Integration tests](https://github.com/enthought/traits-futures/actions/runs/31295629151) run is already failing this way against traits' `main`:

```
ERROR: Package 'traits' requires a different Python: 3.8.10 not in '>=3.10'
```

The current PySide6 (6.11) and wxPython (4.3.1) releases require Python >= 3.10 too. Rather than pin our way around all of this, we follow our key dependency and drop 3.8 and 3.9. Python 3.11 is getting old in its own right, so the matrices are extended upwards at the same time.

## Dropping 3.8 and 3.9

`requires-python` becomes `>=3.10`. The docs, the developer instructions and the changelog follow.

## Extending to 3.14

The dependencies are ready: traits 7.1.0 ships cp310–cp314 wheels (no cp315 yet, so 3.15 stays out for now), pyface is a pure-Python wheel, PySide6 6.11.1 is built against the stable ABI (`cp310-abi3`, `requires-python <3.15,>=3.10`), and wxPython has cp310–cp314 wheels.

This keeps the repository's existing two-tier convention. Scheduled workflows enumerate the whole supported range; per-PR checks and the bleeding-edge job sample the oldest and newest supported versions.

| Workflow / job | Before | After |
|---|---|---|
| `run-tests` / `tests-pyside6` | `3.8, 3.10` | `3.10, 3.14` |
| `run-tests` / `tests-wx` | `3.11` | `3.10, 3.14` |
| `weekly` / `test-bleeding-edge` | `3.8, 3.10` | `3.10, 3.14` |
| `weekly` / `test-all-platform-python-combinations` | `3.8, 3.9, 3.10, 3.11` | `3.10 … 3.14` |
| `test-from-pypi` / sdist + wheel | `3.8, 3.9, 3.10, 3.11` | `3.10 … 3.13` (see below) |

### Why `test-from-pypi` stops at 3.13

That workflow installs the **latest release** from PyPI, not the code on this branch. The current release predates the `AsyncioEventLoop` fix (#492), so on Python 3.14 `asyncio.get_event_loop` raises instead of creating an event loop and every test errors in `setUp`:

```
File ".../site-packages/traits_futures/asyncio/event_loop.py", line 28, in __init__
    self._event_loop = asyncio.get_event_loop()
RuntimeError: There is no current event loop in thread 'MainThread'.
```

Probed against PyPI with `fail-fast` disabled, the released package passes on 3.10, 3.11, 3.12 and 3.13, and fails only on 3.14, for both the sdist and the wheel. This is not a coverage gap: 3.14 is exercised against the code we actually ship by `run-tests` and by the weekly integration workflow. Adding 3.14 there after the 0.4.0 release is tracked in #539.

### One other judgement call

This also removes the `if: matrix.python-version == '3.11'` special-casing in `test-from-pypi.yml`, which skipped PySide6 with the stale comment *"PySide6 does not yet work on Python 3.11"*. With 3.8 and 3.9 gone, keeping it would have left PySide6 exercised on a single Python version in that workflow.

## Verification

All on this branch:

* **`run-tests`** — 12/12 green: PySide6 and wx, on 3.10 and 3.14, on Ubuntu and Windows.
* **`Integration tests`** ([run 31413542949](https://github.com/enthought/traits-futures/actions/runs/31413542949)) — 21/21 green, including `test-bleeding-edge` on 3.14 against the traits and pyface development branches.
* **`Test installation from PyPI`** ([run 31414042672](https://github.com/enthought/traits-futures/actions/runs/31414042672)) — 24/24 green with the capped matrix.
* `docs`, `style`, `strict-style` — green.

Depends on #538, now merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
