### PR TITLE
Install wxPython on Ubuntu from wheels only

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,8 +81,10 @@ jobs:
         python -m pip install wxPython
       if: matrix.os != 'ubuntu-latest'
     - name: Install wxPython (Ubuntu)
+      # Without --only-binary, pip prefers the newer sdist on PyPI and tries
+      # to build wxWidgets from source.
       run: |
-        python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 wxPython
+        python -m pip install --only-binary wxPython -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 wxPython
       if: matrix.os == 'ubuntu-latest'
     - name: Create clean test directory
       run: |


### PR DESCRIPTION
## Problem

`tests-wx (ubuntu-latest, 3.11)` currently fails on `main`:

```
configure: error: Package requirements (gtk+-3.0) were not met:
ERROR: failed building wxWidgets
ERROR: Failed building wheel for wxPython
```

wxPython publishes **no Linux wheels on PyPI** — only macOS and Windows. On Linux we get them from `extras.wxpython.org` via a `--find-links` entry. That index currently tops out at wxPython **4.2.5**, while PyPI has **4.3.1**.

pip considers both sources together and prefers the highest version, so it selects 4.3.1, finds no Linux wheel for it, and falls back to building the sdist. That build fails immediately on missing GTK development headers.

This is why the job passed in July and fails now: nothing in the repo changed, wxPython 4.3.x was simply released.

## Fix

Pass `--only-binary wxPython` so pip restricts itself to wheels and takes 4.2.5 from the extras index. Building wxWidgets from source would need GTK development packages we don't install, and would be very slow even if we did.

The Windows step is unaffected — it installs 4.3.1 from PyPI as before.

## Verification

Resolution dry-run for `cp311` / `linux_x86_64`:

```
$ pip download --no-deps --only-binary wxPython \
    --platform linux_x86_64 --python-version 3.11 --implementation cp --abi cp311 \
    -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 wxPython
Looking in links: https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04
Collecting wxPython
  Downloading wxpython-4.2.5-cp311-cp311-linux_x86_64.whl (151.1 MB)
Successfully downloaded wxPython
```

plus the `tests-wx` checks on this PR.

## Note

The extras index carries cp310–cp314 wheels for 4.2.5, so this does not constrain which Python versions the wx job can use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)